### PR TITLE
Add Tokio and config-rs features

### DIFF
--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -13,14 +13,21 @@ include = [
     "Cargo.toml",
 ]
 
+[features]
+default = ["config_source", "tokio"]
+# Required for a lot of callback functionality
+tokio = ["dep:tokio"]
+# Config crate required to implement its interface. 
+config_source = ["config"]
+
 [dependencies]
 tracing.workspace = true
-tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros"] }
+tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros"], optional = true }
 windows-core = "0.56"
 ctrlc = { version = "3.0", features = ["termination"] }
 trait-variant = "0.1.1"
 bitflags = "2.5.0"
-config = { version = "0.14.0",  default-features = false}
+config = { version = "0.14.0",  default-features = false, optional = true }
 
 [dev-dependencies]
 paste = "1.0"

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -15,8 +15,9 @@ include = [
 
 [features]
 default = ["config_source", "tokio"]
-# Required for a lot of callback functionality
-tokio = ["dep:tokio"]
+# Required for a lot of callback functionality.
+# Also requires ctrlc for signal handling
+tokio = ["dep:tokio", "ctrlc"]
 # Config crate required to implement its interface. 
 config_source = ["config"]
 
@@ -24,7 +25,7 @@ config_source = ["config"]
 tracing.workspace = true
 tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros"], optional = true }
 windows-core = "0.56"
-ctrlc = { version = "3.0", features = ["termination"] }
+ctrlc = { version = "3.0", features = ["termination"], optional = true }
 trait-variant = "0.1.1"
 bitflags = "2.5.0"
 config = { version = "0.14.0",  default-features = false, optional = true }

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -9,11 +9,11 @@
 //! - when you are using the lower-level COM API to do something more custom
 //! You might not need all of the functionality that the mssf-core crate provides
 //! In this case, you can configure only what you need to reduce dependencies and compile times.
-//! 
-//! * ** config_source **  - 
+//!
+//! * ** config_source **  -
 //!     Provides an implementation of config::Source. Requires config_rs crate
-//! 
-//! * ** Tokio **  - 
+//!
+//! * ** Tokio **  -
 //!     A lot of the sophoisticated functionality in this crate requires Tokio.
 //!     However, even without tokio, some of the higher level wrappers over COM types have utility.
 #![allow(non_snake_case)]

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -2,17 +2,33 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-
+//! # Features
+//! All features are enabled by default unless otherwise noted.
+//! For most scenarios, you'll want the features. However, in some scenarios, such as:
+//! - integrating Rust into an existing Service Fabric Application written in another language
+//! - when you are using the lower-level COM API to do something more custom
+//! You might not need all of the functionality that the mssf-core crate provides
+//! In this case, you can configure only what you need to reduce dependencies and compile times.
+//! 
+//! * ** config_source **  - 
+//!     Provides an implementation of config::Source. Requires config_rs crate
+//! 
+//! * ** Tokio **  - 
+//!     A lot of the sophoisticated functionality in this crate requires Tokio.
+//!     However, even without tokio, some of the higher level wrappers over COM types have utility.
 #![allow(non_snake_case)]
 
 // lib that contains all common extensions for the raw fabric apis.
 
+#[cfg(feature = "tokio")]
 pub mod client;
+#[cfg(feature = "config_source")]
 pub mod conf;
 pub mod debug;
 mod iter;
 pub mod runtime;
 pub mod strings;
+#[cfg(feature = "tokio")]
 pub mod sync;
 
 // re-export some windows types

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -5,17 +5,15 @@
 
 use mssf_com::{
     FabricCommon::FabricRuntime::{
-            FabricCreateRuntime, FabricGetActivationContext, IFabricCodePackageActivationContext,
-            IFabricRuntime,
-        },
+        FabricCreateRuntime, FabricGetActivationContext, IFabricCodePackageActivationContext,
+        IFabricRuntime,
+    },
     FABRIC_ENDPOINT_RESOURCE_DESCRIPTION,
 };
 use windows_core::{Error, Interface, HSTRING, PCWSTR};
-    
+
 #[cfg(feature = "tokio")]
