### PR TITLE
[FabricClient] Support FabricClient user notification callback

### DIFF
--- a/crates/libs/core/src/client/connection.rs
+++ b/crates/libs/core/src/client/connection.rs
@@ -1,0 +1,94 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// --------------------------------------------------
+
+use mssf_com::FabricClient::{
+    IFabricClientConnectionEventHandler, IFabricClientConnectionEventHandler_Impl,
+    IFabricGatewayInformationResult,
+};
+
+use crate::{strings::HSTRINGWrap, types::NodeId};
+
+pub trait ClientConnectionEventHandler: 'static {
+    fn on_connected(&self, info: &GatewayInformationResult) -> crate::Result<()>;
+    fn on_disconnected(&self, info: &GatewayInformationResult) -> crate::Result<()>;
+}
+
+// IFabricGatewayInformationResult
+#[derive(Debug, Clone)]
+pub struct GatewayInformationResult {
+    pub node_address: crate::HSTRING,
+    pub node_id: NodeId,
+    pub node_instance_id: u64,
+    pub node_name: crate::HSTRING,
+}
+
+impl GatewayInformationResult {
+    fn from_com(com: &IFabricGatewayInformationResult) -> Self {
+        let info = unsafe { com.get_GatewayInformation().as_ref().unwrap() };
+        Self {
+            node_address: HSTRINGWrap::from(info.NodeAddress).into(),
+            node_id: info.NodeId.into(),
+            node_instance_id: info.NodeInstanceId,
+            node_name: HSTRINGWrap::from(info.NodeName).into(),
+        }
+    }
+}
+
+// IFabricClientConnectionEventHandler
+#[windows_core::implement(IFabricClientConnectionEventHandler)]
+pub struct ClientConnectionEventHandlerBridge<T>
+where
+    T: ClientConnectionEventHandler,
+{
+    inner: T,
+}
+
+impl<T> ClientConnectionEventHandlerBridge<T>
+where
+    T: ClientConnectionEventHandler,
+{
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+    pub fn new_com(inner: T) -> IFabricClientConnectionEventHandler {
+        Self::new(inner).into()
+    }
+}
+
+impl<T> IFabricClientConnectionEventHandler_Impl for ClientConnectionEventHandlerBridge<T>
+where
+    T: ClientConnectionEventHandler,
+{
+    fn OnConnected(
+        &self,
+        gw_info: Option<&IFabricGatewayInformationResult>,
+    ) -> windows_core::Result<()> {
+        let info = GatewayInformationResult::from_com(gw_info.unwrap());
+        self.inner.on_connected(&info)
+    }
+
+    fn OnDisconnected(
+        &self,
+        gw_info: Option<&IFabricGatewayInformationResult>,
+    ) -> windows_core::Result<()> {
+        let info = GatewayInformationResult::from_com(gw_info.unwrap());
+        self.inner.on_disconnected(&info)
+    }
+}
+
+// Default implementation of ClientConnectionEventHandler
+pub struct DefaultClientConnectionEventHandler {}
+
+impl ClientConnectionEventHandler for DefaultClientConnectionEventHandler {
+    fn on_connected(&self, info: &GatewayInformationResult) -> crate::Result<()> {
+        tracing::debug!("on_connected: {:?}", info);
+        Ok(())
+    }
+
+    fn on_disconnected(&self, info: &GatewayInformationResult) -> crate::Result<()> {
+        tracing::debug!("on_disconnected: {:?}", info);
+        Ok(())
+    }
+}

--- a/crates/libs/core/src/client/connection.rs
+++ b/crates/libs/core/src/client/connection.rs
@@ -92,3 +92,37 @@ impl ClientConnectionEventHandler for DefaultClientConnectionEventHandler {
         Ok(())
     }
 }
