### PR TITLE
Impl FabricClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bytes"
@@ -282,6 +282,7 @@ dependencies = [
 name = "mssf-core"
 version = "0.0.3"
 dependencies = [
+ "bitflags 2.5.0",
  "ctrlc",
  "env_logger",
  "log",
@@ -313,7 +314,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "cfg_aliases",
  "libc",

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros"]
 windows-core = "0.54"
 ctrlc = { version = "3.0", features = ["termination"] }
 trait-variant = "0.1.1"
+bitflags = "2.5.0"
 
 [dev-dependencies]
 paste = "1.0"

--- a/crates/libs/core/src/client/gen/app.rs
+++ b/crates/libs/core/src/client/gen/app.rs
@@ -8,6 +8,11 @@ impl IFabricApplicationManagementClient10Wrap {
     pub fn new() -> IFabricApplicationManagementClient10Wrap {
         IFabricApplicationManagementClient10Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricApplicationManagementClient10 > () , }
     }
+    pub fn from_com(
+        com : :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricApplicationManagementClient10,
+    ) -> IFabricApplicationManagementClient10Wrap {
+        IFabricApplicationManagementClient10Wrap { com }
+    }
     pub fn CreateApplication(
         &self,
         description: &::mssf_com::Microsoft::ServiceFabric::FABRIC_APPLICATION_DESCRIPTION,

--- a/crates/libs/core/src/client/gen/health.rs
+++ b/crates/libs/core/src/client/gen/health.rs
@@ -9,6 +9,11 @@ impl Default for IFabricHealthClient4Wrap {
 impl IFabricHealthClient4Wrap {
     pub fn new() -> IFabricHealthClient4Wrap {
         IFabricHealthClient4Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricHealthClient4 > () , }
+    }
+    pub fn from_com(
+        com: ::mssf_com::Microsoft::ServiceFabric::FabricCommon::FabricClient::IFabricHealthClient4,
+    ) -> IFabricHealthClient4Wrap {
+        IFabricHealthClient4Wrap { com }
     }    pub fn GetApplicationHealth (& self , applicationName : & u16 , healthPolicy : & :: mssf_com :: Microsoft :: ServiceFabric :: FABRIC_APPLICATION_HEALTH_POLICY , timeoutMilliseconds : u32) -> crate :: sync :: FabricReceiver < :: windows_core :: Result < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricApplicationHealthResult >>{
         let (tx, rx) = crate::sync::oneshot_channel();
         let callback = crate::sync::AwaitableCallback2::i_new(move |ctx| {

--- a/crates/libs/core/src/client/gen/mgmt.rs
+++ b/crates/libs/core/src/client/gen/mgmt.rs
@@ -8,6 +8,11 @@ impl IFabricClusterManagementClient10Wrap {
     pub fn new() -> IFabricClusterManagementClient10Wrap {
         IFabricClusterManagementClient10Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricClusterManagementClient10 > () , }
     }
+    pub fn from_com(
+        com : :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricClusterManagementClient10,
+    ) -> IFabricClusterManagementClient10Wrap {
+        IFabricClusterManagementClient10Wrap { com }
+    }
     pub fn ActivateNode(
         &self,
         nodeName: ::windows_core::PCWSTR,

--- a/crates/libs/core/src/client/gen/mod.rs
+++ b/crates/libs/core/src/client/gen/mod.rs
@@ -1,0 +1,7 @@
+pub mod app;
+pub mod health;
+pub mod mgmt;
+pub mod property;
+pub mod query;
+pub mod svc;
+pub mod svcgp;

--- a/crates/libs/core/src/client/gen/property.rs
+++ b/crates/libs/core/src/client/gen/property.rs
@@ -8,6 +8,11 @@ impl IFabricPropertyManagementClient2Wrap {
     pub fn new() -> IFabricPropertyManagementClient2Wrap {
         IFabricPropertyManagementClient2Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricPropertyManagementClient2 > () , }
     }
+    pub fn from_com(
+        com : :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricPropertyManagementClient2,
+    ) -> IFabricPropertyManagementClient2Wrap {
+        IFabricPropertyManagementClient2Wrap { com }
+    }
     pub fn CreateName(
         &self,
         name: &u16,

--- a/crates/libs/core/src/client/gen/query.rs
+++ b/crates/libs/core/src/client/gen/query.rs
@@ -9,6 +9,11 @@ impl Default for IFabricQueryClient10Wrap {
 impl IFabricQueryClient10Wrap {
     pub fn new() -> IFabricQueryClient10Wrap {
         IFabricQueryClient10Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricQueryClient10 > () , }
+    }
+    pub fn from_com(
+        com: ::mssf_com::Microsoft::ServiceFabric::FabricCommon::FabricClient::IFabricQueryClient10,
+    ) -> IFabricQueryClient10Wrap {
+        IFabricQueryClient10Wrap { com }
     }    pub fn GetApplicationList (& self , queryDescription : & :: mssf_com :: Microsoft :: ServiceFabric :: FABRIC_APPLICATION_QUERY_DESCRIPTION , timeoutMilliseconds : u32) -> crate :: sync :: FabricReceiver < :: windows_core :: Result < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricGetApplicationListResult >>{
         let (tx, rx) = crate::sync::oneshot_channel();
         let callback = crate::sync::AwaitableCallback2::i_new(move |ctx| {

--- a/crates/libs/core/src/client/gen/svc.rs
+++ b/crates/libs/core/src/client/gen/svc.rs
@@ -8,6 +8,11 @@ impl IFabricServiceManagementClient6Wrap {
     pub fn new() -> IFabricServiceManagementClient6Wrap {
         IFabricServiceManagementClient6Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricServiceManagementClient6 > () , }
     }
+    pub fn from_com(
+        com : :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricServiceManagementClient6,
+    ) -> IFabricServiceManagementClient6Wrap {
+        IFabricServiceManagementClient6Wrap { com }
+    }
     pub fn CreateService(
         &self,
         description: &::mssf_com::Microsoft::ServiceFabric::FABRIC_SERVICE_DESCRIPTION,

--- a/crates/libs/core/src/client/gen/svcgp.rs
+++ b/crates/libs/core/src/client/gen/svcgp.rs
@@ -8,6 +8,11 @@ impl IFabricServiceGroupManagementClient4Wrap {
     pub fn new() -> IFabricServiceGroupManagementClient4Wrap {
         IFabricServiceGroupManagementClient4Wrap { com : crate :: sync :: CreateLocalClient :: < :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricServiceGroupManagementClient4 > () , }
     }
+    pub fn from_com(
+        com : :: mssf_com :: Microsoft :: ServiceFabric :: FabricCommon :: FabricClient :: IFabricServiceGroupManagementClient4,
+    ) -> IFabricServiceGroupManagementClient4Wrap {
+        IFabricServiceGroupManagementClient4Wrap { com }
+    }
     pub fn CreateServiceGroup(
         &self,
         description: &::mssf_com::Microsoft::ServiceFabric::FABRIC_SERVICE_GROUP_DESCRIPTION,

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -1,10 +1,81 @@
-pub mod app;
-pub mod health;
-pub mod mgmt;
-pub mod property;
-pub mod query;
-pub mod svc;
-pub mod svcgp;
+use mssf_com::FabricCommon::FabricClient::{
+    IFabricPropertyManagementClient2, IFabricQueryClient10, IFabricServiceManagementClient6,
+};
+use windows_core::Interface;
+
+use self::{
+    gen::{property::IFabricPropertyManagementClient2Wrap, query::IFabricQueryClient10Wrap},
+    query_client::QueryClient,
+    svc_mgmt_client::ServiceManagementClient,
+};
+
+// TODO: make private. Currently exposed for backward compat
+pub mod gen;
+
+pub mod query_client;
+pub mod svc_mgmt_client;
 
 #[cfg(test)]
 mod tests;
+
+// FabricClient safe wrapper
+// The design of FabricClient follows from the csharp client:
+// https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Api/src/System/Fabric/FabricClient.cs
+
+pub struct FabricClient {
+    com_property_client: IFabricPropertyManagementClient2,
+    com_service_client: IFabricServiceManagementClient6,
+    com_query_client: IFabricQueryClient10,
+}
+
+impl Default for FabricClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FabricClient {
+    pub fn new() -> Self {
+        let com = crate::sync::CreateLocalClient::<IFabricPropertyManagementClient2>();
+        Self::from_com(com)
+    }
+
+    // Creates from com directly. This gives the user freedom to create com from
+    // custom code and pass it in.
+    // For the final state of FabricClient, this function should be private.
+    pub fn from_com(com: IFabricPropertyManagementClient2) -> Self {
+        let com_property_client = com.clone();
+        let com_service_client = com
+            .clone()
+            .cast::<IFabricServiceManagementClient6>()
+            .unwrap();
+        let com_query_client = com.clone().cast::<IFabricQueryClient10>().unwrap();
+        Self {
+            com_property_client,
+            com_service_client,
+            com_query_client,
+        }
+    }
+
+    pub fn get_property_manager(&self) -> PropertyManagementClient {
+        PropertyManagementClient {
+            _com: self.com_property_client.clone(),
+            _gen_wrap: IFabricPropertyManagementClient2Wrap::from_com(
+                self.com_property_client.clone(),
+            ),
+        }
+    }
+
+    pub fn get_query_manager(&self) -> QueryClient {
+        QueryClient::from_com(self.com_query_client.clone())
+    }
+
+    pub fn get_service_manager(&self) -> ServiceManagementClient {
+        ServiceManagementClient::from_com(self.com_service_client.clone())
+    }
+}
+
+pub struct PropertyManagementClient {
+    _com: IFabricPropertyManagementClient2,
+    _gen_wrap: IFabricPropertyManagementClient2Wrap,
+}

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -57,6 +57,7 @@ impl FabricClient {
         }
     }
 
+    // Get the client for managing Fabric Properties in Naming Service
     pub fn get_property_manager(&self) -> PropertyManagementClient {
         PropertyManagementClient {
             _com: self.com_property_client.clone(),
@@ -66,10 +67,12 @@ impl FabricClient {
         }
     }
 
+    // Get the client for quering SF info.
     pub fn get_query_manager(&self) -> QueryClient {
         QueryClient::from_com(self.com_query_client.clone())
     }
 
+    // Get the client for managing service info and lifecycles.
     pub fn get_service_manager(&self) -> ServiceManagementClient {
         ServiceManagementClient::from_com(self.com_service_client.clone())
     }

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -62,10 +62,7 @@ impl QueryClient {
         let fu;
         {
             let ex3 = FABRIC_NODE_QUERY_DESCRIPTION_EX3 {
-                MaxResults: match desc.paged_query.max_results {
-                    Some(x) => x,
-                    None => 0,
-                },
+                MaxResults: desc.paged_query.max_results.unwrap_or(0),
                 Reserved: std::ptr::null_mut(),
             };
 

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -152,9 +152,10 @@ impl NodeList {
     pub fn iter(&self) -> NodeListIter {
         NodeListIter::new(self.com.clone())
     }
-    pub fn get_paging_status(&self) -> PagingStatus {
-        let raw = unsafe { self.com.get_PagingStatus().as_ref().unwrap() };
-        raw.into()
+    pub fn get_paging_status(&self) -> Option<PagingStatus> {
+        // If there is no more entries there is no paging status returned.
+        let raw = unsafe { self.com.get_PagingStatus().as_ref() }?;
+        Some(raw.into())
     }
 }
 

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -1,29 +1,55 @@
 use std::{ffi::c_void, time::Duration};
 
-use crate::client::IFabricQueryClient10Wrap;
+use crate::{client::IFabricQueryClient10Wrap, unsafe_pwstr_to_hstring};
 use bitflags::bitflags;
 use mssf_com::{
-    FabricCommon::FabricClient::{IFabricGetNodeListResult, IFabricQueryClient10},
+    FabricCommon::FabricClient::{IFabricGetNodeListResult2, IFabricQueryClient10},
     FABRIC_NODE_QUERY_DESCRIPTION, FABRIC_NODE_QUERY_DESCRIPTION_EX1,
-    FABRIC_NODE_QUERY_DESCRIPTION_EX2, FABRIC_NODE_QUERY_RESULT_ITEM,
-    FABRIC_QUERY_NODE_STATUS_FILTER_ALL, FABRIC_QUERY_NODE_STATUS_FILTER_DEFAULT,
-    FABRIC_QUERY_NODE_STATUS_FILTER_DISABLED, FABRIC_QUERY_NODE_STATUS_FILTER_DISABLING,
-    FABRIC_QUERY_NODE_STATUS_FILTER_DOWN, FABRIC_QUERY_NODE_STATUS_FILTER_ENABLING,
-    FABRIC_QUERY_NODE_STATUS_FILTER_REMOVED, FABRIC_QUERY_NODE_STATUS_FILTER_UNKNOWN,
-    FABRIC_QUERY_NODE_STATUS_FILTER_UP,
+    FABRIC_NODE_QUERY_DESCRIPTION_EX2, FABRIC_NODE_QUERY_DESCRIPTION_EX3,
+    FABRIC_NODE_QUERY_RESULT_ITEM, FABRIC_NODE_QUERY_RESULT_ITEM_EX1,
+    FABRIC_NODE_QUERY_RESULT_ITEM_EX2, FABRIC_PAGING_STATUS, FABRIC_QUERY_NODE_STATUS_FILTER_ALL,
+    FABRIC_QUERY_NODE_STATUS_FILTER_DEFAULT, FABRIC_QUERY_NODE_STATUS_FILTER_DISABLED,
+    FABRIC_QUERY_NODE_STATUS_FILTER_DISABLING, FABRIC_QUERY_NODE_STATUS_FILTER_DOWN,
+    FABRIC_QUERY_NODE_STATUS_FILTER_ENABLING, FABRIC_QUERY_NODE_STATUS_FILTER_REMOVED,
+    FABRIC_QUERY_NODE_STATUS_FILTER_UNKNOWN, FABRIC_QUERY_NODE_STATUS_FILTER_UP,
 };
 use windows_core::{HSTRING, PCWSTR};
 
 pub struct QueryClient {
-    _com: IFabricQueryClient10,
-    gen_wrap: IFabricQueryClient10Wrap,
+    com: IFabricQueryClient10,
+    _gen_wrap: IFabricQueryClient10Wrap,
 }
 
 impl QueryClient {
     pub fn from_com(com: IFabricQueryClient10) -> Self {
         Self {
-            _com: com.clone(),
-            gen_wrap: IFabricQueryClient10Wrap::from_com(com),
+            com: com.clone(),
+            _gen_wrap: IFabricQueryClient10Wrap::from_com(com),
+        }
+    }
+
+    // manually wrapping the com call since this is a irregular api.
+    pub fn get_node_list_internal(
+        &self,
+        queryDescription: &FABRIC_NODE_QUERY_DESCRIPTION,
+        timeoutMilliseconds: u32,
+    ) -> crate::sync::FabricReceiver<::windows_core::Result<IFabricGetNodeListResult2>> {
+        let (tx, rx) = crate::sync::oneshot_channel();
+        let callback = crate::sync::AwaitableCallback2::i_new(move |ctx| {
+            // Note we use the v2 api
+            let res = unsafe { self.com.EndGetNodeList2(ctx) };
+            tx.send(res);
+        });
+        let ctx = unsafe {
+            self.com
+                .BeginGetNodeList(queryDescription, timeoutMilliseconds, &callback)
+        };
+        if ctx.is_err() {
+            let (tx2, rx2) = crate::sync::oneshot_channel();
+            tx2.send(Err(ctx.err().unwrap()));
+            rx2
+        } else {
+            rx
         }
     }
 
@@ -35,13 +61,21 @@ impl QueryClient {
     ) -> windows_core::Result<NodeList> {
         let fu;
         {
-            let ex2 = FABRIC_NODE_QUERY_DESCRIPTION_EX2 {
-                NodeStatusFilter: desc.node_status_filter.bits(),
+            let ex3 = FABRIC_NODE_QUERY_DESCRIPTION_EX3 {
+                MaxResults: match desc.paged_query.max_results {
+                    Some(x) => x,
+                    None => 0,
+                },
                 Reserved: std::ptr::null_mut(),
             };
 
+            let ex2 = FABRIC_NODE_QUERY_DESCRIPTION_EX2 {
+                NodeStatusFilter: desc.node_status_filter.bits(),
+                Reserved: std::ptr::addr_of!(ex3) as *mut c_void,
+            };
+
             let ex1 = FABRIC_NODE_QUERY_DESCRIPTION_EX1 {
-                ContinuationToken: get_pcwstr_from_opt(&desc.continuation_token),
+                ContinuationToken: get_pcwstr_from_opt(&desc.paged_query.continuation_token),
                 Reserved: std::ptr::addr_of!(ex2) as *mut c_void,
             };
 
@@ -49,13 +83,29 @@ impl QueryClient {
                 NodeNameFilter: get_pcwstr_from_opt(&desc.node_name_filter),
                 Reserved: std::ptr::addr_of!(ex1) as *mut c_void,
             };
-            fu = self
-                .gen_wrap
-                .GetNodeList(&arg, timeout.as_millis().try_into().unwrap());
+            fu = self.get_node_list_internal(&arg, timeout.as_millis().try_into().unwrap());
         }
         let res = fu.await?;
         Ok(NodeList::from_com(res))
     }
+}
+
+pub struct PagingStatus {
+    pub continuation_token: HSTRING,
+}
+
+impl From<&FABRIC_PAGING_STATUS> for PagingStatus {
+    fn from(value: &FABRIC_PAGING_STATUS) -> Self {
+        Self {
+            continuation_token: unsafe_pwstr_to_hstring(value.ContinuationToken),
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct PagedQueryDescription {
+    pub continuation_token: Option<HSTRING>,
+    pub max_results: Option<i32>,
 }
 
 // note that hstring must be valid for pcwstr lifetime
@@ -90,25 +140,29 @@ impl Default for NodeStatusFilter {
 #[derive(Default, Debug)]
 pub struct NodeQueryDescription {
     pub node_name_filter: Option<HSTRING>,
-    pub continuation_token: Option<HSTRING>,
     pub node_status_filter: NodeStatusFilter,
+    pub paged_query: PagedQueryDescription,
 }
 
 pub struct NodeList {
-    com: IFabricGetNodeListResult,
+    com: IFabricGetNodeListResult2,
 }
 
 impl NodeList {
-    fn from_com(com: IFabricGetNodeListResult) -> Self {
+    fn from_com(com: IFabricGetNodeListResult2) -> Self {
         Self { com }
     }
     pub fn iter(&self) -> NodeListIter {
         NodeListIter::new(self.com.clone())
     }
+    pub fn get_paging_status(&self) -> PagingStatus {
+        let raw = unsafe { self.com.get_PagingStatus().as_ref().unwrap() };
+        raw.into()
+    }
 }
 
 pub struct NodeListIter {
-    _owner: IFabricGetNodeListResult,
+    _owner: IFabricGetNodeListResult2,
     count: u32, // total
     index: u32,
     curr: *const FABRIC_NODE_QUERY_RESULT_ITEM,
@@ -117,6 +171,17 @@ pub struct NodeListIter {
 #[derive(Debug)]
 pub struct Node {
     pub name: HSTRING,
+    pub ip_address_or_fqdn: HSTRING,
+    pub node_type: HSTRING,
+    pub code_version: HSTRING,
+    pub config_version: HSTRING,
+    // pub node_status
+    pub node_up_time_in_seconds: i64,
+    // pub AggregatedHealthState
+    pub is_seed_node: bool,
+    pub upgrade_domain: HSTRING,
+    pub fault_domain: HSTRING,
+    pub node_instance_id: u64,
 }
 
 impl Iterator for NodeListIter {
@@ -128,8 +193,28 @@ impl Iterator for NodeListIter {
         }
         // get the curr out
         let raw = unsafe { self.curr.as_ref().unwrap() };
+        // TODO: get node id. integrate with another PR
+        let raw1 = unsafe {
+            (raw.Reserved as *const FABRIC_NODE_QUERY_RESULT_ITEM_EX1)
+                .as_ref()
+                .unwrap()
+        };
+        let raw2 = unsafe {
+            (raw1.Reserved as *const FABRIC_NODE_QUERY_RESULT_ITEM_EX2)
+                .as_ref()
+                .unwrap()
+        };
         let res = Node {
             name: HSTRING::from_wide(unsafe { raw.NodeName.as_wide() }).unwrap(),
+            ip_address_or_fqdn: unsafe_pwstr_to_hstring(raw.IpAddressOrFQDN),
+            node_type: unsafe_pwstr_to_hstring(raw.NodeType),
+            code_version: unsafe_pwstr_to_hstring(raw.CodeVersion),
+            config_version: unsafe_pwstr_to_hstring(raw.ConfigVersion),
+            node_up_time_in_seconds: raw.NodeUpTimeInSeconds,
+            is_seed_node: raw.IsSeedNode.as_bool(),
+            upgrade_domain: unsafe_pwstr_to_hstring(raw.UpgradeDomain),
+            fault_domain: unsafe_pwstr_to_hstring(windows_core::PCWSTR(raw.FaultDomain)),
+            node_instance_id: raw2.NodeInstanceId,
         };
         self.index += 1;
         self.curr = unsafe { self.curr.offset(1) };
@@ -138,7 +223,7 @@ impl Iterator for NodeListIter {
 }
 
 impl NodeListIter {
-    fn new(com: IFabricGetNodeListResult) -> Self {
+    fn new(com: IFabricGetNodeListResult2) -> Self {
         let list = unsafe { com.get_NodeList().as_ref().unwrap() };
 
         let count = list.Count;

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -1,0 +1,119 @@
+use std::{ffi::c_void, time::Duration};
+
+use crate::client::IFabricQueryClient10Wrap;
+use mssf_com::{
+    FabricCommon::FabricClient::{IFabricGetNodeListResult, IFabricQueryClient10},
+    FABRIC_NODE_QUERY_DESCRIPTION, FABRIC_NODE_QUERY_DESCRIPTION_EX1,
+    FABRIC_NODE_QUERY_RESULT_ITEM,
+};
+use windows_core::{HSTRING, PCWSTR};
+
+pub struct QueryClient {
+    _com: IFabricQueryClient10,
+    gen_wrap: IFabricQueryClient10Wrap,
+}
+
+impl QueryClient {
+    pub fn from_com(com: IFabricQueryClient10) -> Self {
+        Self {
+            _com: com.clone(),
+            gen_wrap: IFabricQueryClient10Wrap::from_com(com),
+        }
+    }
+
+    pub async fn get_node_list(
+        &self,
+        desc: NodeQueryDescription,
+        timeout: Duration,
+    ) -> windows_core::Result<NodeList> {
+        let fu;
+        {
+            let ex1 = FABRIC_NODE_QUERY_DESCRIPTION_EX1 {
+                ContinuationToken: get_pcwstr_from_opt(&desc.continuation_token),
+                Reserved: std::ptr::null_mut(),
+            };
+
+            let arg = FABRIC_NODE_QUERY_DESCRIPTION {
+                NodeNameFilter: get_pcwstr_from_opt(&desc.node_name_filter),
+                Reserved: std::ptr::addr_of!(ex1) as *mut c_void,
+            };
+            fu = self
+                .gen_wrap
+                .GetNodeList(&arg, timeout.as_millis().try_into().unwrap());
+        }
+        let res = fu.await?;
+        Ok(NodeList::from_com(res))
+    }
+}
+
+// note that hstring must be valid for pcwstr lifetime
+fn get_pcwstr_from_opt(opt: &Option<HSTRING>) -> PCWSTR {
+    match opt {
+        Some(x) => PCWSTR(x.as_ptr()),
+        None => PCWSTR::null(),
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct NodeQueryDescription {
+    pub node_name_filter: Option<HSTRING>,
+    pub continuation_token: Option<HSTRING>,
+}
+
+pub struct NodeList {
+    com: IFabricGetNodeListResult,
+}
+
+impl NodeList {
+    fn from_com(com: IFabricGetNodeListResult) -> Self {
+        Self { com }
+    }
+    pub fn iter(&self) -> NodeListIter {
+        NodeListIter::new(self.com.clone())
+    }
+}
+
+pub struct NodeListIter {
+    _owner: IFabricGetNodeListResult,
+    count: u32, // total
+    index: u32,
+    curr: *const FABRIC_NODE_QUERY_RESULT_ITEM,
+}
+
+#[derive(Debug)]
+pub struct Node {
+    pub name: HSTRING,
+}
+
+impl Iterator for NodeListIter {
+    type Item = Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.count {
+            return None;
+        }
+        // get the curr out
+        let raw = unsafe { self.curr.as_ref().unwrap() };
+        let res = Node {
+            name: HSTRING::from_wide(unsafe { raw.NodeName.as_wide() }).unwrap(),
+        };
+        self.index += 1;
+        self.curr = unsafe { self.curr.offset(1) };
+        Some(res)
+    }
+}
+
+impl NodeListIter {
+    fn new(com: IFabricGetNodeListResult) -> Self {
+        let list = unsafe { com.get_NodeList().as_ref().unwrap() };
+
+        let count = list.Count;
+        let item = list.Items;
+        Self {
+            _owner: com,
+            count,
+            index: 0,
+            curr: item,
+        }
+    }
+}

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -1,0 +1,320 @@
+use std::{ffi::c_void, time::Duration};
+
+use mssf_com::{
+    FabricCommon::FabricClient::{
+        IFabricResolvedServicePartitionResult, IFabricServiceManagementClient6,
+    },
+    FABRIC_PARTITION_KEY_TYPE, FABRIC_PARTITION_KEY_TYPE_INT64, FABRIC_PARTITION_KEY_TYPE_INVALID,
+    FABRIC_PARTITION_KEY_TYPE_NONE, FABRIC_PARTITION_KEY_TYPE_STRING,
+    FABRIC_RESOLVED_SERVICE_ENDPOINT, FABRIC_SERVICE_ENDPOINT_ROLE, FABRIC_SERVICE_PARTITION_KIND,
+    FABRIC_SERVICE_PARTITION_KIND_INT64_RANGE, FABRIC_SERVICE_PARTITION_KIND_INVALID,
+    FABRIC_SERVICE_PARTITION_KIND_NAMED, FABRIC_SERVICE_PARTITION_KIND_SINGLETON,
+    FABRIC_SERVICE_ROLE_INVALID, FABRIC_SERVICE_ROLE_STATEFUL_PRIMARY,
+    FABRIC_SERVICE_ROLE_STATEFUL_SECONDARY, FABRIC_SERVICE_ROLE_STATELESS,
+};
+use windows_core::{Interface, HSTRING, PCWSTR};
+
+use super::gen::svc::IFabricServiceManagementClient6Wrap;
+
+// Service Management Client
+pub struct ServiceManagementClient {
+    gen_wrap: IFabricServiceManagementClient6Wrap,
+}
+
+impl ServiceManagementClient {
+    pub fn from_com(com: IFabricServiceManagementClient6) -> Self {
+        Self {
+            gen_wrap: IFabricServiceManagementClient6Wrap::from_com(com),
+        }
+    }
+
+    // Resolve service partition
+    pub async fn resolve_service_partition(
+        &self,
+        name: &HSTRING,
+        key_type: &PartitionKeyType,
+        prev: Option<&ResolvedServicePartition>,
+        timeout: Duration,
+    ) -> windows_core::Result<ResolvedServicePartition> {
+        let uri = unsafe { name.as_ptr().as_ref().unwrap() };
+        // supply prev as null if not present
+        let prev_ptr = std::ptr::null_mut();
+        let prev_empty = unsafe { IFabricResolvedServicePartitionResult::from_raw(prev_ptr) };
+        let mut prev_ref = &prev_empty;
+        if prev.is_some() {
+            prev_ref = &prev.unwrap().com;
+        }
+
+        let part_key_raw_ptr = key_type.get_raw();
+        let part_key_raw = unsafe { &*part_key_raw_ptr };
+
+        let fu = self.gen_wrap.ResolveServicePartition(
+            uri,
+            key_type.into(),
+            part_key_raw,
+            prev_ref,
+            timeout.as_millis().try_into().unwrap(),
+        );
+        // Do not run destruct/drop. TODO: find a better way to construct null prev result.
+        // prev_empty is constructed with a null ptr inside, and drop will try do Release()
+        // which dereferences the null ptr.
+        std::mem::forget(prev_empty);
+
+        let com = fu.await?;
+        let res = ResolvedServicePartition::from_com(com);
+        Ok(res)
+    }
+}
+
+// see ComFabricClient.cpp for conversion details in cpp
+#[derive(Debug, PartialEq)]
+pub enum PartitionKeyType {
+    Int64(i64),
+    Invalid,
+    None,
+    String(HSTRING),
+}
+
+impl PartitionKeyType {
+    fn from_raw_svc_part(svc: ServicePartitionKind, data: *const c_void) -> PartitionKeyType {
+        match svc {
+            ServicePartitionKind::Int64Range => {
+                let x = data as *mut i64;
+                assert!(!x.is_null());
+                PartitionKeyType::Int64(unsafe { *x })
+            }
+            ServicePartitionKind::Invalid => PartitionKeyType::Invalid,
+            ServicePartitionKind::Singleton => PartitionKeyType::None,
+            ServicePartitionKind::Named => {
+                let x = data as *mut u16;
+                assert!(!x.is_null());
+                let s = HSTRING::from_wide(unsafe { PCWSTR::from_raw(x).as_wide() }).unwrap();
+                PartitionKeyType::String(s)
+            }
+        }
+    }
+}
+
+impl From<&PartitionKeyType> for FABRIC_PARTITION_KEY_TYPE {
+    fn from(value: &PartitionKeyType) -> Self {
+        match value {
+            PartitionKeyType::Int64(_) => FABRIC_PARTITION_KEY_TYPE_INT64,
+            PartitionKeyType::Invalid => FABRIC_PARTITION_KEY_TYPE_INVALID,
+            PartitionKeyType::None => FABRIC_PARTITION_KEY_TYPE_NONE,
+            PartitionKeyType::String(_) => FABRIC_PARTITION_KEY_TYPE_STRING,
+        }
+    }
+}
+
+impl PartitionKeyType {
+    // get raw ptr to pass in com api
+    fn get_raw(&self) -> *const c_void {
+        match self {
+            // Not sure if this is ok for i64
+            PartitionKeyType::Int64(x) => x as *const i64 as *const c_void,
+            PartitionKeyType::Invalid => std::ptr::null(),
+            PartitionKeyType::None => std::ptr::null(),
+            PartitionKeyType::String(x) => PCWSTR::from_raw(x.as_ptr()).as_ptr() as *const c_void,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ServicePartitionKind {
+    Int64Range,
+    Invalid,
+    Named,
+    Singleton,
+}
+
+impl From<&ServicePartitionKind> for FABRIC_SERVICE_PARTITION_KIND {
+    fn from(value: &ServicePartitionKind) -> Self {
+        match value {
+            ServicePartitionKind::Int64Range => FABRIC_SERVICE_PARTITION_KIND_INT64_RANGE,
+            ServicePartitionKind::Invalid => FABRIC_SERVICE_PARTITION_KIND_INVALID,
+            ServicePartitionKind::Named => FABRIC_SERVICE_PARTITION_KIND_NAMED,
+            ServicePartitionKind::Singleton => FABRIC_SERVICE_PARTITION_KIND_SINGLETON,
+        }
+    }
+}
+
+impl From<FABRIC_SERVICE_PARTITION_KIND> for ServicePartitionKind {
+    fn from(value: FABRIC_SERVICE_PARTITION_KIND) -> Self {
+        match value {
+            FABRIC_SERVICE_PARTITION_KIND_INT64_RANGE => ServicePartitionKind::Int64Range,
+            FABRIC_SERVICE_PARTITION_KIND_INVALID => ServicePartitionKind::Invalid,
+            FABRIC_SERVICE_PARTITION_KIND_NAMED => ServicePartitionKind::Named,
+            FABRIC_SERVICE_PARTITION_KIND_SINGLETON => ServicePartitionKind::Singleton,
+            _ => {
+                if cfg!(debug_assertions) {
+                    panic!("unknown type: {:?}", value);
+                } else {
+                    ServicePartitionKind::Invalid
+                }
+            }
+        }
+    }
+}
+
+pub struct ResolvedServicePartition {
+    com: IFabricResolvedServicePartitionResult,
+}
+
+impl ResolvedServicePartition {
+    fn from_com(com: IFabricResolvedServicePartitionResult) -> Self {
+        Self { com }
+    }
+}
+
+#[derive(Debug)]
+pub struct ResolvedServicePartitionInfo {
+    pub name: HSTRING,
+    pub service_partition_kind: ServicePartitionKind,
+    pub partition_key_type: PartitionKeyType,
+}
+
+impl ResolvedServicePartition {
+    // Get the service partition info/metadata
+    pub fn get_info(&self) -> ResolvedServicePartitionInfo {
+        let raw = unsafe { self.com.get_Partition().as_ref().unwrap() };
+        let name =
+            HSTRING::from_wide(unsafe { PCWSTR::from_raw(raw.ServiceName).as_wide() }).unwrap();
+        let kind_raw = raw.Info.Kind;
+        let val = raw.Info.Value;
+        let service_partition_kind: ServicePartitionKind = kind_raw.into();
+        let partition_key_type = PartitionKeyType::from_raw_svc_part(service_partition_kind, val);
+        ResolvedServicePartitionInfo {
+            name,
+            service_partition_kind,
+            partition_key_type,
+        }
+    }
+
+    // Get the list of endpoints
+    pub fn get_endpoint_list(&self) -> ResolvedServiceEndpointList {
+        ResolvedServiceEndpointList::from_com(self.com.clone())
+    }
+}
+
+#[derive(Debug)]
+pub enum ServiceRole {
+    Invalid,
+    StatefulPrimary,
+    StatefulSecondary,
+    Stateless,
+}
+
+impl From<FABRIC_SERVICE_ENDPOINT_ROLE> for ServiceRole {
+    fn from(value: FABRIC_SERVICE_ENDPOINT_ROLE) -> Self {
+        match value {
+            FABRIC_SERVICE_ROLE_INVALID => ServiceRole::Invalid,
+            FABRIC_SERVICE_ROLE_STATEFUL_PRIMARY => ServiceRole::StatefulPrimary,
+            FABRIC_SERVICE_ROLE_STATEFUL_SECONDARY => ServiceRole::StatefulSecondary,
+            FABRIC_SERVICE_ROLE_STATELESS => ServiceRole::Stateless,
+            _ => {
+                if cfg!(debug_assertions) {
+                    panic!("unknown type: {:?}", value);
+                } else {
+                    ServiceRole::Invalid
+                }
+            }
+        }
+    }
+}
+
+pub struct ResolvedServiceEndpointList {
+    com: IFabricResolvedServicePartitionResult,
+}
+
+impl ResolvedServiceEndpointList {
+    fn from_com(com: IFabricResolvedServicePartitionResult) -> Self {
+        Self { com }
+    }
+    // Get iterator for the list
+    pub fn iter(&self) -> ResolvedServiceEndpointListIter {
+        ResolvedServiceEndpointListIter::new(self.com.clone())
+    }
+}
+
+#[derive(Debug)]
+pub struct ResolvedServiceEndpoint {
+    pub address: HSTRING,
+    pub role: ServiceRole,
+}
+
+pub struct ResolvedServiceEndpointListIter {
+    _owner: IFabricResolvedServicePartitionResult,
+    count: u32, // total
+    index: u32,
+    curr: *const FABRIC_RESOLVED_SERVICE_ENDPOINT,
+}
+
+impl ResolvedServiceEndpointListIter {
+    fn new(com: IFabricResolvedServicePartitionResult) -> Self {
+        let raw = unsafe { com.get_Partition().as_ref().unwrap() };
+        let count = raw.EndpointCount;
+        let item = raw.Endpoints;
+        Self {
+            _owner: com,
+            count,
+            index: 0,
+            curr: item,
+        }
+    }
+}
+
+impl Iterator for ResolvedServiceEndpointListIter {
+    type Item = ResolvedServiceEndpoint;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.count {
+            return None;
+        }
+        // get the curr out
+        let raw = unsafe { self.curr.as_ref().unwrap() };
+        let res = Self::Item {
+            address: HSTRING::from_wide(unsafe { raw.Address.as_wide() }).unwrap(),
+            role: raw.Role.into(),
+        };
+        self.index += 1;
+        self.curr = unsafe { self.curr.offset(1) };
+        Some(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use windows_core::{HSTRING, PCWSTR};
+
+    use super::{PartitionKeyType, ServicePartitionKind};
+
+    #[test]
+    fn test_conversion_int() {
+        let k = PartitionKeyType::Int64(99);
+        // check the raw ptr is ok
+        let raw = k.get_raw();
+        let i = unsafe { (raw as *const i64).as_ref().unwrap() };
+        assert_eq!(*i, 99);
+
+        let service_type = ServicePartitionKind::Int64Range;
+        // restore the key
+        let k2 = PartitionKeyType::from_raw_svc_part(service_type, raw);
+        assert_eq!(k, k2);
+    }
+
+    #[test]
+    fn test_conversion_string() {
+        let src = HSTRING::from("mystr");
+        let k = PartitionKeyType::String(src.clone());
+        // check the raw ptr is ok
+        let raw = k.get_raw();
+        let s =
+            HSTRING::from_wide(unsafe { PCWSTR::from_raw(raw as *const u16).as_wide() }).unwrap();
+        assert_eq!(s, src);
+
+        let service_type = ServicePartitionKind::Named;
+        // restore the key
+        let k2 = PartitionKeyType::from_raw_svc_part(service_type, raw);
+        assert_eq!(k, k2);
+    }
+}

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -6,7 +6,9 @@ use mssf_com::{FABRIC_E_SERVICE_DOES_NOT_EXIST, FABRIC_NODE_QUERY_DESCRIPTION};
 use windows_core::HSTRING;
 
 use crate::client::{
-    query_client::NodeQueryDescription, svc_mgmt_client::PartitionKeyType, FabricClient,
+    query_client::{NodeQueryDescription, NodeStatusFilter},
+    svc_mgmt_client::PartitionKeyType,
+    FabricClient,
 };
 
 use super::gen::query::IFabricQueryClient10Wrap;
@@ -33,10 +35,11 @@ async fn test_fabric_client() {
     let qc = c.get_query_manager();
     let timeout = Duration::from_secs(1);
     {
-        let list = qc
-            .get_node_list(NodeQueryDescription::default(), timeout)
-            .await
-            .unwrap();
+        let desc = NodeQueryDescription {
+            node_status_filter: NodeStatusFilter::Up,
+            ..Default::default()
+        };
+        let list = qc.get_node_list(&desc, timeout).await.unwrap();
 
         let v = list.iter().collect::<Vec<_>>();
         assert_ne!(v.len(), 0);

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -66,11 +66,22 @@ async fn test_fabric_client() {
             }
             Err(e) => {
                 // If the app is not provisioned we validate the error.
-                assert_eq!(
-                    e.code(),
-                    windows_core::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0)
-                );
-                println!("EchoApp not provisioned. Skip validate.")
+                if cfg!(unix) {
+                    // In linux ci the app is not healthy from day one.
+                    // FABRIC_E_SERVICE_OFFLINE is the expected result.
+                    // TODO: Investigate the ci.
+                    assert!(
+                        e.code() == windows_core::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0)
+                            || e.code()
+                                == windows_core::HRESULT(mssf_com::FABRIC_E_SERVICE_OFFLINE.0)
+                    );
+                } else {
+                    assert_eq!(
+                        e.code(),
+                        windows_core::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0)
+                    );
+                    println!("EchoApp not provisioned. Skip validate.")
+                }
             }
         }
     }

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -57,7 +57,7 @@ async fn test_fabric_client() {
         let desc = NodeQueryDescription {
             node_status_filter: NodeStatusFilter::Up,
             paged_query: PagedQueryDescription {
-                continuation_token: Some(paging_status.continuation_token),
+                continuation_token: paging_status.map(|x| x.continuation_token),
                 max_results: Some(2),
             },
             ..Default::default()

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -21,7 +21,7 @@ use mssf_com::FabricCommon::{
     IFabricStringResult_Impl,
 };
 use windows::core::implement;
-use windows_core::HSTRING;
+use windows_core::{HSTRING, PCWSTR};
 
 #[derive(Debug)]
 #[implement(IFabricAsyncOperationCallback)]
@@ -147,6 +147,15 @@ impl IFabricStringResult_Impl for StringResult {
 pub fn IFabricStringResultToHString(s: &IFabricStringResult) -> HSTRING {
     let content = unsafe { s.get_String() };
     HSTRING::from_wide(unsafe { content.as_wide() }).unwrap()
+}
+
+// better wrapping conversion utilities
+// If nullptr returns empty string
+fn unsafe_pwstr_to_hstring(raw: PCWSTR) -> HSTRING {
+    if raw.is_null() {
+        return HSTRING::new();
+    }
+    HSTRING::from_wide(unsafe { raw.as_wide() }).unwrap()
 }
 
 #[cfg(test)]

--- a/crates/tools/fabric-gen/src/gen.rs
+++ b/crates/tools/fabric-gen/src/gen.rs
@@ -510,6 +510,12 @@ pub mod code {
                         }
                     }
 
+                    pub fn from_com(com: #itf_full_type) -> #wrap_ident {
+                        #wrap_ident {
+                            com
+                        }
+                    }
+
                     #method_stream
                 }
             }

--- a/crates/tools/fabric-gen/src/main.rs
+++ b/crates/tools/fabric-gen/src/main.rs
@@ -72,7 +72,7 @@ fn gen_class(ns: &'static str, name: &'static str, file_path: &Path, exclude: &V
 }
 
 fn main() {
-    let gen_folder = Path::new("crates/libs/core/src/client");
+    let gen_folder = Path::new("crates/libs/core/src/client/gen");
 
     // property client
     gen_class(


### PR DESCRIPTION
Implement safe rust wrapper for fabric client.
Safely wrapped resolve_service_partition and get_node_list.
The API design is modeled after Csharp FabricClient.
Added unit tests for calling these apis with SF onebox and echo app running locally (and in ci).
#15 