### PR TITLE
[FabricClient] implement restart replica api

### DIFF
--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -21,7 +21,7 @@ mod tests;
 // https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Api/src/System/Fabric/FabricClient.cs
 
 pub struct FabricClient {
-    _com_property_client: IFabricPropertyManagementClient2,
+    com_property_client: IFabricPropertyManagementClient2,
     com_service_client: IFabricServiceManagementClient6,
     com_query_client: IFabricQueryClient10,
 }
@@ -38,6 +38,11 @@ impl FabricClient {
         Self::from_com(com)
     }
 
+    // Get a copy of COM object
+    pub fn get_com(&self) -> IFabricPropertyManagementClient2 {
+        self.com_property_client.clone()
+    }
+
     // Creates from com directly. This gives the user freedom to create com from
     // custom code and pass it in.
     // For the final state of FabricClient, this function should be private.
@@ -49,7 +54,7 @@ impl FabricClient {
             .unwrap();
         let com_query_client = com.clone().cast::<IFabricQueryClient10>().unwrap();
         Self {
-            _com_property_client: com_property_client,
+            com_property_client,
             com_service_client,
             com_query_client,
         }
@@ -58,7 +63,7 @@ impl FabricClient {
     // Get the client for managing Fabric Properties in Naming Service
     pub fn get_property_manager(&self) -> PropertyManagementClient {
         PropertyManagementClient {
-            _com: self._com_property_client.clone(),
+            _com: self.com_property_client.clone(),
         }
     }
 

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -4,14 +4,14 @@ use mssf_com::{
         FABRIC_QUERY_SERVICE_REPLICA_STATUS, FABRIC_QUERY_SERVICE_REPLICA_STATUS_DOWN,
         FABRIC_QUERY_SERVICE_REPLICA_STATUS_DROPPED, FABRIC_QUERY_SERVICE_REPLICA_STATUS_INBUILD,
         FABRIC_QUERY_SERVICE_REPLICA_STATUS_INVALID, FABRIC_QUERY_SERVICE_REPLICA_STATUS_READY,
-        FABRIC_QUERY_SERVICE_REPLICA_STATUS_STANDBY, FABRIC_SERVICE_KIND_STATEFUL,
-        FABRIC_SERVICE_KIND_STATELESS, FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
-        FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM,
+        FABRIC_QUERY_SERVICE_REPLICA_STATUS_STANDBY, FABRIC_RESTART_REPLICA_DESCRIPTION,
+        FABRIC_SERVICE_KIND_STATEFUL, FABRIC_SERVICE_KIND_STATELESS,
+        FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION, FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM,
         FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM,
         FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM,
     },
 };
-use windows_core::{GUID, HSTRING};
+use windows_core::{GUID, HSTRING, PCWSTR};
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
@@ -176,6 +176,24 @@ impl From<&FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM>
             replica_address: HSTRINGWrap::from(value.ReplicaAddress).into(),
             node_name: HSTRINGWrap::from(value.NodeName).into(),
             last_in_build_duration_in_seconds: value.LastInBuildDurationInSeconds,
+        }
+    }
+}
+
+// FABRIC_RESTART_REPLICA_DESCRIPTION
+pub struct RestartReplicaDescription {
+    pub node_name: HSTRING,
+    pub partition_id: GUID,
+    pub replica_or_instance_id: i64,
+}
+
+impl From<&RestartReplicaDescription> for FABRIC_RESTART_REPLICA_DESCRIPTION {
+    fn from(value: &RestartReplicaDescription) -> Self {
+        Self {
+            NodeName: PCWSTR(value.node_name.as_ptr()),
+            PartitionId: value.partition_id,
+            ReplicaOrInstanceId: value.replica_or_instance_id,
+            Reserved: std::ptr::null_mut(),
         }
     }
 }


### PR DESCRIPTION
Implemented restart replica fabric client api for testing stateful service replica restart. This API will be used to test replica reopen workflow implementation.
Tested for the restarting of the example stateful service.