+
+/// Turns a Fn into client connection notification handler.
+pub struct LambdaClientConnectionNotificationHandler<T, K>
+where
+    T: Fn(&GatewayInformationResult) -> crate::Result<()> + 'static,
+    K: Fn(&GatewayInformationResult) -> crate::Result<()> + 'static,
+{
+    f_conn: T,
+    f_disconn: K,
+}
+
+impl<T, K> LambdaClientConnectionNotificationHandler<T, K>
+where
+    T: Fn(&GatewayInformationResult) -> crate::Result<()> + 'static,
+    K: Fn(&GatewayInformationResult) -> crate::Result<()> + 'static,
+{
+    pub fn new(f_conn: T, f_disconn: K) -> Self {
+        Self { f_conn, f_disconn }
+    }
+}
+
+impl<T, K> ClientConnectionEventHandler for LambdaClientConnectionNotificationHandler<T, K>
+where
+    T: Fn(&GatewayInformationResult) -> crate::Result<()> + 'static,
+    K: Fn(&GatewayInformationResult) -> crate::Result<()> + 'static,
+{
+    fn on_connected(&self, info: &GatewayInformationResult) -> crate::Result<()> {
+        (self.f_conn)(info)
+    }
+
+    fn on_disconnected(&self, info: &GatewayInformationResult) -> crate::Result<()> {
+        (self.f_disconn)(info)
+    }
+}

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -63,6 +63,12 @@ pub struct FabricClientBuilder {
     client_role: ClientRole,
 }
 
