### PR TITLE
Correctly validate pointers are non-null

### DIFF
--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -79,7 +79,11 @@ where
         let h_servicename = HSTRING::from_wide(unsafe { p_servicename.as_wide() }).unwrap();
         let h_servicetypename = HSTRING::from_wide(unsafe { servicetypename.as_wide() }).unwrap();
         let data = unsafe {
-            std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
+            if initializationdata != std::ptr::null() {
+                std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
+            } else {
+                &[]
+            }
         };
 
         let replica = self.inner.create_replica(

--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -79,7 +79,7 @@ where
         let h_servicename = HSTRING::from_wide(unsafe { p_servicename.as_wide() }).unwrap();
         let h_servicetypename = HSTRING::from_wide(unsafe { servicetypename.as_wide() }).unwrap();
         let data = unsafe {
-            if initializationdata != std::ptr::null() {
+            if !initializationdata.is_null() {
                 std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
             } else {
                 &[]

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -68,7 +68,11 @@ where
         let h_servicename = HSTRING::from_wide(unsafe { p_servicename.as_wide() }).unwrap();
         let h_servicetypename = HSTRING::from_wide(unsafe { servicetypename.as_wide() }).unwrap();
         let data = unsafe {
-            std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
+            if initializationdata != std::ptr::null() {
+                std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
+            } else {
+                &[]
+            }
         };
 
         let instance = self.inner.create_instance(

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -68,7 +68,7 @@ where
         let h_servicename = HSTRING::from_wide(unsafe { p_servicename.as_wide() }).unwrap();
         let h_servicetypename = HSTRING::from_wide(unsafe { servicetypename.as_wide() }).unwrap();
         let data = unsafe {
-            if initializationdata != std::ptr::null() {
+            if !initializationdata.is_null() {
                 std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
             } else {
                 &[]


### PR DESCRIPTION
Rust 1.78 will now validate preconditions to unsafe standard library functions. This includes std::slice::from_raw_parts which validates the pointer is:
1) Non-null
2) Correctly aligned

In this case, initializationdata can be null, so we need to correctly address that by returning an empty slice explicitly rather than calling from_raw_parts() will a nullptr.