### PR TITLE
Standardize wstring and hstring conversion

### DIFF
--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
 use mssf_com::FabricCommon::FabricClient::{
     IFabricPropertyManagementClient2, IFabricQueryClient10, IFabricServiceManagementClient6,
 };

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, time::Duration};
 use crate::{
     client::IFabricQueryClient10Wrap,
     iter::{FabricIter, FabricListAccessor},
-    unsafe_pwstr_to_hstring,
+    strings::HSTRINGWrap,
 };
 use bitflags::bitflags;
 use mssf_com::{
@@ -98,7 +98,7 @@ pub struct PagingStatus {
 impl From<&FABRIC_PAGING_STATUS> for PagingStatus {
     fn from(value: &FABRIC_PAGING_STATUS) -> Self {
         Self {
-            continuation_token: unsafe_pwstr_to_hstring(value.ContinuationToken),
+            continuation_token: HSTRINGWrap::from(value.ContinuationToken).into(),
         }
     }
 }
@@ -209,14 +209,14 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for Node {
         };
         Node {
             name: HSTRING::from_wide(unsafe { raw.NodeName.as_wide() }).unwrap(),
-            ip_address_or_fqdn: unsafe_pwstr_to_hstring(raw.IpAddressOrFQDN),
-            node_type: unsafe_pwstr_to_hstring(raw.NodeType),
-            code_version: unsafe_pwstr_to_hstring(raw.CodeVersion),
-            config_version: unsafe_pwstr_to_hstring(raw.ConfigVersion),
+            ip_address_or_fqdn: HSTRINGWrap::from(raw.IpAddressOrFQDN).into(),
+            node_type: HSTRINGWrap::from(raw.NodeType).into(),
+            code_version: HSTRINGWrap::from(raw.CodeVersion).into(),
+            config_version: HSTRINGWrap::from(raw.ConfigVersion).into(),
             node_up_time_in_seconds: raw.NodeUpTimeInSeconds,
             is_seed_node: raw.IsSeedNode.as_bool(),
-            upgrade_domain: unsafe_pwstr_to_hstring(raw.UpgradeDomain),
-            fault_domain: unsafe_pwstr_to_hstring(windows_core::PCWSTR(raw.FaultDomain)),
+            upgrade_domain: HSTRINGWrap::from(raw.UpgradeDomain).into(),
+            fault_domain: HSTRINGWrap::from(windows_core::PCWSTR(raw.FaultDomain)).into(),
             node_instance_id: raw2.NodeInstanceId,
         }
     }

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
 use std::{ffi::c_void, time::Duration};
 
 use mssf_com::{

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
 // contains tests for generated fabric client
 
 use std::time::Duration;

--- a/crates/libs/core/src/iter.rs
+++ b/crates/libs/core/src/iter.rs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
 // iterator implementation
 // Iter infrastructure to convert Fabric raw list into rust safe wrappers.
 // Raw lists needs to be wrapped in FabricListAccessor, and raw item needs to

--- a/crates/libs/core/src/runtime/config.rs
+++ b/crates/libs/core/src/runtime/config.rs
@@ -8,7 +8,7 @@ use windows_core::HSTRING;
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    unsafe_pwstr_to_hstring, HSTRINGWrap, IFabricStringResultToHString,
+    strings::HSTRINGWrap,
 };
 
 #[derive(Debug, Clone)]
@@ -64,10 +64,10 @@ impl ConfigurationPackage {
         let raw = unsafe { self.com.get_Description().as_ref().unwrap() };
 
         ConfigurationPackageDesc {
-            name: unsafe_pwstr_to_hstring(raw.Name),
-            ServiceManifestName: unsafe_pwstr_to_hstring(raw.ServiceManifestName),
-            ServiceManifestVersion: unsafe_pwstr_to_hstring(raw.ServiceManifestVersion),
-            Version: unsafe_pwstr_to_hstring(raw.Version),
+            name: HSTRINGWrap::from(raw.Name).into(),
+            ServiceManifestName: HSTRINGWrap::from(raw.ServiceManifestName).into(),
+            ServiceManifestVersion: HSTRINGWrap::from(raw.ServiceManifestVersion).into(),
+            Version: HSTRINGWrap::from(raw.Version).into(),
         }
     }
 
@@ -118,7 +118,7 @@ impl ConfigurationPackage {
 
     pub fn decrypt_value(&self, encryptedvalue: &HSTRING) -> windows_core::Result<HSTRING> {
         let s = unsafe { self.com.DecryptValue(encryptedvalue) }?;
-        Ok(IFabricStringResultToHString(&s))
+        Ok(HSTRINGWrap::from(&s).into())
     }
 }
 

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -6,7 +6,7 @@ use mssf_com::FabricCommon::FabricRuntime::{
 };
 use windows_core::{Interface, HSTRING};
 
-use crate::{unsafe_pwstr_to_hstring, IFabricStringResultToHString};
+use crate::strings::HSTRINGWrap;
 
 pub fn get_com_node_context(
     timeoutMilliseconds: u32,
@@ -64,9 +64,9 @@ impl NodeContext {
         let raw_ref = unsafe { raw.as_ref() }.unwrap();
         Self {
             com: com.clone(),
-            node_name: unsafe_pwstr_to_hstring(raw_ref.NodeName),
-            node_type: unsafe_pwstr_to_hstring(raw_ref.NodeType),
-            ip_address_or_fqdn: unsafe_pwstr_to_hstring(raw_ref.IPAddressOrFQDN),
+            node_name: HSTRINGWrap::from(raw_ref.NodeName).into(),
+            node_type: HSTRINGWrap::from(raw_ref.NodeType).into(),
+            ip_address_or_fqdn: HSTRINGWrap::from(raw_ref.IPAddressOrFQDN).into(),
             node_instance_id: raw_ref.NodeInstanceId,
             node_id: NodeId {
                 low: raw_ref.NodeId.Low,
@@ -79,6 +79,6 @@ impl NodeContext {
     pub fn get_directory(&self, logical_directory_name: &HSTRING) -> windows_core::Result<HSTRING> {
         let com2 = self.com.cast::<IFabricNodeContextResult2>()?;
         let dir = unsafe { com2.GetDirectory(logical_directory_name) }?;
-        Ok(IFabricStringResultToHString(&dir))
+        Ok(HSTRINGWrap::from(&dir).into())
     }
 }

--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -31,7 +31,7 @@ use crate::{
         stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, Role},
         BridgeContext,
     },
-    StringResult,
+    strings::HSTRINGWrap,
 };
 
 use super::{
@@ -164,7 +164,7 @@ where
             unsafe { context.unwrap().as_impl() };
         let content = ctx_bridge.consume_content()?;
         info!("IFabricReplicatorBridge::EndOpen addr {}", content);
-        Ok(StringResult::new(content).into())
+        Ok(HSTRINGWrap::from(content).into())
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -675,7 +675,7 @@ where
             unsafe { context.unwrap().as_impl() };
         let addr = ctx_bridge.consume_content()?;
         info!("IFabricStatefulReplicaBridge::EndChangeRole: addr {}", addr);
-        Ok(StringResult::new(addr).into())
+        Ok(HSTRINGWrap::from(addr).into())
     }
 
     fn BeginClose(

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -15,7 +15,7 @@ use mssf_com::{
 };
 use windows_core::{Interface, HSTRING};
 
-use crate::IFabricStringResultToHString;
+use crate::strings::HSTRINGWrap;
 
 use super::{
     stateful::{PrimaryReplicator, Replicator, StatefulServicePartition, StatefulServiceReplica},
@@ -72,7 +72,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
 
         let _ = unsafe { self.com_impl.BeginChangeRole(newrole.into(), &callback)? };
         let addr = rx.await.unwrap()?;
-        Ok(IFabricStringResultToHString(&addr))
+        Ok(HSTRINGWrap::from(&addr).into())
     }
     async fn close(&self) -> windows::core::Result<()> {
         info!("StatefulServiceReplicaProxy::close");
@@ -117,7 +117,7 @@ impl Replicator for ReplicatorProxy {
         });
         let _ = unsafe { self.com_impl.BeginOpen(&callback)? };
         let addr = rx.await.unwrap()?;
-        Ok(IFabricStringResultToHString(&addr))
+        Ok(HSTRINGWrap::from(&addr).into())
     }
     async fn close(&self) -> ::windows_core::Result<()> {
         info!("ReplicatorProxy::close");

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::{
     runtime::{stateless::StatelessServicePartition, BridgeContext},
-    StringResult,
+    strings::HSTRINGWrap,
 };
 use log::info;
 use mssf_com::FabricCommon::{
@@ -153,7 +153,7 @@ where
             unsafe { context.unwrap().as_impl() };
 
         let content = ctx_bridge.consume_content()?;
-        Ok(StringResult::new(content).into())
+        Ok(HSTRINGWrap::from(content).into())
     }
 
     fn BeginClose(

--- a/crates/libs/core/src/strings.rs
+++ b/crates/libs/core/src/strings.rs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::FabricCommon::{IFabricStringResult, IFabricStringResult_Impl};
+use windows_core::{implement, HSTRING, PCWSTR};
+
+// Basic implementation of fabric string result
+// usually used as string return value to fabric runtime.
+#[derive(Debug)]
+#[implement(IFabricStringResult)]
+pub struct StringResult {
+    data: HSTRING,
+}
+
+// Recommend to use HSTRINGWrap to construct this and convert to
+// IFabricStringResult.
+impl StringResult {
+    pub fn new(data: HSTRING) -> StringResult {
+        StringResult { data }
+    }
+}
+
+impl IFabricStringResult_Impl for StringResult {
+    fn get_String(&self) -> windows::core::PCWSTR {
+        // This is some hack to get the raw pointer out.
+        windows::core::PCWSTR::from_raw(self.data.as_ptr())
+    }
+}
+
+// If nullptr returns empty string.
+// requires the PCWSTR points to a valid buffer with null terminatior
+fn safe_pwstr_to_hstring(raw: PCWSTR) -> HSTRING {
+    if raw.is_null() {
+        return HSTRING::new();
+    }
+    HSTRING::from_wide(unsafe { raw.as_wide() }).unwrap()
+}
+
+// Convert helper for HSTRING and PCWSTR and IFabricStringResult
+pub struct HSTRINGWrap {
+    h: HSTRING,
+}
+
+impl From<HSTRING> for HSTRINGWrap {
+    fn from(value: HSTRING) -> Self {
+        Self { h: value }
+    }
+}
+
+impl From<PCWSTR> for HSTRINGWrap {
+    fn from(value: PCWSTR) -> Self {
+        let h = safe_pwstr_to_hstring(value);
+        Self { h }
+    }
+}
+
+impl From<HSTRINGWrap> for HSTRING {
+    fn from(val: HSTRINGWrap) -> Self {
+        val.h
+    }
+}
+
+impl From<&IFabricStringResult> for HSTRINGWrap {
+    fn from(value: &IFabricStringResult) -> Self {
+        let content = unsafe { value.get_String() };
+        let h = safe_pwstr_to_hstring(content);
+        Self { h }
+    }
+}
+
+impl From<HSTRINGWrap> for IFabricStringResult {
+    fn from(value: HSTRINGWrap) -> Self {
+        StringResult::new(value.h).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::strings::HSTRINGWrap;
+
+    use super::StringResult;
+    use mssf_com::FabricCommon::IFabricStringResult;
+    use windows_core::HSTRING;
+
+    #[test]
+    fn test_str_addr() {
+        // Test the addr returned to SF is right.
+        let addr = "1.2.3.4:1234";
+
+        // Check hstring len.
+        let haddr = HSTRING::from(addr);
+        let haddr_slice = haddr.as_wide();
+        assert_eq!(haddr_slice.len(), 12);
+
+        // check StringResult len.
+        let com_addr: IFabricStringResult = StringResult::new(haddr.clone()).into();
+        let raw = unsafe { com_addr.get_String() };
+        let slice = unsafe { raw.as_wide() };
+        assert_eq!(slice.len(), 12);
+
+        // check StringResult conversion is right
+        let haddr2: HSTRING = HSTRINGWrap::from(&com_addr).into();
+        assert_eq!(haddr, haddr2);
+    }
+}

--- a/crates/samples/echomain-stateful/src/app.rs
+++ b/crates/samples/echomain-stateful/src/app.rs
@@ -20,12 +20,11 @@ use mssf_com::FabricCommon::FabricRuntime::{
 use mssf_com::FabricCommon::{
     IFabricAsyncOperationCallback, IFabricAsyncOperationContext, IFabricStringResult,
 };
-use mssf_core::{AsyncContext, StringResult};
+use mssf_core::{strings::HSTRINGWrap, AsyncContext};
 use tokio::sync::oneshot::{self, Sender};
 use windows::core::implement;
 use windows::core::w;
 use windows_core::HSTRING;
-//use windows_core::Error as WError;
 
 mod echo;
 
@@ -125,7 +124,7 @@ impl IFabricReplicator_Impl for AppFabricReplicator {
         info!("AppFabricReplicator::EndOpen");
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
         info!("AppFabricReplicator::EndOpen {}", addr);
-        let str_res: IFabricStringResult = StringResult::new(HSTRING::from(addr)).into();
+        let str_res: IFabricStringResult = HSTRINGWrap::from(HSTRING::from(addr)).into();
         Ok(str_res)
     }
 
@@ -439,7 +438,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance {
         info!("AppInstance::EndChangeRole");
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
         info!("AppInstance::EndChangeRole {}", addr);
-        let str_res: IFabricStringResult = StringResult::new(HSTRING::from(addr)).into();
+        let str_res: IFabricStringResult = HSTRINGWrap::from(HSTRING::from(addr)).into();
         Ok(str_res)
     }
 }

--- a/crates/samples/echomain/src/app.rs
+++ b/crates/samples/echomain/src/app.rs
@@ -19,7 +19,7 @@ use mssf_com::FabricCommon::FabricRuntime::{
 use mssf_com::FabricCommon::{
     IFabricAsyncOperationCallback, IFabricAsyncOperationContext, IFabricStringResult,
 };
-use mssf_core::{AsyncContext, StringResult};
+use mssf_core::{strings::HSTRINGWrap, AsyncContext};
 use tokio::sync::oneshot::{self, Sender};
 use windows::core::implement;
 use windows::core::w;
@@ -156,7 +156,7 @@ impl IFabricStatelessServiceInstance_Impl for AppInstance {
 
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
 
-        let str_res: IFabricStringResult = StringResult::new(HSTRING::from(addr)).into();
+        let str_res: IFabricStringResult = HSTRINGWrap::from(HSTRING::from(addr)).into();
         Ok(str_res)
     }
 


### PR DESCRIPTION
All WCHAR related string types conversion goes through the HSTRINGWrap type.
And the conversion is as safe as possible, unless the raw pointer points to invalid wide string buffer.