+impl Default for FabricClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FabricClientBuilder {
     pub fn new() -> Self {
         Self {

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -108,7 +108,9 @@ impl FabricClientBuilder {
         if self.cc_handler.is_none() {
             self.cc_handler = Some(LambdaClientConnectionNotificationHandler::new());
         }
-        self.cc_handler.as_mut().map(|cc| cc.set_f_conn(f));
+        if let Some(cc) = self.cc_handler.as_mut() {
+            cc.set_f_conn(f)
+        }
         self
     }
 
@@ -121,7 +123,9 @@ impl FabricClientBuilder {
         if self.cc_handler.is_none() {
             self.cc_handler = Some(LambdaClientConnectionNotificationHandler::new());
         }
-        self.cc_handler.as_mut().map(|cc| cc.set_f_disconn(f));
+        if let Some(cc) = self.cc_handler.as_mut() {
+            cc.set_f_disconn(f)
+        }
         self
     }
 
@@ -144,7 +148,7 @@ impl FabricClientBuilder {
     pub fn build_interface<T: Interface>(self) -> T {
         let cc_handler = self
             .cc_handler
-            .map(|cc| ClientConnectionEventHandlerBridge::new_com(cc));
+            .map(ClientConnectionEventHandlerBridge::new_com);
         create_local_client_internal::<T>(
             self.sn_handler.as_ref(),
             cc_handler.as_ref(),

--- a/crates/libs/core/src/client/notification.rs
+++ b/crates/libs/core/src/client/notification.rs
@@ -1,0 +1,136 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::{
+    FabricClient::{
+        IFabricServiceEndpointsVersion, IFabricServiceNotification,
+        IFabricServiceNotificationEventHandler, IFabricServiceNotificationEventHandler_Impl,
+    },
+    FabricTypes::FABRIC_RESOLVED_SERVICE_ENDPOINT,
+};
+
+use crate::{
+    iter::{FabricIter, FabricListAccessor},
+    types::ServicePartitionInformation,
+};
+
+use super::svc_mgmt_client::ResolvedServiceEndpoint;
+
+pub trait ServiceNotificationEventHandler: 'static {
+    fn on_notification(&self, notification: &ServiceNotification) -> crate::Result<()>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceNotification {
+    pub partition_info: ServicePartitionInformation,
+    pub partition_id: crate::GUID,
+    pub endpoints: ServiceEndpointList,
+    com: IFabricServiceNotification,
+}
+
+impl ServiceNotification {
+    fn from_com(com: IFabricServiceNotification) -> Self {
+        let raw = unsafe { com.get_Notification().as_ref().unwrap() };
+        Self {
+            partition_info: unsafe { raw.PartitionInfo.as_ref().unwrap().into() },
+            partition_id: raw.PartitionId,
+            endpoints: ServiceEndpointList { com: com.clone() },
+            com,
+        }
+    }
+
+    pub fn get_version(&self) -> crate::Result<ServiceEndpointsVersion> {
+        let version = unsafe { self.com.GetVersion() }?;
+        Ok(ServiceEndpointsVersion::from_com(version))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceEndpointList {
+    com: IFabricServiceNotification,
+}
+
+impl ServiceEndpointList {
+    // Get iterator for the list
+    pub fn iter(&self) -> ServiceEndpointListIter {
+        ServiceEndpointListIter::new(self, self)
+    }
+}
+
+impl FabricListAccessor<FABRIC_RESOLVED_SERVICE_ENDPOINT> for ServiceEndpointList {
+    fn get_count(&self) -> u32 {
+        let raw = unsafe { self.com.get_Notification().as_ref().unwrap() };
+        raw.EndpointCount
+    }
+
+    fn get_first_item(&self) -> *const FABRIC_RESOLVED_SERVICE_ENDPOINT {
+        let raw = unsafe { self.com.get_Notification().as_ref().unwrap() };
+        raw.Endpoints
+    }
+}
+
+type ServiceEndpointListIter<'a> =
+    FabricIter<'a, FABRIC_RESOLVED_SERVICE_ENDPOINT, ResolvedServiceEndpoint, ServiceEndpointList>;
+
+pub struct ServiceEndpointsVersion {
+    com: IFabricServiceEndpointsVersion,
+}
+
+impl ServiceEndpointsVersion {
+    fn from_com(com: IFabricServiceEndpointsVersion) -> Self {
+        Self { com }
+    }
+
+    /// TODO: documentation.
+    pub fn compare(&self, other: &ServiceEndpointsVersion) -> crate::Result<i32> {
+        unsafe { self.com.Compare(&other.com) }
+    }
+}
+
+// Bridge implementation for the notification handler
+#[windows_core::implement(IFabricServiceNotificationEventHandler)]
+pub struct ServiceNotificationEventHandlerBridge<T>
+where
+    T: ServiceNotificationEventHandler,
+{
+    inner: T,
+}
+
+impl<T> ServiceNotificationEventHandlerBridge<T>
+where
+    T: ServiceNotificationEventHandler,
+{
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn new_com(inner: T) -> IFabricServiceNotificationEventHandler {
+        Self::new(inner).into()
+    }
+}
+
+impl<T> IFabricServiceNotificationEventHandler_Impl for ServiceNotificationEventHandlerBridge<T>
+where
+    T: ServiceNotificationEventHandler,
+{
+    fn OnNotification(
+        &self,
+        notification: Option<&IFabricServiceNotification>,
+    ) -> crate::Result<()> {
+        let com = notification.unwrap();
+        let msg = ServiceNotification::from_com(com.to_owned());
+        self.inner.on_notification(&msg)
+    }
+}
+
+// default implementation of ServiceNotificationEventHandler
+pub struct DefaultServiceNotificationEventHandler {}
+
+impl ServiceNotificationEventHandler for DefaultServiceNotificationEventHandler {
+    fn on_notification(&self, notification: &ServiceNotification) -> crate::Result<()> {
+        tracing::debug!("Got service notification {:?}", notification);
+        Ok(())
+    }
+}

--- a/crates/libs/core/src/client/notification.rs
+++ b/crates/libs/core/src/client/notification.rs
@@ -125,12 +125,28 @@ where
     }
 }
 
-// default implementation of ServiceNotificationEventHandler
-pub struct DefaultServiceNotificationEventHandler {}
+/// Turns a Fn into service notification handler.
+pub struct LambdaServiceNotificationHandler<T>
+where
+    T: Fn(&ServiceNotification) -> crate::Result<()> + 'static,
+{
+    f: T,
+}
 
-impl ServiceNotificationEventHandler for DefaultServiceNotificationEventHandler {
+impl<T> LambdaServiceNotificationHandler<T>
+where
+    T: Fn(&ServiceNotification) -> crate::Result<()> + 'static,
+{
+    pub fn new(f: T) -> Self {
+        Self { f }
+    }
+}
+
+impl<T> ServiceNotificationEventHandler for LambdaServiceNotificationHandler<T>
+where
+    T: Fn(&ServiceNotification) -> crate::Result<()> + 'static,
+{
     fn on_notification(&self, notification: &ServiceNotification) -> crate::Result<()> {
-        tracing::debug!("Got service notification {:?}", notification);
-        Ok(())
+        (self.f)(notification)
     }
 }

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -12,14 +12,14 @@ use tokio_util::sync::CancellationToken;
 use windows_core::HSTRING;
 
 use crate::{
-    client::{svc_mgmt_client::PartitionKeyType, FabricClient},
+    client::{svc_mgmt_client::PartitionKeyType, FabricClientBuilder},
     error::FabricErrorCode,
     types::{NodeQueryDescription, NodeStatusFilter, PagedQueryDescription},
 };
 
 #[tokio::test]
 async fn test_fabric_client() {
-    let c = FabricClient::new();
+    let c = FabricClientBuilder::new().build();
     let qc = c.get_query_manager();
     let timeout = Duration::from_secs(1);
     let paging_status;

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -9,6 +9,7 @@ use windows_core::{Interface, HSTRING};
 use crate::{
     strings::HSTRINGWrap,
     sync::{fabric_begin_end_proxy2, CancellationToken},
+    types::NodeId,
 };
 
 pub fn get_com_node_context(
@@ -25,12 +26,6 @@ pub fn get_com_node_context(
         },
         cancellation_token,
     )
-}
-
-#[derive(Debug)]
-pub struct NodeId {
-    pub low: u64,
-    pub high: u64,
 }
 
 #[derive(Debug)]
@@ -81,10 +76,7 @@ impl From<&IFabricNodeContextResult> for NodeContext {
             node_type: HSTRINGWrap::from(raw_ref.NodeType).into(),
             ip_address_or_fqdn: HSTRINGWrap::from(raw_ref.IPAddressOrFQDN).into(),
             node_instance_id: raw_ref.NodeInstanceId,
-            node_id: NodeId {
-                low: raw_ref.NodeId.Low,
-                high: raw_ref.NodeId.High,
-            },
+            node_id: raw_ref.NodeId.into(),
         }
     }
 }

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -232,7 +232,7 @@ mod tests {
                 pub fn new() -> $name {
                     return $name {
                         com: paste::item! {
-                            crate::client::create_local_client_default::<mssf_com::FabricClient::[<I $name>]>()
+                            crate::client::FabricClientBuilder::new().build_interface::<mssf_com::FabricClient::[<I $name>]>()
                         },
                     };
                 }
@@ -320,7 +320,8 @@ mod tests {
     impl FabricQueryClient {
         pub fn new() -> FabricQueryClient {
             FabricQueryClient {
-                com: crate::client::create_local_client_default::<IFabricQueryClient>(),
+                com: crate::client::FabricClientBuilder::new()
+                    .build_interface::<IFabricQueryClient>(),
             }
         }
 
@@ -510,7 +511,8 @@ mod tests {
 
     #[test]
     fn local_client_create() {
-        let _mgmt = crate::client::create_local_client_default::<IFabricClusterManagementClient3>();
+        let _mgmt = crate::client::FabricClientBuilder::new()
+            .build_interface::<IFabricClusterManagementClient3>();
     }
 
     #[tokio::test]

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -13,16 +13,11 @@ use std::{
     task::{Context, Poll},
 };
 
-use mssf_com::{
-    FabricClient::FabricCreateLocalClient,
-    FabricCommon::{
-        IFabricAsyncOperationCallback, IFabricAsyncOperationCallback_Impl,
-        IFabricAsyncOperationContext,
-    },
+use mssf_com::FabricCommon::{
+    IFabricAsyncOperationCallback, IFabricAsyncOperationCallback_Impl, IFabricAsyncOperationContext,
 };
 use tokio::sync::oneshot::Receiver;
 use windows::core::implement;
-use windows_core::Interface;
 
 mod proxy;
 pub mod wait;
@@ -35,11 +30,6 @@ pub mod cancel;
 pub use cancel::*;
 
 // fabric code begins here
-
-// Creates the local client
-pub fn CreateLocalClient<T: Interface>() -> T {
-    unsafe { T::from_raw(FabricCreateLocalClient(&T::IID).expect("cannot get localclient")) }
-}
 
 pub trait Callback:
     FnOnce(::core::option::Option<&IFabricAsyncOperationContext>) + 'static
@@ -183,7 +173,7 @@ mod tests {
     use windows::core::implement;
     use windows_core::{Interface, HSTRING};
 
-    use super::{oneshot_channel, CreateLocalClient, FabricReceiver, SBox};
+    use super::{oneshot_channel, FabricReceiver, SBox};
 
     use super::AwaitableCallback2;
 
@@ -242,7 +232,7 @@ mod tests {
                 pub fn new() -> $name {
                     return $name {
                         com: paste::item! {
-                            crate::sync::CreateLocalClient::<mssf_com::FabricClient::[<I $name>]>()
+                            crate::client::create_local_client_default::<mssf_com::FabricClient::[<I $name>]>()
                         },
                     };
                 }
@@ -330,7 +320,7 @@ mod tests {
     impl FabricQueryClient {
         pub fn new() -> FabricQueryClient {
             FabricQueryClient {
-                com: CreateLocalClient::<IFabricQueryClient>(),
+                com: crate::client::create_local_client_default::<IFabricQueryClient>(),
             }
         }
 
@@ -520,7 +510,7 @@ mod tests {
 
     #[test]
     fn local_client_create() {
-        let _mgmt = CreateLocalClient::<IFabricClusterManagementClient3>();
+        let _mgmt = crate::client::create_local_client_default::<IFabricClusterManagementClient3>();
     }
 
     #[tokio::test]

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -6,8 +6,9 @@
 // This mod contains fabric client related types
 mod partition;
 use mssf_com::FabricTypes::{
-    FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION, FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS,
-    FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS_NAME_PREFIX,
+    FABRIC_CLIENT_ROLE, FABRIC_CLIENT_ROLE_ADMIN, FABRIC_CLIENT_ROLE_UNKNOWN,
+    FABRIC_CLIENT_ROLE_USER, FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
+    FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS, FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS_NAME_PREFIX,
     FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS_NONE,
     FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS_PRIMARY_ONLY, FABRIC_URI,
 };
@@ -51,6 +52,37 @@ impl From<&ServiceNotificationFilterDescription>
             Name: FABRIC_URI(value.name.as_ptr() as *mut u16),
             Flags: (&value.flags).into(),
             Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+// FABRIC_CLIENT_ROLE
+#[derive(Debug, PartialEq, Clone)]
+pub enum ClientRole {
+    Unknown, // Do not pass this in SF api, use User instead.
+    User,
+    Admin,
+    // ElevatedAdmin not supported by SF 6.x sdk yet.
+}
+
+impl From<FABRIC_CLIENT_ROLE> for ClientRole {
+    fn from(value: FABRIC_CLIENT_ROLE) -> Self {
+        match value {
+            FABRIC_CLIENT_ROLE_UNKNOWN => Self::Unknown,
+            FABRIC_CLIENT_ROLE_USER => Self::User,
+            FABRIC_CLIENT_ROLE_ADMIN => Self::Admin,
+            // FABRIC_CLIENT_ROLE_ELEVATED_ADMIN => Self::ElevatedAdmin,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<ClientRole> for FABRIC_CLIENT_ROLE {
+    fn from(value: ClientRole) -> Self {
+        match value {
+            ClientRole::Unknown => FABRIC_CLIENT_ROLE_UNKNOWN,
+            ClientRole::User => FABRIC_CLIENT_ROLE_USER,
+            ClientRole::Admin => FABRIC_CLIENT_ROLE_ADMIN,
         }
     }
 }

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -11,7 +11,7 @@ use bitflags::bitflags;
 use mssf_com::{
     FabricClient::IFabricGetNodeListResult2,
     FabricTypes::{
-        FABRIC_NODE_QUERY_RESULT_ITEM, FABRIC_NODE_QUERY_RESULT_ITEM_EX1,
+        FABRIC_NODE_ID, FABRIC_NODE_QUERY_RESULT_ITEM, FABRIC_NODE_QUERY_RESULT_ITEM_EX1,
         FABRIC_NODE_QUERY_RESULT_ITEM_EX2, FABRIC_PAGING_STATUS,
         FABRIC_QUERY_NODE_STATUS_FILTER_ALL, FABRIC_QUERY_NODE_STATUS_FILTER_DEFAULT,
         FABRIC_QUERY_NODE_STATUS_FILTER_DISABLED, FABRIC_QUERY_NODE_STATUS_FILTER_DISABLING,
@@ -142,6 +142,22 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for Node {
             upgrade_domain: HSTRINGWrap::from(raw.UpgradeDomain).into(),
             fault_domain: HSTRINGWrap::from(windows_core::PCWSTR(raw.FaultDomain.0)).into(),
             node_instance_id: raw2.NodeInstanceId,
+        }
+    }
+}
+
+// FABRIC_NODE_ID
+#[derive(Debug, Clone)]
+pub struct NodeId {
+    pub low: u64,
+    pub high: u64,
+}
+
+impl From<FABRIC_NODE_ID> for NodeId {
+    fn from(value: FABRIC_NODE_ID) -> Self {
+        Self {
+            low: value.Low,
+            high: value.High,
         }
     }
 }

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -11,7 +11,7 @@ use mssf_core::{
             PartitionKeyType, ResolvedServiceEndpoint, ResolvedServicePartition,
             ServiceEndpointRole, ServicePartitionKind,
         },
-        FabricClient,
+        FabricClient, FabricClientBuilder,
     },
     error::FabricErrorCode,
     types::{
@@ -233,7 +233,7 @@ impl TestClient {
 // Uses fabric client to perform various actions for this service.
 #[tokio::test]
 async fn test_partition_info() {
-    let fc = FabricClient::new();
+    let fc = FabricClientBuilder::new().build();
     let tc = TestClient::new(fc.clone());
     let timeout = Duration::from_secs(1);
 

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -11,7 +11,7 @@ use mssf_core::{
             PartitionKeyType, ResolvedServiceEndpoint, ResolvedServicePartitionInfo,
             ServiceEndpointRole, ServicePartitionKind,
         },
-        FabricClient,
+        FabricClient, FabricClientBuilder, GatewayInformationResult, ServiceNotification,
     },
     error::FabricErrorCode,
     types::{
@@ -25,6 +25,8 @@ use mssf_core::{
 };
 
 static ECHO_SVC_URI: &str = "fabric:/EchoApp/EchoAppService";
+static MAX_RETRY_COUNT: i32 = 5;
+static RETRY_DURATION_SHORT: Duration = Duration::from_secs(1);
 
 // Test client for echo server.
 pub struct EchoTestClient {
@@ -114,7 +116,26 @@ impl EchoTestClient {
 // Uses fabric client to perform various actions to the app.
 #[tokio::test]
 async fn test_fabric_client() {
-    let fc = FabricClient::new();
+    // channel for service notification
+    let (sn_tx, mut sn_rx) = tokio::sync::mpsc::channel::<ServiceNotification>(1);
+    // channel for client connection notification
+    let (cc_tx, mut cc_rx) = tokio::sync::mpsc::channel::<GatewayInformationResult>(1);
+    let fc = FabricClientBuilder::new()
+        .with_service_notification_handler_fn(move |notification| {
+            sn_tx
+                .blocking_send(notification.clone())
+                .expect("cannot send notification");
+            Ok(())
+        })
+        .with_client_connection_handler_fn(
+            move |gw| {
+                cc_tx.blocking_send(gw.clone()).expect("cannot send");
+                Ok(())
+            },
+            |_| Ok(()), // we only care about connection even in this test.
+        )
+        .build();
+
     let ec = EchoTestClient::new(fc.clone());
 
     let timeout = Duration::from_secs(1);
@@ -127,6 +148,10 @@ async fn test_fabric_client() {
     // For some reason the state is unknown
     // assert_eq!(stateless.health_state, HealthState::Ok);
     assert_ne!(single.id, GUID::zeroed());
+
+    // Connection event notification should be received since we already sent a request.
+    let gw = cc_rx.try_recv().expect("notification not present");
+    assert!(!gw.node_name.is_empty());
 
     // Get replica info
     let stateless_replica = ec.get_replica(single.id).await.unwrap();
@@ -182,16 +207,36 @@ async fn test_fabric_client() {
         if replica2.instance_id != stateless_replica.instance_id {
             break;
         } else {
-            if count > 5 {
+            if count > MAX_RETRY_COUNT {
                 panic!(
                     "replica id not changed after retry. original {}, new {}",
                     stateless_replica.instance_id, replica2.instance_id
                 );
             }
             // replica has not changed yet.
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(RETRY_DURATION_SHORT).await;
         }
         count += 1;
+    }
+
+    // check service notification is invoked because service addr is changed for
+    // replica removal and recreation.
+    for i in 0..MAX_RETRY_COUNT {
+        match sn_rx.try_recv() {
+            Ok(sn) => {
+                assert_eq!(sn.partition_id, single.id);
+                break;
+            }
+            Err(e) => {
+                if e == tokio::sync::mpsc::error::TryRecvError::Disconnected {
+                    panic!("channnel should not be closed");
+                }
+                if i == MAX_RETRY_COUNT {
+                    panic!("notification not received");
+                }
+                tokio::time::sleep(RETRY_DURATION_SHORT).await;
+            }
+        };
     }
 
     // unregisters the notification


### PR DESCRIPTION
Support service notification callback and client connection notification callbacks.
You can construct FabricClient with callbacks lambda functions like this:
```rs
let fc = FabricClientBuilder::new()
        .with_on_service_notification(move |notification| {
            Ok(())
        })
        .with_on_client_connect(move |gw| {
            Ok(())
        })
        .with_on_client_disconnect(move |_| {
             Ok(())
        })
        .with_client_role(mssf_core::types::ClientRole::User).build()
```
with_on_service_notification callback is configured by register_service_notification_filter API.