### PR TITLE
Initial support for cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "mssf-com",
  "paste",
  "tokio",
+ "tokio-util",
  "tracing",
  "trait-variant",
  "windows",

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -17,13 +17,14 @@ include = [
 default = ["config_source", "tokio_async"]
 # Required for a lot of callback functionality.
 # Also requires ctrlc for signal handling
-tokio_async = ["dep:tokio", "ctrlc"]
+tokio_async = ["dep:tokio", "dep:tokio-util", "dep:ctrlc"]
 # Config crate required to implement its interface. 
-config_source = ["config"]
+config_source = ["dep:config"]
 
 [dependencies]
 tracing.workspace = true
 tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros"], optional = true }
+tokio-util = { version = "0.7", optional = true }
 windows-core = "0.57"
 ctrlc = { version = "3.0", features = ["termination"], optional = true }
 trait-variant = "0.1.1"
@@ -32,6 +33,8 @@ config = { version = "0.14.0",  default-features = false, optional = true }
 
 [dev-dependencies]
 paste = "1.0"
+# need time for testing
+tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros", "time"] }
 
 [dependencies.windows]
 version = "0.57"

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------
 
 use super::HRESULT;
-use mssf_com::FabricTypes::FABRIC_ERROR_CODE;
+use mssf_com::FabricTypes::{
+    FABRIC_ERROR_CODE, FABRIC_E_OPERATION_NOT_COMPLETE, FABRIC_E_OPERATION_NOT_SUPPORTED,
+};
 use windows::Win32::Foundation::{
     E_ABORT, E_ACCESSDENIED, E_FAIL, E_INVALIDARG, E_NOTIMPL, E_OUTOFMEMORY, E_POINTER, S_OK,
 };
@@ -58,7 +60,9 @@ pub enum FabricErrorCode {
     OperationFailed = E_FAIL.0 as isize,
     OutOfMemory = E_OUTOFMEMORY.0 as isize,
     NotImplemented = E_NOTIMPL.0 as isize,
-    // TODO: maybe all fabric error constants should be defined here as well in future.
+    // Some common errors from raw fabric code
+    AsyncOperationNotComplete = FABRIC_E_OPERATION_NOT_COMPLETE.0 as isize,
+    OperationNotSupported = FABRIC_E_OPERATION_NOT_SUPPORTED.0 as isize, // TODO: maybe all fabric error constants should be defined here as well in future.
 }
 
 impl From<FabricErrorCode> for FabricError {

--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -6,6 +6,7 @@
 #![deny(non_snake_case)] // this file is safe rust
 
 use mssf_com::FabricRuntime::IFabricStatelessServicePartition;
+use tokio_util::sync::CancellationToken;
 use windows_core::HSTRING;
 
 use crate::types::ServicePartitionInformation;
@@ -44,6 +45,6 @@ pub trait StatelessServiceFactory {
 #[trait_variant::make(StatelessServiceInstance: Send)]
 pub trait LocalStatelessServiceInstance: Send + Sync + 'static {
     async fn open(&self, partition: &StatelessServicePartition) -> windows::core::Result<HSTRING>;
-    async fn close(&self) -> windows::core::Result<()>;
+    async fn close(&self, cancellation_token: CancellationToken) -> windows::core::Result<()>;
     fn abort(&self);
 }

--- a/crates/libs/core/src/sync/cancel.rs
+++ b/crates/libs/core/src/sync/cancel.rs
@@ -1,0 +1,519 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use mssf_com::FabricCommon::{
+    IFabricAsyncOperationCallback, IFabricAsyncOperationContext, IFabricAsyncOperationContext_Impl,
+};
+pub use tokio_util::sync::CancellationToken;
+use windows_core::{implement, AsImpl};
+
+use crate::{error::FabricErrorCode, runtime::executor::Executor};
+
+#[implement(IFabricAsyncOperationContext)]
+pub struct BridgeContext2<T>
+where
+    T: 'static,
+{
+    content: Cell<Option<T>>,
+    is_completed: Cell<bool>,
+    is_completed_synchronously: bool,
+    callback: IFabricAsyncOperationCallback,
+    token: CancellationToken,
+}
+
+impl<T> BridgeContext2<T> {
+    pub fn new(
+        callback: IFabricAsyncOperationCallback,
+        token: CancellationToken,
+    ) -> BridgeContext2<T> {
+        BridgeContext2 {
+            content: Cell::new(None),
+            is_completed: Cell::new(false),
+            is_completed_synchronously: false,
+            callback,
+            token,
+        }
+    }
+
+    // TODO: send and comsume is expected to happend accross threads.
+    // Even though we use a oneshot channel to send the signal,
+    // it might be safer to add another memory barrier here.
+    pub fn set_content(&self, content: T) {
+        let prev = self.content.replace(Some(content));
+        assert!(prev.is_none())
+    }
+
+    // can only be called once after set content.
+    pub fn consume_content(&self) -> crate::Result<T> {
+        let opt = self.content.take();
+        match opt {
+            Some(x) => Ok(x),
+            None => {
+                if !self.IsCompleted().as_bool() {
+                    return Err(FabricErrorCode::AsyncOperationNotComplete.into());
+                }
+                if self.token.is_cancelled() {
+                    Err(FabricErrorCode::OperationCanceled.into())
+                } else {
+                    panic!("content is consumed twice.")
+                }
+            }
+        }
+    }
+
+    pub fn set_complete(&self) {
+        self.is_completed.swap(&Cell::new(true));
+    }
+}
+
+impl<T> IFabricAsyncOperationContext_Impl for BridgeContext2<T> {
+    fn IsCompleted(&self) -> ::windows::Win32::Foundation::BOOLEAN {
+        self.is_completed.get().into()
+    }
+
+    // This always returns false because we defer all tasks in the background executuor.
+    fn CompletedSynchronously(&self) -> ::windows::Win32::Foundation::BOOLEAN {
+        self.is_completed_synchronously.into()
+    }
+
+    fn Callback(&self) -> ::windows_core::Result<IFabricAsyncOperationCallback> {
+        let cp = self.callback.clone();
+        Ok(cp)
+    }
+
+    fn Cancel(&self) -> ::windows_core::Result<()> {
+        self.token.cancel();
+        Ok(())
+    }
+}
+
+// such context returned supports cancel.
+pub fn fabric_begin_bridge2<F>(
+    rt: &impl Executor,
+    callback: Option<&IFabricAsyncOperationCallback>,
+    token: CancellationToken,
+    future: F,
+) -> crate::Result<IFabricAsyncOperationContext>
+where
+    F: Future + Send + 'static,
+{
+    let cb = callback.unwrap().clone();
+    let ctx: IFabricAsyncOperationContext = BridgeContext2::<F::Output>::new(cb, token).into();
+    let ctx_cpy = ctx.clone();
+    rt.spawn(async move {
+        let ok = future.await;
+        let ctx_bridge: &BridgeContext2<F::Output> = unsafe { ctx_cpy.as_impl() };
+        ctx_bridge.set_content(ok);
+        let cb = ctx_bridge.Callback().unwrap();
+        unsafe { cb.Invoke(&ctx_cpy) };
+    });
+    Ok(ctx)
+}
+
+pub fn fabric_end_bridge2<T>(context: Option<&IFabricAsyncOperationContext>) -> crate::Result<T>
+where
+    T: 'static,
+{
+    let ctx_bridge: &BridgeContext2<T> = unsafe { context.unwrap().as_impl() };
+    ctx_bridge.consume_content()
+}
+
+// proxy impl
+
+// Token that wraps oneshot receiver.
+// The future recieve does not have error. This is designed for the use
+// case where SF guarantees that sender will be called.
+pub struct FabricReceiver2<T> {
+    rx: tokio::sync::oneshot::Receiver<T>,
+    token: Option<CancellationToken>,
+}
+
+impl<T> FabricReceiver2<T> {
+    fn new(
+        rx: tokio::sync::oneshot::Receiver<T>,
+        token: Option<CancellationToken>,
+    ) -> FabricReceiver2<T> {
+        FabricReceiver2 { rx, token }
+    }
+
+    pub fn blocking_recv(self) -> crate::Result<T> {
+        if let Some(t) = self.token {
+            if t.is_cancelled() {
+                return Err(FabricErrorCode::OperationCanceled.into());
+            }
+        }
+        // sender must send stuff so that there is not error.
+        Ok(self.rx.blocking_recv().unwrap())
+    }
+
+    // cancels the operation
+    pub fn cancel(&self) -> crate::Result<()> {
+        match &self.token {
+            Some(t) => {
+                t.cancel();
+                Ok(())
+            }
+            None => Err(FabricErrorCode::OperationNotSupported.into()),
+        }
+    }
+}
+
+// The future differs from tokio oneshot that it will not error when awaited.
+// Returns error if cancelled.
+impl<T> Future for FabricReceiver2<T> {
+    type Output = crate::Result<T>;
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // if cancelled return error, and the sender will not send anything.
+
+        // try to poll cancel
+        if let Some(t) = &self.token {
+            // this is cancel safe so we can poll it once and discard?
+            let fu = t.cancelled();
+            let inner = std::pin::pin!(fu).poll(_cx);
+            match inner {
+                Poll::Ready(_) => {
+                    // operation cancelled
+                    return Poll::Ready(Err(FabricErrorCode::OperationCanceled.into()));
+                }
+                Poll::Pending => {
+                    // continue to poll rx
+                }
+            }
+        }
+
+        // Try to receive the value from the sender
+        let innner =
+            <tokio::sync::oneshot::Receiver<T> as Future>::poll(Pin::new(&mut self.rx), _cx);
+        match innner {
+            Poll::Ready(x) => {
+                // error only happens when sender is dropped without sending.
+                match x {
+                    Ok(data) => Poll::Ready(Ok(data)),
+                    Err(_) => {
+                        if let Some(t) = self.token.as_ref() {
+                            if t.is_cancelled() {
+                                return Poll::Ready(Err(FabricErrorCode::OperationCanceled.into()));
+                            }
+                        }
+                        panic!("sender dropped without sending")
+                    }
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub struct FabricSender2<T> {
+    tx: tokio::sync::oneshot::Sender<T>,
+    token: Option<CancellationToken>,
+}
+
+impl<T> FabricSender2<T> {
+    fn new(
+        tx: tokio::sync::oneshot::Sender<T>,
+        token: Option<CancellationToken>,
+    ) -> FabricSender2<T> {
+        FabricSender2 { tx, token }
+    }
+
+    pub fn send(self, data: T) {
+        let e = self.tx.send(data);
+        if e.is_err() {
+            // In SF use case receiver should not be dropped by user.
+            // If it acctually dropped by user, it is ok to ignore because user
+            // does not want to want the value any more. But too bad SF has done
+            // the work to get the value.
+
+            // receiver should never be dropped if operation is not cancelled.
+            if let Some(t) = self.token {
+                if !t.is_cancelled() {
+                    panic!("receiver dropped.");
+                }
+            }
+        }
+    }
+}
+
+// Creates a fabric oneshot channel.
+pub fn oneshot_channel<T>(
+    token: Option<CancellationToken>,
+) -> (FabricSender2<T>, FabricReceiver2<T>) {
+    let (tx, rx) = tokio::sync::oneshot::channel::<T>();
+    (
+        FabricSender2::new(tx, token.clone()),
+        FabricReceiver2::new(rx, token),
+    )
+}
+
+pub fn fabric_begin_end_proxy2<BEGIN, END, T>(
+    begin: BEGIN,
+    end: END,
+    token: Option<CancellationToken>,
+) -> FabricReceiver2<::windows_core::Result<T>>
+where
+    BEGIN: FnOnce(
+        Option<&IFabricAsyncOperationCallback>,
+    ) -> crate::Result<IFabricAsyncOperationContext>,
+    END: FnOnce(Option<&IFabricAsyncOperationContext>) -> crate::Result<T> + 'static,
+    T: 'static,
+{
+    let (tx, rx) = oneshot_channel(token);
+
+    let callback = crate::sync::AwaitableCallback2::i_new(move |ctx| {
+        let res = end(ctx);
+        tx.send(res);
+    });
+    let ctx = begin(Some(&callback));
+    if ctx.is_err() {
+        let (tx2, rx2) = oneshot_channel(None);
+        tx2.send(Err(ctx.err().unwrap()));
+        rx2
+    } else {
+        rx
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
+    use tokio::{runtime::Handle, select};
+    use tokio_util::sync::CancellationToken;
+
+    use crate::{
+        error::FabricErrorCode, runtime::executor::DefaultExecutor, sync::cancel::oneshot_channel,
+    };
+
+    use super::{fabric_begin_bridge2, fabric_begin_end_proxy2, fabric_end_bridge2};
+
+    #[tokio::test]
+    async fn test_channel() {
+        // success send
+        {
+            let (tx, rx) = oneshot_channel::<bool>(Some(CancellationToken::new()));
+            tx.send(true);
+            assert!(rx.await.unwrap());
+        }
+        // receiver cancelled after send
+        {
+            let (tx, rx) = oneshot_channel::<bool>(Some(CancellationToken::new()));
+            tx.send(true);
+            rx.cancel().unwrap();
+            assert_eq!(
+                rx.await.unwrap_err(),
+                FabricErrorCode::OperationCanceled.into()
+            );
+        }
+        // receiver cancelled before send
+        {
+            let (tx, rx) = oneshot_channel::<bool>(Some(CancellationToken::new()));
+            rx.cancel().unwrap();
+            tx.send(true);
+            assert_eq!(
+                rx.await.unwrap_err(),
+                FabricErrorCode::OperationCanceled.into()
+            );
+        }
+        // receiver cancelled and droped, send is no op
+        {
+            let (tx, rx) = oneshot_channel::<bool>(Some(CancellationToken::new()));
+            rx.cancel().unwrap();
+            std::mem::drop(rx);
+            tx.send(true);
+        }
+        // receiver cancelled and sender dropped. receiver get error
+        {
+            let (tx, rx) = oneshot_channel::<bool>(Some(CancellationToken::new()));
+            rx.cancel().unwrap();
+            std::mem::drop(tx);
+            assert_eq!(
+                rx.await.unwrap_err(),
+                FabricErrorCode::OperationCanceled.into()
+            );
+        }
+    }
+
+    pub struct MyObj {
+        data: String,
+        rt: Handle,
+    }
+
+    impl MyObj {
+        pub fn new(rt: Handle, data: String) -> Self {
+            Self { data, rt }
+        }
+        // concat input with data.
+        // This operation is slow and use it to test cancel.
+        pub async fn get_data_slow(
+            &self,
+            input: String,
+            token: Option<CancellationToken>,
+        ) -> crate::Result<String> {
+            match token {
+                Some(t) => {
+                    select! {
+                        _ = t.cancelled() => {
+                            // The token was cancelled
+                            Err(FabricErrorCode::OperationCanceled.into())
+                        }
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                            self.get_data(input, None).await
+                        }
+                    }
+                }
+                None => {
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                    self.get_data(input, None).await
+                }
+            }
+        }
+
+        pub async fn get_data(
+            &self,
+            input: String,
+            _: Option<CancellationToken>,
+        ) -> crate::Result<String> {
+            let data_cp = self.data.clone();
+            match self
+                .rt
+                .spawn(async move { format!("{}:{}", data_cp, input) })
+                .await
+            {
+                Ok(s) => Ok(s),
+                Err(_) => Err(FabricErrorCode::OperationFailed.into()),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct MyObjBridge {
+        inner: Arc<MyObj>,
+        rt: DefaultExecutor,
+    }
+
+    impl MyObjBridge {
+        pub fn new(rt: Handle, data: String) -> Self {
+            let inner = Arc::new(MyObj::new(rt.clone(), data));
+            Self {
+                inner,
+                rt: DefaultExecutor::new(rt),
+            }
+        }
+
+        pub fn begin_get_data(
+            &self,
+            input: String,
+            callback: ::core::option::Option<&IFabricAsyncOperationCallback>,
+        ) -> crate::Result<IFabricAsyncOperationContext> {
+            let inner = self.inner.clone();
+            let token = CancellationToken::new();
+            let token_cp = token.clone();
+            fabric_begin_bridge2(&self.rt, callback, token, async move {
+                inner.get_data(input, Some(token_cp)).await
+            })
+        }
+
+        pub fn end_get_data(
+            &self,
+            context: ::core::option::Option<&IFabricAsyncOperationContext>,
+        ) -> crate::Result<String> {
+            fabric_end_bridge2(context)?
+        }
+
+        pub fn begin_get_data_slow(
+            &self,
+            input: String,
+            callback: ::core::option::Option<&IFabricAsyncOperationCallback>,
+        ) -> crate::Result<IFabricAsyncOperationContext> {
+            let inner = self.inner.clone();
+            let token = CancellationToken::new();
+            let token_cp = token.clone();
+            fabric_begin_bridge2(&self.rt, callback, token, async move {
+                inner.get_data_slow(input, Some(token_cp)).await
+            })
+        }
+
+        pub fn end_get_data_slow(
+            &self,
+            context: ::core::option::Option<&IFabricAsyncOperationContext>,
+        ) -> crate::Result<String> {
+            fabric_end_bridge2(context)?
+        }
+    }
+
+    pub struct MyObjProxy {
+        com: MyObjBridge,
+    }
+
+    impl MyObjProxy {
+        pub fn new(com: MyObjBridge) -> Self {
+            Self { com }
+        }
+
+        pub async fn get_data(
+            &self,
+            input: String,
+            token: Option<CancellationToken>,
+        ) -> crate::Result<String> {
+            let com1 = &self.com;
+            let com2 = self.com.clone();
+            fabric_begin_end_proxy2(
+                move |callback| com1.begin_get_data(input, callback),
+                move |context| com2.end_get_data(context),
+                token,
+            )
+            .await?
+        }
+
+        pub async fn get_data_slow(
+            &self,
+            input: String,
+            token: Option<CancellationToken>,
+        ) -> crate::Result<String> {
+            let com1 = &self.com;
+            let com2 = self.com.clone();
+            fabric_begin_end_proxy2(
+                move |callback| com1.begin_get_data_slow(input, callback),
+                move |context| com2.end_get_data_slow(context),
+                token,
+            )
+            .await?
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel() {
+        let h = tokio::runtime::Handle::current();
+        let bridge = MyObjBridge::new(h, "mydata".to_string());
+        let proxy = MyObjProxy::new(bridge);
+
+        // no cancel
+        {
+            let token = CancellationToken::new();
+            let out = proxy
+                .get_data("myinput".to_string(), Some(token))
+                .await
+                .unwrap();
+            assert_eq!(out, "mydata:myinput");
+        }
+        // cancel
+        {
+            let token = CancellationToken::new();
+            let fu = proxy.get_data_slow("myinput".to_string(), Some(token.clone()));
+            token.cancel();
+            let err = fu.await.unwrap_err();
+            assert_eq!(err, FabricErrorCode::OperationCanceled.into());
+        }
+    }
+}

--- a/crates/libs/core/src/sync/cancel.rs
+++ b/crates/libs/core/src/sync/cancel.rs
@@ -61,12 +61,10 @@ where
         F: Future<Output = T> + Send + 'static,
     {
         let self_cp: IFabricAsyncOperationContext = self.into();
-        // extra clone is necessary to avoid access violation.
-        let self_cp3 = self_cp.clone();
         let self_cp2 = self_cp.clone();
         rt.spawn(async move {
             let ok = future.await;
-            let self_impl: &BridgeContext3<T> = unsafe { self_cp3.as_impl() };
+            let self_impl: &BridgeContext3<T> = unsafe { self_cp.as_impl() };
             self_impl.set_content(ok);
             self_impl.set_complete();
             let cb = self_impl.Callback().unwrap();

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -33,6 +33,8 @@ pub use bridge::*;
 // This is intentional private. User should directly use bridge mod.
 mod bridge_context;
 
+pub mod cancel;
+
 // fabric code begins here
 
 // Creates the local client

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -34,6 +34,7 @@ pub use bridge::*;
 mod bridge_context;
 
 pub mod cancel;
+pub use cancel::*;
 
 // fabric code begins here
 

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -68,6 +68,7 @@ pub struct NodeQueryDescription {
     pub paged_query: PagedQueryDescription,
 }
 
+#[derive(Debug)]
 pub struct NodeList {
     com: IFabricGetNodeListResult2,
 }


### PR DESCRIPTION
Implement #46 
All SF rust api should have a new parameter `cancellation_token: CancellationToken`. CancellationToken is taken directly from tokio_util crate, as I don't see an advantage to do a wrapping of it or creating our own implementation of cancellation token. SF treats cancellation as an advisory signal, and in user application(rust api), user can ignore the cancel signal, but it might stall SF until the operation is finished.

In this PR there is only 1 proxy api and 1 bridge api has been modified to have this cancellation token, and I will create another PR to change all apis.
The implementation requires new BridgeContext, oneshot Sender/Receiver, and fabric_begin_end_proxy. The original implementations are not changed in this PR but will be removed/replaced in the next PR.