### PR TITLE
[mssf-core] Reexport hresult type

### DIFF
--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -32,4 +32,4 @@ pub mod strings;
 pub mod sync;
 
 // re-export some windows types
-pub use windows_core::{Error, Result, GUID, HSTRING, PCWSTR};
+pub use windows_core::{Error, Result, GUID, HRESULT, HSTRING, PCWSTR};


### PR DESCRIPTION
HRESULT from windows_core is used by many apps, and previously not re-exported.
Reexport it so that those apps can have no direct dep on windows_core.