### PR TITLE
[FabricClient] Service notification perf comparison

### DIFF
--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -199,6 +199,7 @@ impl ServiceManagementClient {
     /// This will always return the endpoints in the client cache updated by the latest notification.
     /// The notification mechanism itself will keep the client cache updated when service endpoints change.
     /// TODO: explore the relation to IFabricServiceNotification.
+    /// This is observed to have 1~4 secs delay compared with brute force complaint based resolve.
     pub async fn register_service_notification_filter(
         &self,
         desc: &ServiceNotificationFilterDescription,
@@ -324,6 +325,7 @@ impl From<FABRIC_SERVICE_PARTITION_KIND> for ServicePartitionKind {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct ResolvedServicePartition {
     com: IFabricResolvedServicePartitionResult,
 }

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -44,6 +44,8 @@ pub struct ServiceNotificationFilterDescription {
 impl From<&ServiceNotificationFilterDescription>
     for FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION
 {
+    /// The lifetime of the SF raw type returned must match the
+    /// original struct.
     fn from(value: &ServiceNotificationFilterDescription) -> Self {
         Self {
             Name: FABRIC_URI(value.name.as_ptr() as *mut u16),


### PR DESCRIPTION
Added a test to compare service notification performance with the brute force complain based resolution.
In the test notification is observed to be 1 to 4 seconds slower than the brute force way, and the typical lag for brute force is 6 seconds. So the notification takes about 7 to 10 seconds.