### PR TITLE
Add public available documentations to traits

### DIFF
--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -29,8 +29,11 @@ impl StatelessServicePartition {
     }
 }
 
-// safe factory
+/// Stateless service factories are registered with the FabricRuntime by service hosts via
+/// Runtime::register_stateless_service_factory().
+///
 pub trait StatelessServiceFactory {
+    /// Creates a stateless service instance for a particular service. This method is called by Service Fabric.
     fn create_instance(
         &self,
         servicetypename: &HSTRING,
@@ -41,14 +44,28 @@ pub trait StatelessServiceFactory {
     ) -> windows_core::Result<impl StatelessServiceInstance>;
 }
 
-// safe service instance
+/// Defines behavior that governs the lifecycle of a stateless service instance, such as startup, initialization, and shutdown.
 #[trait_variant::make(StatelessServiceInstance: Send)]
 pub trait LocalStatelessServiceInstance: Send + Sync + 'static {
+    /// Opens an initialized service instance so that it can be contacted by clients.
+    /// Remarks:
+    /// Opening an instance stateless service indicates that the service is now resolvable
+    /// and discoverable by service clients. The string that is returned is the address of this service instance.
+    /// The address is associated with the service name via Service Fabric naming and returned to
+    /// clients that resolve the service via resolve_service_partition(uri).
     async fn open(
         &self,
         partition: &StatelessServicePartition,
         cancellation_token: CancellationToken,
     ) -> windows::core::Result<HSTRING>;
+
+    /// Closes this service instance gracefully when the service instance is being shut down.
     async fn close(&self, cancellation_token: CancellationToken) -> windows::core::Result<()>;
+
+    /// Terminates this instance ungracefully with this synchronous method call.
+    /// Remarks:
+    /// Examples of ungraceful termination are network issues resulting in Service Fabric process shutdown and the
+    /// use of ReportFault(FaultType) to report a Permanent fault. When the service instance receives this method,
+    /// it should immediately release and clean up all references and return.
     fn abort(&self);
 }


### PR DESCRIPTION
Added documentation for service factories, stateless instance, stateful replica.
Replicator documentation is not public (yet), so only added minimal information for them.