### PR TITLE
[FabricClient] Implement get_replica_list api

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,8 +49,9 @@ jobs:
     - name: check sf exist
       run: Powershell.exe -File .\build\_deps\service_fabric_cpp-src\scripts\check_sf_installed.ps1
 
+    # Creates a 5 node dev cluster
     - name: start sf cluster
-      run: Powershell.exe -File "C:\Program Files\Microsoft SDKs\Service Fabric\ClusterSetup\DevClusterSetup.ps1" -CreateOneNodeCluster
+      run: Powershell.exe -File "C:\Program Files\Microsoft SDKs\Service Fabric\ClusterSetup\DevClusterSetup.ps1"
 
     - name: start connection
       run: Powershell.exe -File .\build\_deps\service_fabric_cpp-src\scripts\check_cluster_online.ps1

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -38,10 +38,10 @@ impl ServiceManagementClient {
     fn resolve_service_partition_internal(
         &self,
         name: FABRIC_URI,
-        partitionKeyType: FABRIC_PARTITION_KEY_TYPE,
-        partitionKey: Option<*const ::core::ffi::c_void>,
-        previousResult: Option<&IFabricResolvedServicePartitionResult>, // This is different from generated code
-        timeoutMilliseconds: u32,
+        partition_key_type: FABRIC_PARTITION_KEY_TYPE,
+        partition_key: Option<*const ::core::ffi::c_void>,
+        previous_result: Option<&IFabricResolvedServicePartitionResult>, // This is different from generated code
+        timeout_milliseconds: u32,
     ) -> crate::sync::FabricReceiver<::windows_core::Result<IFabricResolvedServicePartitionResult>>
     {
         let com1 = &self.com;
@@ -50,10 +50,10 @@ impl ServiceManagementClient {
             move |callback| unsafe {
                 com1.BeginResolveServicePartition(
                     name,
-                    partitionKeyType,
-                    partitionKey.unwrap_or(std::ptr::null()),
-                    previousResult,
-                    timeoutMilliseconds,
+                    partition_key_type,
+                    partition_key.unwrap_or(std::ptr::null()),
+                    previous_result,
+                    timeout_milliseconds,
                     callback,
                 )
             },

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -16,7 +16,6 @@
 //! * ** Tokio **  -
 //!     A lot of the sophoisticated functionality in this crate requires Tokio.
 //!     However, even without tokio, some of the higher level wrappers over COM types have utility.
-#![allow(non_snake_case)]
 
 // lib that contains all common extensions for the raw fabric apis.
 

--- a/crates/libs/core/src/runtime/config.rs
+++ b/crates/libs/core/src/runtime/config.rs
@@ -26,9 +26,9 @@ pub struct ConfigurationPackage {
 
 pub struct ConfigurationPackageDesc {
     pub name: HSTRING,
-    pub ServiceManifestName: HSTRING,
-    pub ServiceManifestVersion: HSTRING,
-    pub Version: HSTRING,
+    pub service_manifest_name: HSTRING,
+    pub service_manifest_version: HSTRING,
+    pub version: HSTRING,
 }
 
 pub struct ConfigurationSettings {
@@ -73,9 +73,9 @@ impl ConfigurationPackage {
 
         ConfigurationPackageDesc {
             name: HSTRINGWrap::from(raw.Name).into(),
-            ServiceManifestName: HSTRINGWrap::from(raw.ServiceManifestName).into(),
-            ServiceManifestVersion: HSTRINGWrap::from(raw.ServiceManifestVersion).into(),
-            Version: HSTRINGWrap::from(raw.Version).into(),
+            service_manifest_name: HSTRINGWrap::from(raw.ServiceManifestName).into(),
+            service_manifest_version: HSTRINGWrap::from(raw.ServiceManifestVersion).into(),
+            version: HSTRINGWrap::from(raw.Version).into(),
         }
     }
 

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -62,22 +62,22 @@ pub fn get_com_activation_context() -> ::windows_core::Result<IFabricCodePackage
 
 #[derive(Debug)]
 pub struct EndpointResourceDesc {
-    pub Name: ::windows_core::HSTRING,
-    pub Protocol: ::windows_core::HSTRING,
-    pub Type: ::windows_core::HSTRING,
-    pub Port: u32,
-    pub CertificateName: ::windows_core::HSTRING,
+    pub name: ::windows_core::HSTRING,
+    pub protocol: ::windows_core::HSTRING,
+    pub r#type: ::windows_core::HSTRING,
+    pub port: u32,
+    pub certificate_name: ::windows_core::HSTRING,
     //pub Reserved: *mut ::core::ffi::c_void,
 }
 
 impl From<&FABRIC_ENDPOINT_RESOURCE_DESCRIPTION> for EndpointResourceDesc {
     fn from(e: &FABRIC_ENDPOINT_RESOURCE_DESCRIPTION) -> Self {
         EndpointResourceDesc {
-            Name: HSTRING::from_wide(unsafe { e.Name.as_wide() }).unwrap(),
-            Protocol: HSTRING::from_wide(unsafe { e.Protocol.as_wide() }).unwrap(),
-            Type: HSTRING::from_wide(unsafe { e.Type.as_wide() }).unwrap(),
-            Port: e.Port,
-            CertificateName: HSTRING::from_wide(unsafe { e.CertificateName.as_wide() }).unwrap(),
+            name: HSTRING::from_wide(unsafe { e.Name.as_wide() }).unwrap(),
+            protocol: HSTRING::from_wide(unsafe { e.Protocol.as_wide() }).unwrap(),
+            r#type: HSTRING::from_wide(unsafe { e.Type.as_wide() }).unwrap(),
+            port: e.Port,
+            certificate_name: HSTRING::from_wide(unsafe { e.CertificateName.as_wide() }).unwrap(),
         }
     }
 }

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -9,10 +9,10 @@ use windows_core::{Interface, HSTRING};
 use crate::{strings::HSTRINGWrap, sync::fabric_begin_end_proxy};
 
 pub fn get_com_node_context(
-    timeoutMilliseconds: u32,
+    timeout_milliseconds: u32,
 ) -> crate::sync::FabricReceiver<::windows_core::Result<IFabricNodeContextResult>> {
     fabric_begin_end_proxy(
-        move |callback| unsafe { FabricBeginGetNodeContext(timeoutMilliseconds, callback) },
+        move |callback| unsafe { FabricBeginGetNodeContext(timeout_milliseconds, callback) },
         move |ctx| {
             unsafe { FabricEndGetNodeContext(ctx) }.map(|raw| {
                 assert!(!raw.is_null());

--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -8,9 +8,9 @@
 use mssf_com::FabricRuntime::IFabricStatefulServicePartition;
 use windows_core::{Error, HSTRING};
 
-use super::stateful_types::{
-    Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode, Role,
-};
+use crate::types::ReplicaRole;
+
+use super::stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode};
 
 pub trait StatefulServiceFactory {
     fn create_replica(
@@ -38,7 +38,7 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
         openmode: OpenMode,
         partition: &StatefulServicePartition,
     ) -> windows::core::Result<impl PrimaryReplicator>;
-    async fn change_role(&self, newrole: Role) -> ::windows_core::Result<HSTRING>; // replica address
+    async fn change_role(&self, newrole: ReplicaRole) -> ::windows_core::Result<HSTRING>; // replica address
     async fn close(&self) -> windows::core::Result<()>;
     fn abort(&self);
 }
@@ -65,7 +65,7 @@ impl From<&IFabricStatefulServicePartition> for StatefulServicePartition {
 pub trait LocalReplicator: Send + Sync + 'static {
     async fn open(&self) -> ::windows_core::Result<HSTRING>; // replicator address
     async fn close(&self) -> ::windows_core::Result<()>;
-    async fn change_role(&self, epoch: &Epoch, role: &Role) -> ::windows_core::Result<()>;
+    async fn change_role(&self, epoch: &Epoch, role: &ReplicaRole) -> ::windows_core::Result<()>;
     async fn update_epoch(&self, epoch: &Epoch) -> ::windows_core::Result<()>;
     fn get_current_progress(&self) -> ::windows_core::Result<i64>;
     fn get_catch_up_capability(&self) -> ::windows_core::Result<i64>;

--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -5,6 +5,9 @@
 
 // stateful bridge is to wrap rs types into com to expose to SF
 
+// windows::core::implement macro generates snake case types.
+#![allow(non_camel_case_types)]
+
 use std::sync::Arc;
 
 use tracing::info;
@@ -31,9 +34,10 @@ use crate::{
     runtime::{
         bridge::BridgeContext,
         stateful::StatefulServicePartition,
-        stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, Role},
+        stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig},
     },
     strings::HSTRINGWrap,
+    types::ReplicaRole,
 };
 
 use super::{
@@ -187,7 +191,7 @@ where
             BridgeContext::<Result<HSTRING, Error>>::new(callback_cp).into();
 
         let epoch2: Epoch = unsafe { epoch.as_ref().unwrap().into() };
-        let role2: Role = (&role).into();
+        let role2: ReplicaRole = (&role).into();
         info!(
             "IFabricReplicatorBridge::BeginChangeRole epoch {:?}, role {:?}",
             epoch2, role2
@@ -654,7 +658,7 @@ where
         let inner_cp = self.inner.clone();
         let callback_cp = callback.unwrap().clone();
 
-        let newrole2: Role = (&newrole).into();
+        let newrole2: ReplicaRole = (&newrole).into();
         info!(
             "IFabricStatefulReplicaBridge::BeginChangeRole: {:?}",
             newrole2

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -14,11 +14,11 @@ use mssf_com::FabricRuntime::{
 use tracing::info;
 use windows_core::{Interface, HSTRING};
 
-use crate::{strings::HSTRINGWrap, sync::fabric_begin_end_proxy};
+use crate::{strings::HSTRINGWrap, sync::fabric_begin_end_proxy, types::ReplicaRole};
 
 use super::{
     stateful::{PrimaryReplicator, Replicator, StatefulServicePartition, StatefulServiceReplica},
-    stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode, Role},
+    stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode},
 };
 
 pub struct StatefulServiceReplicaProxy {
@@ -53,7 +53,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         let res = PrimaryReplicatorProxy::new(p_rplctr);
         Ok(res)
     }
-    async fn change_role(&self, newrole: Role) -> ::windows_core::Result<HSTRING> {
+    async fn change_role(&self, newrole: ReplicaRole) -> ::windows_core::Result<HSTRING> {
         // replica address
         info!("StatefulServiceReplicaProxy::change_role {:?}", newrole);
         let com1 = &self.com_impl;
@@ -115,7 +115,7 @@ impl Replicator for ReplicatorProxy {
         );
         rx.await
     }
-    async fn change_role(&self, epoch: &Epoch, role: &Role) -> ::windows_core::Result<()> {
+    async fn change_role(&self, epoch: &Epoch, role: &ReplicaRole) -> ::windows_core::Result<()> {
         info!("ReplicatorProxy::change_role");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -168,7 +168,7 @@ impl Replicator for PrimaryReplicatorProxy {
     async fn close(&self) -> ::windows_core::Result<()> {
         self.parent.close().await
     }
-    async fn change_role(&self, epoch: &Epoch, role: &Role) -> ::windows_core::Result<()> {
+    async fn change_role(&self, epoch: &Epoch, role: &ReplicaRole) -> ::windows_core::Result<()> {
         self.parent.change_role(epoch, role).await
     }
     async fn update_epoch(&self, epoch: &Epoch) -> ::windows_core::Result<()> {

--- a/crates/libs/core/src/runtime/stateful_types.rs
+++ b/crates/libs/core/src/runtime/stateful_types.rs
@@ -10,16 +10,14 @@ use std::{ffi::c_void, marker::PhantomData};
 use mssf_com::FabricTypes::{
     FABRIC_EPOCH, FABRIC_REPLICA_INFORMATION, FABRIC_REPLICA_INFORMATION_EX1,
     FABRIC_REPLICA_OPEN_MODE, FABRIC_REPLICA_OPEN_MODE_EXISTING, FABRIC_REPLICA_OPEN_MODE_INVALID,
-    FABRIC_REPLICA_OPEN_MODE_NEW, FABRIC_REPLICA_ROLE, FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY,
-    FABRIC_REPLICA_ROLE_IDLE_SECONDARY, FABRIC_REPLICA_ROLE_NONE, FABRIC_REPLICA_ROLE_PRIMARY,
-    FABRIC_REPLICA_SET_CONFIGURATION, FABRIC_REPLICA_SET_QUORUM_ALL,
+    FABRIC_REPLICA_OPEN_MODE_NEW, FABRIC_REPLICA_SET_CONFIGURATION, FABRIC_REPLICA_SET_QUORUM_ALL,
     FABRIC_REPLICA_SET_QUORUM_INVALID, FABRIC_REPLICA_SET_QUORUM_MODE,
     FABRIC_REPLICA_SET_WRITE_QUORUM, FABRIC_REPLICA_STATUS, FABRIC_REPLICA_STATUS_DOWN,
     FABRIC_REPLICA_STATUS_INVALID, FABRIC_REPLICA_STATUS_UP,
 };
 use windows_core::PCWSTR;
 
-use crate::strings::HSTRINGWrap;
+use crate::{strings::HSTRINGWrap, types::ReplicaRole};
 
 #[derive(Debug)]
 pub enum OpenMode {
@@ -99,39 +97,6 @@ impl From<&Epoch> for FABRIC_EPOCH {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
-pub enum Role {
-    ActiveSecondary,
-    IdleSecondary,
-    None,
-    Primary,
-    Unknown,
-}
-
-impl From<&FABRIC_REPLICA_ROLE> for Role {
-    fn from(r: &FABRIC_REPLICA_ROLE) -> Self {
-        match *r {
-            FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY => Role::ActiveSecondary,
-            FABRIC_REPLICA_ROLE_IDLE_SECONDARY => Role::IdleSecondary,
-            FABRIC_REPLICA_ROLE_NONE => Role::None,
-            FABRIC_REPLICA_ROLE_PRIMARY => Role::Primary,
-            _ => Role::Unknown,
-        }
-    }
-}
-
-impl From<&Role> for FABRIC_REPLICA_ROLE {
-    fn from(val: &Role) -> Self {
-        match *val {
-            Role::ActiveSecondary => FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY,
-            Role::IdleSecondary => FABRIC_REPLICA_ROLE_IDLE_SECONDARY,
-            Role::None => FABRIC_REPLICA_ROLE_NONE,
-            Role::Primary => FABRIC_REPLICA_ROLE_PRIMARY,
-            Role::Unknown => FABRIC_REPLICA_ROLE_NONE,
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReplicaStatus {
     Invalid,
@@ -163,21 +128,21 @@ impl From<FABRIC_REPLICA_STATUS> for ReplicaStatus {
 // Safe wrapping for FABRIC_REPLICA_SET_CONFIGURATION
 #[derive(Debug)]
 pub struct ReplicaSetConfig {
-    pub Replicas: Vec<ReplicaInfo>,
-    pub WriteQuorum: u32,
+    pub replicas: Vec<ReplicaInfo>,
+    pub write_quorum: u32,
 }
 
 impl From<&FABRIC_REPLICA_SET_CONFIGURATION> for ReplicaSetConfig {
     fn from(r: &FABRIC_REPLICA_SET_CONFIGURATION) -> Self {
         let mut res = ReplicaSetConfig {
-            Replicas: vec![],
-            WriteQuorum: r.WriteQuorum,
+            replicas: vec![],
+            write_quorum: r.WriteQuorum,
         };
         // fill the vec
         for i in 0..r.ReplicaCount {
             let replica = unsafe { r.Replicas.offset(i as isize) };
             let replica_ref = unsafe { replica.as_ref().unwrap() };
-            res.Replicas.push(ReplicaInfo::from(replica_ref))
+            res.replicas.push(ReplicaInfo::from(replica_ref))
         }
         res
     }
@@ -190,7 +155,7 @@ impl ReplicaSetConfig {
         let mut replica_raw_cache: Vec<FABRIC_REPLICA_INFORMATION> = vec![];
         let mut replica_ex1_cache: Vec<FABRIC_REPLICA_INFORMATION_EX1> = vec![];
         // prepare vec cache
-        for replica in &self.Replicas {
+        for replica in &self.replicas {
             let (info, ex1) = replica.get_raw_parts();
             replica_raw_cache.push(info);
             replica_ex1_cache.push(ex1);
@@ -208,7 +173,7 @@ impl ReplicaSetConfig {
         let config = FABRIC_REPLICA_SET_CONFIGURATION {
             ReplicaCount: replica_raw_cache.len() as u32,
             Replicas: replica_raw_cache.as_ptr(),
-            WriteQuorum: self.WriteQuorum,
+            WriteQuorum: self.write_quorum,
             Reserved: std::ptr::null_mut(),
         };
 
@@ -240,13 +205,13 @@ impl ReplicaSetConfigView<'_> {
 // Safe wrapping for FABRIC_REPLICA_INFORMATION
 #[derive(Debug, PartialEq, Clone)]
 pub struct ReplicaInfo {
-    pub Id: i64,
-    pub Role: Role,
-    pub Status: ReplicaStatus,
-    pub ReplicatorAddress: ::windows_core::HSTRING,
-    pub CurrentProgress: i64,
-    pub CatchUpCapability: i64,
-    pub MustCatchUp: bool,
+    pub id: i64,
+    pub role: ReplicaRole,
+    pub status: ReplicaStatus,
+    pub replicator_address: ::windows_core::HSTRING,
+    pub current_progress: i64,
+    pub catch_up_capability: i64,
+    pub must_catch_up: bool,
 }
 
 impl From<&FABRIC_REPLICA_INFORMATION> for ReplicaInfo {
@@ -259,13 +224,13 @@ impl From<&FABRIC_REPLICA_INFORMATION> for ReplicaInfo {
             }
         }
         ReplicaInfo {
-            Id: r.Id,
-            Role: (&r.Role).into(),
-            Status: r.Status.into(),
-            ReplicatorAddress: HSTRINGWrap::from(r.ReplicatorAddress).into(),
-            CurrentProgress: r.CurrentProgress,
-            CatchUpCapability: r.CatchUpCapability,
-            MustCatchUp: must_catchup,
+            id: r.Id,
+            role: (&r.Role).into(),
+            status: r.Status.into(),
+            replicator_address: HSTRINGWrap::from(r.ReplicatorAddress).into(),
+            current_progress: r.CurrentProgress,
+            catch_up_capability: r.CatchUpCapability,
+            must_catch_up: must_catchup,
         }
     }
 }
@@ -276,16 +241,16 @@ impl ReplicaInfo {
     // FABRIC_REPLICA_INFORMATION::Reserved needs to point at FABRIC_REPLICA_INFORMATION_EX1
     pub fn get_raw_parts(&self) -> (FABRIC_REPLICA_INFORMATION, FABRIC_REPLICA_INFORMATION_EX1) {
         let info = FABRIC_REPLICA_INFORMATION {
-            Id: self.Id,
-            Role: (&self.Role).into(),
-            Status: self.Status.clone().into(),
-            ReplicatorAddress: PCWSTR::from_raw(self.ReplicatorAddress.as_ptr()),
-            CurrentProgress: self.CurrentProgress,
-            CatchUpCapability: self.CatchUpCapability,
+            Id: self.id,
+            Role: (&self.role).into(),
+            Status: self.status.clone().into(),
+            ReplicatorAddress: PCWSTR::from_raw(self.replicator_address.as_ptr()),
+            CurrentProgress: self.current_progress,
+            CatchUpCapability: self.catch_up_capability,
             Reserved: std::ptr::null_mut(),
         };
         let ex1 = FABRIC_REPLICA_INFORMATION_EX1 {
-            MustCatchup: self.MustCatchUp.into(),
+            MustCatchup: self.must_catch_up.into(),
             Reserved: std::ptr::null_mut(),
         };
         (info, ex1)
@@ -357,8 +322,8 @@ mod test {
 
         // test raw -> wrap
         let wrap = ReplicaInfo::from(&info);
-        assert_eq!(wrap.Id, 123);
-        assert!(wrap.MustCatchUp);
+        assert_eq!(wrap.id, 123);
+        assert!(wrap.must_catch_up);
 
         // test wrap -> raw
         let (info_b, ex1_b) = wrap.get_raw_parts();
@@ -369,28 +334,28 @@ mod test {
     #[test]
     fn test_replica_set_config_conv() {
         let replica1 = ReplicaInfo {
-            Id: 1,
-            Role: super::Role::Primary,
-            Status: super::ReplicaStatus::Up,
-            ReplicatorAddress: HSTRING::from("addr1"),
-            CurrentProgress: 123,
-            CatchUpCapability: 123,
-            MustCatchUp: true,
+            id: 1,
+            role: super::ReplicaRole::Primary,
+            status: super::ReplicaStatus::Up,
+            replicator_address: HSTRING::from("addr1"),
+            current_progress: 123,
+            catch_up_capability: 123,
+            must_catch_up: true,
         };
 
         let replica2 = ReplicaInfo {
-            Id: 2,
-            Role: super::Role::ActiveSecondary,
-            Status: super::ReplicaStatus::Up,
-            ReplicatorAddress: HSTRING::from("addr2"),
-            CurrentProgress: 120,
-            CatchUpCapability: 120,
-            MustCatchUp: false,
+            id: 2,
+            role: super::ReplicaRole::ActiveSecondary,
+            status: super::ReplicaStatus::Up,
+            replicator_address: HSTRING::from("addr2"),
+            current_progress: 120,
+            catch_up_capability: 120,
+            must_catch_up: false,
         };
 
         let config_a = ReplicaSetConfig {
-            Replicas: vec![replica1.clone(), replica2.clone()],
-            WriteQuorum: 2,
+            replicas: vec![replica1.clone(), replica2.clone()],
+            write_quorum: 2,
         };
 
         // test wrap -> raw type conversion
@@ -401,9 +366,9 @@ mod test {
 
         // test raw type -> wrap conversion
         let config_b = ReplicaSetConfig::from(raw);
-        assert_eq!(config_b.Replicas.len(), 2);
-        let replica1_b = &config_b.Replicas[0];
-        let replica2_b = &config_b.Replicas[1];
+        assert_eq!(config_b.replicas.len(), 2);
+        let replica1_b = &config_b.replicas[0];
+        let replica2_b = &config_b.replicas[1];
         assert_eq!(&replica1, replica1_b);
         assert_eq!(&replica2, replica2_b);
     }

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -3,7 +3,8 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-#![deny(non_snake_case)] // this file is safe rust
+// windows::core::implement macro generates snake case types.
+#![allow(non_camel_case_types)]
 
 use std::sync::Arc;
 

--- a/crates/libs/core/src/runtime/store_types.rs
+++ b/crates/libs/core/src/runtime/store_types.rs
@@ -16,15 +16,15 @@ use windows_core::PCWSTR;
 
 #[derive(Default)]
 pub struct ReplicatorSettings {
-    pub Flags: u32,
-    pub RetryIntervalMilliseconds: u32,
-    pub BatchAcknowledgementIntervalMilliseconds: u32,
-    pub ReplicatorAddress: ::windows_core::HSTRING,
-    pub RequireServiceAck: bool,
-    pub InitialReplicationQueueSize: u32,
-    pub MaxReplicationQueueSize: u32,
-    pub InitialCopyQueueSize: u32,
-    pub MaxCopyQueueSize: u32,
+    pub flags: u32,
+    pub retry_interval_milliseconds: u32,
+    pub batch_acknowledgement_interval_milliseconds: u32,
+    pub replicator_address: ::windows_core::HSTRING,
+    pub require_service_ack: bool,
+    pub initial_replication_queue_size: u32,
+    pub max_replication_queue_size: u32,
+    pub initial_copy_queue_size: u32,
+    pub max_copy_queue_size: u32,
     //pub SecurityCredentials: *const FABRIC_SECURITY_CREDENTIALS,
     //pub Reserved: *mut ::core::ffi::c_void,
 }
@@ -32,15 +32,16 @@ pub struct ReplicatorSettings {
 impl ReplicatorSettings {
     pub fn get_raw(&self) -> FABRIC_REPLICATOR_SETTINGS {
         FABRIC_REPLICATOR_SETTINGS {
-            Flags: self.Flags,
-            RetryIntervalMilliseconds: self.RetryIntervalMilliseconds,
-            BatchAcknowledgementIntervalMilliseconds: self.BatchAcknowledgementIntervalMilliseconds,
-            ReplicatorAddress: PCWSTR::from_raw(self.ReplicatorAddress.as_ptr()),
-            RequireServiceAck: self.RequireServiceAck.into(),
-            InitialReplicationQueueSize: self.InitialReplicationQueueSize,
-            MaxReplicationQueueSize: self.MaxReplicationQueueSize,
-            InitialCopyQueueSize: self.InitialCopyQueueSize,
-            MaxCopyQueueSize: self.MaxCopyQueueSize,
+            Flags: self.flags,
+            RetryIntervalMilliseconds: self.retry_interval_milliseconds,
+            BatchAcknowledgementIntervalMilliseconds: self
+                .batch_acknowledgement_interval_milliseconds,
+            ReplicatorAddress: PCWSTR::from_raw(self.replicator_address.as_ptr()),
+            RequireServiceAck: self.require_service_ack.into(),
+            InitialReplicationQueueSize: self.initial_replication_queue_size,
+            MaxReplicationQueueSize: self.max_replication_queue_size,
+            InitialCopyQueueSize: self.initial_copy_queue_size,
+            MaxCopyQueueSize: self.max_copy_queue_size,
             SecurityCredentials: std::ptr::null(),
             Reserved: std::ptr::null_mut(),
         }
@@ -64,24 +65,24 @@ impl From<LocalStoreKind> for FABRIC_LOCAL_STORE_KIND {
 #[derive(Default)]
 pub struct EseLocalStoreSettings {
     // FABRIC_ESE_LOCAL_STORE_SETTINGS
-    pub DbFolderPath: ::windows_core::HSTRING,
-    pub LogFileSizeInKB: i32,
-    pub LogBufferSizeInKB: i32,
-    pub MaxCursors: i32,
-    pub MaxVerPages: i32,
-    pub MaxAsyncCommitDelayInMilliseconds: i32,
+    pub db_folder_path: ::windows_core::HSTRING,
+    pub log_file_size_in_kb: i32,
+    pub log_buffer_size_in_kb: i32,
+    pub max_cursors: i32,
+    pub max_ver_pages: i32,
+    pub max_async_commit_delay_in_milliseconds: i32,
     // pub Reserved: *mut ::core::ffi::c_void,
 }
 
 impl EseLocalStoreSettings {
     pub fn get_raw(&self) -> FABRIC_ESE_LOCAL_STORE_SETTINGS {
         FABRIC_ESE_LOCAL_STORE_SETTINGS {
-            DbFolderPath: windows_core::PCWSTR::from_raw(self.DbFolderPath.as_ptr()),
-            LogFileSizeInKB: self.LogFileSizeInKB,
-            LogBufferSizeInKB: self.LogBufferSizeInKB,
-            MaxCursors: self.MaxCursors,
-            MaxVerPages: self.MaxVerPages,
-            MaxAsyncCommitDelayInMilliseconds: self.MaxAsyncCommitDelayInMilliseconds,
+            DbFolderPath: windows_core::PCWSTR::from_raw(self.db_folder_path.as_ptr()),
+            LogFileSizeInKB: self.log_file_size_in_kb,
+            LogBufferSizeInKB: self.log_buffer_size_in_kb,
+            MaxCursors: self.max_cursors,
+            MaxVerPages: self.max_ver_pages,
+            MaxAsyncCommitDelayInMilliseconds: self.max_async_commit_delay_in_milliseconds,
             Reserved: std::ptr::null_mut(),
         }
     }

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -8,3 +8,5 @@ mod partition;
 pub use partition::*;
 mod node;
 pub use node::*;
+mod replica;
+pub use replica::*;

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -1,0 +1,181 @@
+use mssf_com::{
+    FabricClient::IFabricGetReplicaListResult2,
+    FabricTypes::{
+        FABRIC_QUERY_SERVICE_REPLICA_STATUS, FABRIC_QUERY_SERVICE_REPLICA_STATUS_DOWN,
+        FABRIC_QUERY_SERVICE_REPLICA_STATUS_DROPPED, FABRIC_QUERY_SERVICE_REPLICA_STATUS_INBUILD,
+        FABRIC_QUERY_SERVICE_REPLICA_STATUS_INVALID, FABRIC_QUERY_SERVICE_REPLICA_STATUS_READY,
+        FABRIC_QUERY_SERVICE_REPLICA_STATUS_STANDBY, FABRIC_SERVICE_KIND_STATEFUL,
+        FABRIC_SERVICE_KIND_STATELESS, FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
+        FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM,
+        FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM,
+        FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM,
+    },
+};
+use windows_core::{GUID, HSTRING};
+
+use crate::{
+    iter::{FabricIter, FabricListAccessor},
+    strings::HSTRINGWrap,
+    types::{HealthState, ReplicaRole},
+};
+
+// FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION
+pub struct ServiceReplicaQueryDescription {
+    pub partition_id: GUID,
+    pub replica_id_or_instance_id_filter: Option<i64>, // TODO: reserved fields
+}
+
+impl From<&ServiceReplicaQueryDescription> for FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION {
+    fn from(value: &ServiceReplicaQueryDescription) -> Self {
+        let id_filter = value.replica_id_or_instance_id_filter.unwrap_or_default();
+        Self {
+            PartitionId: value.partition_id,
+            ReplicaIdOrInstanceIdFilter: id_filter,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+// IFabricGetReplicaListResult2
+pub struct ServiceReplicaList {
+    com: IFabricGetReplicaListResult2,
+}
+
+impl ServiceReplicaList {
+    pub fn new(com: IFabricGetReplicaListResult2) -> Self {
+        Self { com }
+    }
+
+    pub fn iter(&self) -> ServiceReplicaListIter {
+        ServiceReplicaListIter::new(self, self)
+    }
+}
+
+type ServiceReplicaListIter<'a> = FabricIter<
+    'a,
+    FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM,
+    ServiceReplicaQueryResult,
+    ServiceReplicaList,
+>;
+
+impl FabricListAccessor<FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM> for ServiceReplicaList {
+    fn get_count(&self) -> u32 {
+        let raw = unsafe { self.com.get_ReplicaList().as_ref() };
+        raw.unwrap().Count
+    }
+
+    fn get_first_item(&self) -> *const FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM {
+        let raw = unsafe { self.com.get_ReplicaList().as_ref() };
+        raw.unwrap().Items
+    }
+}
+
+// FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM
+pub enum ServiceReplicaQueryResult {
+    Invalid,
+    Stateful(StatefulServiceReplicaQueryResult),
+    Stateless(StatelessServiceInstanceQueryResult),
+}
+
+impl From<&FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM> for ServiceReplicaQueryResult {
+    fn from(value: &FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM) -> Self {
+        match value.Kind {
+            FABRIC_SERVICE_KIND_STATEFUL => {
+                let raw = unsafe {
+                    (value.Value as *const FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM)
+                        .as_ref()
+                        .unwrap()
+                };
+                Self::Stateful(raw.into())
+            }
+            FABRIC_SERVICE_KIND_STATELESS => {
+                let raw = unsafe {
+                    (value.Value as *const FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM)
+                        .as_ref()
+                        .unwrap()
+                };
+                Self::Stateless(raw.into())
+            }
+            _ => Self::Invalid,
+        }
+    }
+}
+
+// FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM
+pub struct StatefulServiceReplicaQueryResult {
+    pub replica_id: i64,
+    pub replica_role: ReplicaRole,
+    pub replica_status: QueryServiceReplicaStatus,
+    pub aggregated_health_state: HealthState,
+    pub replica_address: HSTRING,
+    pub node_name: HSTRING,
+    pub last_in_build_duration_in_seconds: i64,
+    // pub Reserved: *mut core::ffi::c_void,
+}
+
+impl From<&FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM>
+    for StatefulServiceReplicaQueryResult
+{
+    fn from(value: &FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM) -> Self {
+        Self {
+            replica_id: value.ReplicaId,
+            replica_role: (&value.ReplicaRole).into(),
+            replica_status: (&value.ReplicaStatus).into(),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+            replica_address: HSTRINGWrap::from(value.ReplicaAddress).into(),
+            node_name: HSTRINGWrap::from(value.NodeName).into(),
+            last_in_build_duration_in_seconds: value.LastInBuildDurationInSeconds,
+        }
+    }
+}
+
+// FABRIC_QUERY_SERVICE_REPLICA_STATUS
+#[derive(Debug, PartialEq)]
+pub enum QueryServiceReplicaStatus {
+    Invalid,
+    Inbuild,
+    Standby,
+    Ready,
+    Down,
+    Dropped,
+}
+
+impl From<&FABRIC_QUERY_SERVICE_REPLICA_STATUS> for QueryServiceReplicaStatus {
+    fn from(value: &FABRIC_QUERY_SERVICE_REPLICA_STATUS) -> Self {
+        match *value {
+            FABRIC_QUERY_SERVICE_REPLICA_STATUS_INVALID => Self::Invalid,
+            FABRIC_QUERY_SERVICE_REPLICA_STATUS_INBUILD => Self::Inbuild,
+            FABRIC_QUERY_SERVICE_REPLICA_STATUS_STANDBY => Self::Standby,
+            FABRIC_QUERY_SERVICE_REPLICA_STATUS_READY => Self::Ready,
+            FABRIC_QUERY_SERVICE_REPLICA_STATUS_DOWN => Self::Down,
+            FABRIC_QUERY_SERVICE_REPLICA_STATUS_DROPPED => Self::Dropped,
+            _ => Self::Invalid,
+        }
+    }
+}
+
+//FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM
+pub struct StatelessServiceInstanceQueryResult {
+    pub instance_id: i64,
+    pub replica_status: QueryServiceReplicaStatus,
+    pub aggregated_health_state: HealthState,
+    pub replica_address: HSTRING,
+    pub node_name: HSTRING,
+    pub last_in_build_duration_in_seconds: i64,
+    // pub Reserved: *mut core::ffi::c_void,
+}
+
+impl From<&FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM>
+    for StatelessServiceInstanceQueryResult
+{
+    fn from(value: &FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM) -> Self {
+        Self {
+            instance_id: value.InstanceId,
+            replica_status: (&value.ReplicaStatus).into(),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+            replica_address: HSTRINGWrap::from(value.ReplicaAddress).into(),
+            node_name: HSTRINGWrap::from(value.NodeName).into(),
+            last_in_build_duration_in_seconds: value.LastInBuildDurationInSeconds,
+        }
+    }
+}

--- a/crates/libs/core/src/types/common/mod.rs
+++ b/crates/libs/core/src/types/common/mod.rs
@@ -6,6 +6,8 @@
 // This mod contains common types shared between FabricRuntime and FabricClient.
 mod partition;
 pub use partition::*;
+mod stateful;
+pub use stateful::*;
 
 use mssf_com::FabricTypes::{
     FABRIC_HEALTH_STATE, FABRIC_HEALTH_STATE_ERROR, FABRIC_HEALTH_STATE_INVALID,

--- a/crates/libs/core/src/types/common/stateful.rs
+++ b/crates/libs/core/src/types/common/stateful.rs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::FabricTypes::{
+    FABRIC_REPLICA_ROLE, FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY, FABRIC_REPLICA_ROLE_IDLE_SECONDARY,
+    FABRIC_REPLICA_ROLE_NONE, FABRIC_REPLICA_ROLE_PRIMARY,
+};
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum ReplicaRole {
+    ActiveSecondary,
+    IdleSecondary,
+    None,
+    Primary,
+    Unknown,
+}
+
+impl From<&FABRIC_REPLICA_ROLE> for ReplicaRole {
+    fn from(r: &FABRIC_REPLICA_ROLE) -> Self {
+        match *r {
+            FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY => ReplicaRole::ActiveSecondary,
+            FABRIC_REPLICA_ROLE_IDLE_SECONDARY => ReplicaRole::IdleSecondary,
+            FABRIC_REPLICA_ROLE_NONE => ReplicaRole::None,
+            FABRIC_REPLICA_ROLE_PRIMARY => ReplicaRole::Primary,
+            _ => ReplicaRole::Unknown,
+        }
+    }
+}
+
+impl From<&ReplicaRole> for FABRIC_REPLICA_ROLE {
+    fn from(val: &ReplicaRole) -> Self {
+        match *val {
+            ReplicaRole::ActiveSecondary => FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY,
+            ReplicaRole::IdleSecondary => FABRIC_REPLICA_ROLE_IDLE_SECONDARY,
+            ReplicaRole::None => FABRIC_REPLICA_ROLE_NONE,
+            ReplicaRole::Primary => FABRIC_REPLICA_ROLE_PRIMARY,
+            ReplicaRole::Unknown => FABRIC_REPLICA_ROLE_NONE,
+        }
+    }
+}

--- a/crates/libs/core/src/types/common/stateful.rs
+++ b/crates/libs/core/src/types/common/stateful.rs
@@ -5,7 +5,7 @@
 
 use mssf_com::FabricTypes::{
     FABRIC_REPLICA_ROLE, FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY, FABRIC_REPLICA_ROLE_IDLE_SECONDARY,
-    FABRIC_REPLICA_ROLE_NONE, FABRIC_REPLICA_ROLE_PRIMARY,
+    FABRIC_REPLICA_ROLE_NONE, FABRIC_REPLICA_ROLE_PRIMARY, FABRIC_REPLICA_ROLE_UNKNOWN,
 };
 
 #[derive(PartialEq, Clone, Debug)]
@@ -36,7 +36,7 @@ impl From<&ReplicaRole> for FABRIC_REPLICA_ROLE {
             ReplicaRole::IdleSecondary => FABRIC_REPLICA_ROLE_IDLE_SECONDARY,
             ReplicaRole::None => FABRIC_REPLICA_ROLE_NONE,
             ReplicaRole::Primary => FABRIC_REPLICA_ROLE_PRIMARY,
-            ReplicaRole::Unknown => FABRIC_REPLICA_ROLE_NONE,
+            ReplicaRole::Unknown => FABRIC_REPLICA_ROLE_UNKNOWN,
         }
     }
 }

--- a/crates/samples/echomain-stateful2/src/main.rs
+++ b/crates/samples/echomain-stateful2/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> windows::core::Result<()> {
         .unwrap();
     let hostname = get_hostname();
 
-    let factory = Factory::create(endpoint.Port, hostname, e.clone());
+    let factory = Factory::create(endpoint.port, hostname, e.clone());
     runtime
         .register_stateful_service_factory(&HSTRING::from("StatefulEchoAppService"), factory)
         .unwrap();

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> mssf_core::Result<()> {
         .get_endpoint_resource(&HSTRING::from("ServiceEndpoint1"))
         .unwrap();
     info!("Get ServiceEndpoint1: {:?}", endpoint);
-    let port = endpoint.Port;
+    let port = endpoint.port;
 
     // get hostname
     let ctx = NodeContext::get_sync(Duration::from_secs(1)).unwrap();

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -8,16 +8,17 @@ use std::time::Duration;
 use mssf_core::{
     client::FabricClient,
     types::{
-        ServicePartition, ServicePartitionInformation, ServicePartitionQueryDescription,
-        ServicePartitionStatus,
+        QueryServiceReplicaStatus, ServicePartition, ServicePartitionInformation,
+        ServicePartitionQueryDescription, ServicePartitionStatus, ServiceReplicaQueryDescription,
+        ServiceReplicaQueryResult,
     },
     GUID, HSTRING,
 };
 
 // Requires app to be deployed on onebox.
-// Uses fabric client to to the app parition info.
+// Uses fabric client to get the app parition and replica info.
 #[tokio::test]
-async fn test_partition_info() {
+async fn test_partition_and_replica_info() {
     let fc = FabricClient::new();
     let qc = fc.get_query_manager();
 
@@ -25,11 +26,9 @@ async fn test_partition_info() {
         service_name: HSTRING::from("fabric:/EchoApp/EchoAppService"),
         partition_id_filter: None,
     };
+    let timeout = Duration::from_secs(1);
 
-    let list = qc
-        .get_partition_list(&desc, Duration::from_secs(1))
-        .await
-        .unwrap();
+    let list = qc.get_partition_list(&desc, timeout).await.unwrap();
     // there is only one partition
     let p = list.iter().next().unwrap();
     let stateless = match p {
@@ -47,4 +46,22 @@ async fn test_partition_info() {
         _ => panic!("not singleton"),
     };
     assert_ne!(single.id, GUID::zeroed());
+
+    // test get replica info
+    let desc = ServiceReplicaQueryDescription {
+        partition_id: single.id,
+        replica_id_or_instance_id_filter: None,
+    };
+    let replicas = qc.get_replica_list(&desc, timeout).await.unwrap();
+    {
+        let replica = replicas.iter().next().unwrap(); // only one replica
+        let stateless = match replica {
+            ServiceReplicaQueryResult::Stateless(s) => s,
+            _ => panic!("not stateless"),
+        };
+        // TODO: health is unknown
+        // assert_eq!(stateless.aggregated_health_state, HealthState::Ok);
+        assert_eq!(stateless.replica_status, QueryServiceReplicaStatus::Ready);
+        assert_ne!(stateless.node_name, HSTRING::new());
+    }
 }

--- a/crates/samples/kvstore/src/main.rs
+++ b/crates/samples/kvstore/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> mssf_core::Result<()> {
         .get_endpoint_resource(&HSTRING::from("KvReplicatorEndpoint"))
         .unwrap();
 
-    let factory = Factory::create(endpoint.Port, e.clone());
+    let factory = Factory::create(endpoint.port, e.clone());
     runtime
         .register_stateful_service_factory(&HSTRING::from("KvStoreService"), factory)
         .unwrap();


### PR DESCRIPTION
Added safe rust wrapper for get_replica_list api.
Moved some shared types from runtime mod to types mod.
Fixed struct field casing in mssf-core crate. Originally it allowed non-snake-case field names, now it is all fixed to have snake case to match rust standard.
Enabled 5 node cluster in ci instread of 1 node to host multiple replicas.