### PR TITLE
Change to use Azure service-fabric-metadata dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(service-fabric-rs LANGUAGES)
 message(STATUS "fetching fabric_metadata")
 include(FetchContent)
 FetchContent_Declare(fabric_metadata
-    GIT_REPOSITORY https://github.com/youyuanwu/fabric-metadata.git
+    GIT_REPOSITORY https://github.com/Azure/service-fabric-metadata.git
     GIT_TAG 87041e9790edb7f87dbf6ca8c1ca0f40db8c82dd
 )
 FetchContent_GetProperties(fabric_metadata)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "fabric-metadata"
 version = "0.1.0"
-source = "git+https://github.com/youyuanwu/fabric-metadata.git?rev=87041e9790edb7f87dbf6ca8c1ca0f40db8c82dd#87041e9790edb7f87dbf6ca8c1ca0f40db8c82dd"
+source = "git+https://github.com/Azure/service-fabric-metadata.git?rev=b070db62d2323d85d402ca3f6dc387f0ce0be37b#b070db62d2323d85d402ca3f6dc387f0ce0be37b"
 
 [[package]]
 name = "fabric_base"

--- a/crates/fabric/base/Cargo.toml
+++ b/crates/fabric/base/Cargo.toml
@@ -12,10 +12,14 @@ authors = ["youyuanwu@outlook.com"]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 # this dep is required on windows to have the support libs.
-fabric-metadata = { git = "https://github.com/youyuanwu/fabric-metadata.git", rev = "87041e9790edb7f87dbf6ca8c1ca0f40db8c82dd"}
+fabric-metadata = { git = "https://github.com/Azure/service-fabric-metadata.git", rev = "b070db62d2323d85d402ca3f6dc387f0ce0be37b"}
+
+[target.'cfg(unix)'.dependencies]
 pal = { path = "../../../crates/fabric/pal" }
+
+[dependencies]
 windows-core = "0.51"
 
 [dependencies.windows]

--- a/crates/fabric/base/src/lib.rs
+++ b/crates/fabric/base/src/lib.rs
@@ -22,6 +22,7 @@ pub mod Microsoft;
 #[cfg(feature = "ServiceFabric")]
 pub use Microsoft::ServiceFabric::*;
 
+#[cfg(target_os = "windows")]
 pub use fabric_metadata;
 
 // In linux force to pull in pal lib for linking


### PR DESCRIPTION
fabric-metadata has been migrated to Azure org.

Also update the dependency to only build fabric-metadata on windows platforms.