### PR TITLE
Refactor rust to com proxy wrapper

### DIFF
--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -187,7 +187,7 @@ where
             BridgeContext::<Result<HSTRING, Error>>::new(callback_cp).into();
 
         let epoch2: Epoch = unsafe { epoch.as_ref().unwrap().into() };
-        let role2: Role = role.into();
+        let role2: Role = (&role).into();
         info!(
             "IFabricReplicatorBridge::BeginChangeRole epoch {:?}, role {:?}",
             epoch2, role2
@@ -654,7 +654,7 @@ where
         let inner_cp = self.inner.clone();
         let callback_cp = callback.unwrap().clone();
 
-        let newrole2: Role = newrole.into();
+        let newrole2: Role = (&newrole).into();
         info!(
             "IFabricStatefulReplicaBridge::BeginChangeRole: {:?}",
             newrole2

--- a/crates/libs/core/src/runtime/stateful_types.rs
+++ b/crates/libs/core/src/runtime/stateful_types.rs
@@ -89,8 +89,8 @@ impl From<&FABRIC_EPOCH> for Epoch {
     }
 }
 
-impl From<Epoch> for FABRIC_EPOCH {
-    fn from(val: Epoch) -> Self {
+impl From<&Epoch> for FABRIC_EPOCH {
+    fn from(val: &Epoch) -> Self {
         FABRIC_EPOCH {
             DataLossNumber: val.data_loss_number,
             ConfigurationNumber: val.configuration_number,
@@ -108,9 +108,9 @@ pub enum Role {
     Unknown,
 }
 
-impl From<FABRIC_REPLICA_ROLE> for Role {
-    fn from(r: FABRIC_REPLICA_ROLE) -> Self {
-        match r {
+impl From<&FABRIC_REPLICA_ROLE> for Role {
+    fn from(r: &FABRIC_REPLICA_ROLE) -> Self {
+        match *r {
             FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY => Role::ActiveSecondary,
             FABRIC_REPLICA_ROLE_IDLE_SECONDARY => Role::IdleSecondary,
             FABRIC_REPLICA_ROLE_NONE => Role::None,
@@ -120,9 +120,9 @@ impl From<FABRIC_REPLICA_ROLE> for Role {
     }
 }
 
-impl From<Role> for FABRIC_REPLICA_ROLE {
-    fn from(val: Role) -> Self {
-        match val {
+impl From<&Role> for FABRIC_REPLICA_ROLE {
+    fn from(val: &Role) -> Self {
+        match *val {
             Role::ActiveSecondary => FABRIC_REPLICA_ROLE_ACTIVE_SECONDARY,
             Role::IdleSecondary => FABRIC_REPLICA_ROLE_IDLE_SECONDARY,
             Role::None => FABRIC_REPLICA_ROLE_NONE,
@@ -260,7 +260,7 @@ impl From<&FABRIC_REPLICA_INFORMATION> for ReplicaInfo {
         }
         ReplicaInfo {
             Id: r.Id,
-            Role: r.Role.into(),
+            Role: (&r.Role).into(),
             Status: r.Status.into(),
             ReplicatorAddress: HSTRINGWrap::from(r.ReplicatorAddress).into(),
             CurrentProgress: r.CurrentProgress,
@@ -277,7 +277,7 @@ impl ReplicaInfo {
     pub fn get_raw_parts(&self) -> (FABRIC_REPLICA_INFORMATION, FABRIC_REPLICA_INFORMATION_EX1) {
         let info = FABRIC_REPLICA_INFORMATION {
             Id: self.Id,
-            Role: self.Role.clone().into(),
+            Role: (&self.Role).into(),
             Status: self.Status.clone().into(),
             ReplicatorAddress: PCWSTR::from_raw(self.ReplicatorAddress.as_ptr()),
             CurrentProgress: self.CurrentProgress,

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -24,7 +24,9 @@ use tokio::sync::oneshot::Receiver;
 use windows::core::implement;
 use windows_core::Interface;
 
+mod proxy;
 pub mod wait;
+pub use proxy::*;
 
 // fabric code begins here
 

--- a/crates/libs/core/src/sync/proxy.rs
+++ b/crates/libs/core/src/sync/proxy.rs
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
+
+/// Wrapper function for turning SF Begin End style api into
+/// rust awaitable future.
+/// begin is a function/closure taking a callback and returns the context.
+/// end is a function/closure taking a context and returns the result type.
+/// See example usage in FabricClient wrappers.
+///
+/// Remarks:
+/// The main work of the closures are for aligning the raw params and return values from SF api.
+/// Due to the complexity and irregularity of the begin and end function signatures,
+/// the begin and end closure needs to be manually written.
+///
+/// Begin closure is initiated/called, and FabricReceiver is returned to the user. FabricSender
+/// is supposed to send the async result obtaind from the end closure to the user.
+/// End closure is wrapped in an awaitable callback (together with a FabricSender),
+/// and such callback is passed to SF begin api and is invoked when
+/// the (begin) initiated operation completes.
+pub fn fabric_begin_end_proxy<BEGIN, END, T>(
+    begin: BEGIN,
+    end: END,
+) -> crate::sync::FabricReceiver<::windows_core::Result<T>>
+where
+    BEGIN: FnOnce(
+        Option<&IFabricAsyncOperationCallback>,
+    ) -> crate::Result<IFabricAsyncOperationContext>,
+    END: FnOnce(Option<&IFabricAsyncOperationContext>) -> crate::Result<T> + 'static,
+    T: 'static,
+{
+    let (tx, rx) = crate::sync::oneshot_channel();
+
+    let callback = crate::sync::AwaitableCallback2::i_new(move |ctx| {
+        let res = end(ctx);
+        tx.send(res);
+    });
+    let ctx = begin(Some(&callback));
+    if ctx.is_err() {
+        let (tx2, rx2) = crate::sync::oneshot_channel();
+        tx2.send(Err(ctx.err().unwrap()));
+        rx2
+    } else {
+        rx
+    }
+}


### PR DESCRIPTION
Refactors the wrapper for rust code calling SF com Begin and End api.
The duplicated code for each api wrapping is eliminated, and the wrapping is easier and more readable. The lines of code is reduced significantly.