-use mssf_com::FabricCommon::{
-        IFabricAsyncOperationCallback, IFabricAsyncOperationContext,
-    };
+use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
 
 use self::config::ConfigurationPackage;
 

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -4,18 +4,20 @@
 // ------------------------------------------------------------
 
 use mssf_com::{
-    FabricCommon::{
-        FabricRuntime::{
+    FabricCommon::FabricRuntime::{
             FabricCreateRuntime, FabricGetActivationContext, IFabricCodePackageActivationContext,
             IFabricRuntime,
         },
-        IFabricAsyncOperationCallback, IFabricAsyncOperationContext,
-    },
     FABRIC_ENDPOINT_RESOURCE_DESCRIPTION,
 };
 use windows_core::{Error, Interface, HSTRING, PCWSTR};
+    
+#[cfg(feature = "tokio")]
+use mssf_com::FabricCommon::{
+        IFabricAsyncOperationCallback, IFabricAsyncOperationContext,
+    };
 
-use self::{config::ConfigurationPackage, stateless::StatelessServiceFactory};
+use self::config::ConfigurationPackage;
 
 #[cfg(feature = "tokio")]
 pub use self::runtime::Runtime;

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -15,20 +15,13 @@ use mssf_com::{
 };
 use windows_core::{Error, Interface, HSTRING, PCWSTR};
 
-use self::{
-    config::ConfigurationPackage,  stateless::StatelessServiceFactory,
-};
-
+use self::{config::ConfigurationPackage, stateless::StatelessServiceFactory};
 
 #[cfg(feature = "tokio")]
-use self::
-{
-    executor::Executor, stateful::StatefulServiceFactory,
-    stateful_bridge::StatefulServiceFactoryBridge,
-    stateless_bridge::StatelessServiceFactoryBridge,
-    runtime::Runtime
+use self::{
+    executor::Executor, runtime::Runtime, stateful::StatefulServiceFactory,
+    stateful_bridge::StatefulServiceFactoryBridge, stateless_bridge::StatelessServiceFactoryBridge,
 };
-
 
 #[cfg(feature = "tokio")]
 mod bridge;
@@ -38,6 +31,8 @@ pub mod error;
 pub mod executor;
 #[cfg(feature = "tokio")]
 pub mod node_context;
+#[cfg(feature = "tokio")]
+pub mod runtime;
 pub mod stateful;
 #[cfg(feature = "tokio")]
 pub mod stateful_bridge;
@@ -51,8 +46,6 @@ pub mod store;
 #[cfg(feature = "tokio")]
 pub mod store_proxy;
 pub mod store_types;
-#[cfg(feature = "tokio")]
-pub mod runtime;
 
 // creates fabric runtime
 pub fn create_com_runtime() -> ::windows_core::Result<IFabricRuntime> {
@@ -69,7 +62,6 @@ pub fn get_com_activation_context() -> ::windows_core::Result<IFabricCodePackage
         unsafe { IFabricCodePackageActivationContext::from_raw(raw_activation_ctx) };
     Ok(activation_ctx)
 }
-
 
 #[derive(Debug)]
 pub struct EndpointResourceDesc {

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use mssf_com::{
     FabricCommon::{
         FabricRuntime::{
             FabricCreateRuntime, FabricGetActivationContext, IFabricCodePackageActivationContext,
-            IFabricRuntime, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory,
+            IFabricRuntime,
         },
         IFabricAsyncOperationCallback, IFabricAsyncOperationContext,
     },
@@ -18,10 +18,7 @@ use windows_core::{Error, Interface, HSTRING, PCWSTR};
 use self::{config::ConfigurationPackage, stateless::StatelessServiceFactory};
 
 #[cfg(feature = "tokio")]
-use self::{
-    executor::Executor, runtime::Runtime, stateful::StatefulServiceFactory,
-    stateful_bridge::StatefulServiceFactoryBridge, stateless_bridge::StatelessServiceFactoryBridge,
-};
+pub use self::runtime::Runtime;
 
 #[cfg(feature = "tokio")]
 mod bridge;

--- a/crates/libs/core/src/runtime/runtime.rs
+++ b/crates/libs/core/src/runtime/runtime.rs
@@ -1,4 +1,3 @@
-
 /// safe wrapping for runtime
 pub struct Runtime<E>
 where

--- a/crates/libs/core/src/runtime/runtime.rs
+++ b/crates/libs/core/src/runtime/runtime.rs
@@ -1,4 +1,8 @@
 /// safe wrapping for runtime
+use mssf_com::FabricCommon::FabricRuntime::{IFabricRuntime, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory};
+use crate::HSTRING;
+
+use super::{create_com_runtime, executor::Executor, stateful::StatefulServiceFactory, stateful_bridge::StatefulServiceFactoryBridge, stateless::StatelessServiceFactory, stateless_bridge::StatelessServiceFactoryBridge};
 pub struct Runtime<E>
 where
     E: Executor,

--- a/crates/libs/core/src/runtime/runtime.rs
+++ b/crates/libs/core/src/runtime/runtime.rs
@@ -1,8 +1,14 @@
-/// safe wrapping for runtime
-use mssf_com::FabricCommon::FabricRuntime::{IFabricRuntime, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory};
 use crate::HSTRING;
+/// safe wrapping for runtime
+use mssf_com::FabricCommon::FabricRuntime::{
+    IFabricRuntime, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory,
+};
 
-use super::{create_com_runtime, executor::Executor, stateful::StatefulServiceFactory, stateful_bridge::StatefulServiceFactoryBridge, stateless::StatelessServiceFactory, stateless_bridge::StatelessServiceFactoryBridge};
+use super::{
+    create_com_runtime, executor::Executor, stateful::StatefulServiceFactory,
+    stateful_bridge::StatefulServiceFactoryBridge, stateless::StatelessServiceFactory,
+    stateless_bridge::StatelessServiceFactoryBridge,
+};
 pub struct Runtime<E>
 where
     E: Executor,

--- a/crates/libs/core/src/runtime/runtime.rs
+++ b/crates/libs/core/src/runtime/runtime.rs
@@ -1,0 +1,50 @@
+
+/// safe wrapping for runtime
+pub struct Runtime<E>
+where
+    E: Executor,
+{
+    com_impl: IFabricRuntime,
+    rt: E,
+}
+
+impl<E> Runtime<E>
+where
+    E: Executor,
+{
+    pub fn create(rt: E) -> ::windows_core::Result<Runtime<E>> {
+        let com = create_com_runtime()?;
+        Ok(Runtime { com_impl: com, rt })
+    }
+
+    pub fn register_stateless_service_factory<F>(
+        &self,
+        servicetypename: &HSTRING,
+        factory: F,
+    ) -> windows_core::Result<()>
+    where
+        F: StatelessServiceFactory,
+    {
+        let rt_cp = self.rt.clone();
+        let bridge: IFabricStatelessServiceFactory =
+            StatelessServiceFactoryBridge::create(factory, rt_cp).into();
+        unsafe {
+            self.com_impl
+                .RegisterStatelessServiceFactory(servicetypename, &bridge)
+        }
+    }
+
+    pub fn register_stateful_service_factory(
+        &self,
+        servicetypename: &HSTRING,
+        factory: impl StatefulServiceFactory,
+    ) -> windows_core::Result<()> {
+        let rt_cp = self.rt.clone();
+        let bridge: IFabricStatefulServiceFactory =
+            StatefulServiceFactoryBridge::create(factory, rt_cp).into();
+        unsafe {
+            self.com_impl
+                .RegisterStatefulServiceFactory(servicetypename, &bridge)
+        }
+    }
+}

--- a/crates/samples/echomain-stateful/Cargo.toml
+++ b/crates/samples/echomain-stateful/Cargo.toml
@@ -27,3 +27,6 @@ features = [
 
 [dependencies.mssf-core]
 path = "../../libs/core"
+# We don't showcase config integration in this particular example
+default-features = false
+#features = []


### PR DESCRIPTION
As discussed offline, I have some oddball integration scenarios where much of the SF runtime interaction is already handled by existing application logic written in other languages, but we'd like to move parts of the system into Rust.

At least for now, my project is not making use of any of the functionality in mssf-core that actually necessitates use of Tokio, nor are we currently using the config_rs crate. At the same time, mssf_com is a bit too low level to be ideal for us - we have no desire to duplicate / rewrite existing Rust wrappers such as:
* mssf_core::runtime::config types
* mssf_core::runtime::ActivationContext

To enable minimizing dependencies and compile times for those of use who don't need the entire runtime at present, this PR adds two default-on features (naming suggestions of course welcome) - one for config-rs, one for tokio (tokio feature also requires ctrlc as that's small and part of the Executor, and I'm assuming most native-Rust applications that are ok with tokio will want that too).

It also moves some of the code form runtimes/mod.rs to its own file to make the conditional complication a bit less messy, though it could be cleaner.

Additionally, one of the echomain examples is adjusted to demonstrate that the config-rs feature is optional. I h aven't shown the Tokio one. it does compile appropriately, but it would require a C# or C++ demo application embedding a Rust dll or static library containing this code - all the examples use callbacks or service factory types that I can see, and those APIs require Tokio presently.