### PR TITLE
Upgrade rust toolchain to 1.79

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.78.0
+        toolchain: 1.79.0
         components: rustfmt, clippy
     
     - name: Run cargo check
@@ -91,7 +91,7 @@ jobs:
     - name: Install rust stable
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.78.0
+        toolchain: 1.79.0
         components: rustfmt, clippy
     
     - name: Run cargo check

--- a/crates/libs/com/src/lib.rs
+++ b/crates/libs/com/src/lib.rs
@@ -15,7 +15,8 @@ extern crate windows;
     clippy::missing_safety_doc,
     clippy::too_many_arguments,
     clippy::extra_unused_lifetimes,
-    clippy::useless_transmute
+    clippy::useless_transmute,
+    clippy::missing_transmute_annotations // winbindgen needs to fix this
 )]
 pub mod Microsoft;
 

--- a/crates/libs/core/src/conf/mod.rs
+++ b/crates/libs/core/src/conf/mod.rs
@@ -9,7 +9,7 @@
 // features of config-rs.
 
 use config::{ConfigError, Source};
-use tracing::info;
+use tracing::debug;
 
 use crate::runtime::config::ConfigurationPackage;
 pub use config::Config;
@@ -41,25 +41,19 @@ impl Source for FabricConfigSource {
         let uri_origion = String::from("fabric source");
         let mut res = config::Map::new();
         let settings = self.inner.get_settings();
-        settings
-            .sections
-            .iter()
-            .enumerate()
-            .for_each(|(_, section)| {
-                let section_name = section.name.to_string();
-                info!("Section: {}", section_name);
-                section.parameters.iter().enumerate().for_each(|(_, p)| {
-                    let param_name = p.name.to_string();
-                    let param_val = p.value.to_string();
-                    info!("Param: {:?}", param_name);
-                    let val = config::Value::new(
-                        Some(&uri_origion),
-                        config::ValueKind::String(param_val),
-                    );
-                    // section and param is separated by a dot.
-                    res.insert(section_name.clone() + "." + &param_name, val);
-                })
-            });
+        settings.sections.iter().for_each(|section| {
+            let section_name = section.name.to_string();
+            debug!("Section: {}", section_name);
+            section.parameters.iter().for_each(|p| {
+                let param_name = p.name.to_string();
+                let param_val = p.value.to_string();
+                debug!("Param: {} Val: {}", param_name, param_val);
+                let val =
+                    config::Value::new(Some(&uri_origion), config::ValueKind::String(param_val));
+                // section and param is separated by a dot.
+                res.insert(section_name.clone() + "." + &param_name, val);
+            })
+        });
         Ok(res)
     }
 }

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -73,18 +73,13 @@ fn validate_configs(actctx: &ActivationContext) {
         .get_configuration_package(&HSTRING::from("Config"))
         .unwrap();
     let settings = config.get_settings();
-    settings
-        .sections
-        .iter()
-        .enumerate()
-        .for_each(|(_, section)| {
-            info!("Section: {}", section.name);
-            section
-                .parameters
-                .iter()
-                .enumerate()
-                .for_each(|(_, p)| info!("Param: {:?}", p))
-        });
+    settings.sections.iter().for_each(|section| {
+        info!("Section: {}", section.name);
+        section
+            .parameters
+            .iter()
+            .for_each(|p| info!("Param: {:?}", p))
+    });
 
     // get the required config
     let (v, encrypt) = config

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # cargo + rustup will use this to consistently build the project
 # with the same version across all checkouts and environments
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 profile = "default"


### PR DESCRIPTION
Fixed all lint errors from the cargo clippy in the new version.