### PR TITLE
impl From<IFabricCodePackageActivationContext> for ActivationContext

### DIFF
--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -161,8 +161,7 @@ impl ActivationContext {
     }
 }
 
-impl From<IFabricCodePackageActivationContext> for ActivationContext
-{
+impl From<IFabricCodePackageActivationContext> for ActivationContext {
     fn from(value: IFabricCodePackageActivationContext) -> Self {
         ActivationContext { com_impl: value }
     }

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -131,7 +131,7 @@ pub struct ActivationContext {
 impl ActivationContext {
     pub fn create() -> Result<ActivationContext, Error> {
         let com = get_com_activation_context()?;
-        Ok(ActivationContext { com_impl: com })
+        Ok(Self::from(com))
     }
 
     pub fn get_endpoint_resource(
@@ -158,5 +158,12 @@ impl ActivationContext {
 
     pub fn get_com(&self) -> IFabricCodePackageActivationContext {
         self.com_impl.clone()
+    }
+}
+
+impl From<IFabricCodePackageActivationContext> for ActivationContext
+{
+    fn from(value: IFabricCodePackageActivationContext) -> Self {
+        ActivationContext { com_impl: value }
     }
 }


### PR DESCRIPTION
I have a potential interop scenario that is easiest achieved by having the caller of my crate provide the IFabricCodePackageActivationContext, as it avoids my crate having to take link or load time dependency on FabricRuntime.dll 

This PR makes that scenario possible.

Since ActivationContext wraps a IFabricCodePackageActivation context, and that COM object already is reference counted, it's reasonable to implement From<IFabricCodePackageActivation> for ActivationContext to support this scenario.

It can be useful within Rust too - if you find a way to create a mock or fake IFabricCodePackageActivationContext implementation (which should be possible), it'll enable unit testing of these code paths.

Refactors ActivationContext::new to use the From method as well for consistency.
