### PR TITLE
Fix code gen task where cargo.toml is changed

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -36,9 +36,8 @@ jobs:
     - name: generate rust code
       run: cmake --build build --config ${{ matrix.BUILD_TYPE }} --target generate_rust
 
-    # generate code modifies cargo. TODO:
-    # - name: check all generated files are checked in git
-    #   run: git diff --exit-code
+    - name: check all generated files are checked in git
+      run: git diff --exit-code
 
-    # - name: build sample rust app
-    #   run: cmake --build build --config ${{ matrix.BUILD_TYPE }} --target build_rust_sample_echomain
+    - name: build rust code
+      run: cmake --build build --config ${{ matrix.BUILD_TYPE }}

--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -40,11 +40,7 @@ features = [
 implement = []
 Foundation = []
 Win32_Foundation = []
-# ServiceFabric = ["Foundation"]
-# ServiceFabric_FabricCommon = ["ServiceFabric"]
-# ServiceFabric_FabricCommon_FabricClient = ["ServiceFabric_FabricCommon"]
-# ServiceFabric_FabricCommon_FabricRuntime = ["ServiceFabric_FabricCommon"]
-# ServiceFabric_FabricCommon_FabricTransport = ["ServiceFabric_FabricCommon"]
+# generated features
 ServiceFabric = ["Foundation"]
 ServiceFabric_FabricCommon = ["ServiceFabric"]
 ServiceFabric_FabricCommon_FabricClient = ["ServiceFabric_FabricCommon"]


### PR DESCRIPTION
From https://github.com/microsoft/windows-rs/issues/2931
it is possible to re-generate the code without duplicated feature entries.
Also enables build the code after regeneration in ci.