### PR TITLE
Update rs version to 1.77 and update rust github actions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,26 +19,19 @@ jobs:
       uses: lukka/get-cmake@v3.21.2
 
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
+        toolchain: 1.77.0
+        components: rustfmt, clippy
     
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
+      run: cargo check
 
     - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
     
     - name: Run cargo clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: -- -D warnings
+      run: cargo clippy -- -D warnings
 
     - name: run cmake
       run: > 
@@ -66,10 +59,7 @@ jobs:
       run: Powershell.exe -File .\tests\echo_script_test.ps1
 
     - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all -- --nocapture
+      run: cargo test --all -- --nocapture
 
   build-linux:
     runs-on: ${{ matrix.os }}
@@ -99,26 +89,19 @@ jobs:
       uses: lukka/get-cmake@v3.21.2
 
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-
+        toolchain: 1.77.0
+        components: rustfmt, clippy
+    
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
+      run: cargo check
 
     - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
     
     - name: Run cargo clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: -- -D warnings
+      run: cargo clippy -- -D warnings
 
     - name: run cmake
       run: > 
@@ -169,7 +152,4 @@ jobs:
     #     sfctl service resolve --service-id EchoApp/EchoAppService
 
     - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all -- --nocapture
+      run: cargo test --all -- --nocapture

--- a/crates/tools/fabric-gen/src/gen.rs
+++ b/crates/tools/fabric-gen/src/gen.rs
@@ -596,7 +596,7 @@ pub mod code {
             stream
         }
 
-        fn gen_return_type(&self, params: &Vec<ParamEntry>) -> TokenStream {
+        fn gen_return_type(&self, params: &[ParamEntry]) -> TokenStream {
             if params.is_empty() {
                 quote! {
                     crate::sync::FabricReceiver<::windows_core::Result<()>>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # cargo + rustup will use this to consistently build the project
 # with the same version across all checkouts and environments
 [toolchain]
-channel = "1.75.0"
+channel = "1.77.0"
 profile = "default"


### PR DESCRIPTION
action-rs are no longer maintained. We migrate to use dtolnay/rust-toolchain as suggested in https://github.com/actions-rs/toolchain/issues/216