### PR TITLE
[FabricClient] Set default client role to unknown

### DIFF
--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -12,14 +12,14 @@ use tokio_util::sync::CancellationToken;
 use windows_core::HSTRING;
 
 use crate::{
-    client::{svc_mgmt_client::PartitionKeyType, FabricClientBuilder},
+    client::{svc_mgmt_client::PartitionKeyType, FabricClient},
     error::FabricErrorCode,
     types::{NodeQueryDescription, NodeStatusFilter, PagedQueryDescription},
 };
 
 #[tokio::test]
 async fn test_fabric_client() {
-    let c = FabricClientBuilder::new().build();
+    let c = FabricClient::builder().build();
     let qc = c.get_query_manager();
     let timeout = Duration::from_secs(1);
     let paging_status;

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -320,8 +320,7 @@ mod tests {
     impl FabricQueryClient {
         pub fn new() -> FabricQueryClient {
             FabricQueryClient {
-                com: crate::client::FabricClientBuilder::new()
-                    .build_interface::<IFabricQueryClient>(),
+                com: crate::client::FabricClient::builder().build_interface::<IFabricQueryClient>(),
             }
         }
 
@@ -511,7 +510,7 @@ mod tests {
 
     #[test]
     fn local_client_create() {
-        let _mgmt = crate::client::FabricClientBuilder::new()
+        let _mgmt = crate::client::FabricClient::builder()
             .build_interface::<IFabricClusterManagementClient3>();
     }
 

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -59,8 +59,8 @@ impl From<&ServiceNotificationFilterDescription>
 // FABRIC_CLIENT_ROLE
 #[derive(Debug, PartialEq, Clone)]
 pub enum ClientRole {
-    Unknown, // Do not pass this in SF api, use User instead.
-    User,
+    Unknown, // Default client role.
+    User,    // User client role. Must set client certificate for tls endpoints.
     Admin,
     // ElevatedAdmin not supported by SF 6.x sdk yet.
 }

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -11,7 +11,7 @@ use mssf_core::{
             PartitionKeyType, ResolvedServiceEndpoint, ResolvedServicePartition,
             ServiceEndpointRole, ServicePartitionKind,
         },
-        FabricClient, FabricClientBuilder,
+        FabricClient,
     },
     error::FabricErrorCode,
     types::{
@@ -233,7 +233,7 @@ impl TestClient {
 // Uses fabric client to perform various actions for this service.
 #[tokio::test]
 async fn test_partition_info() {
-    let fc = FabricClientBuilder::new().build();
+    let fc = FabricClient::builder().build();
     let tc = TestClient::new(fc.clone());
     let timeout = Duration::from_secs(1);
 

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -11,7 +11,7 @@ use mssf_core::{
             PartitionKeyType, ResolvedServiceEndpoint, ResolvedServicePartitionInfo,
             ServiceEndpointRole, ServicePartitionKind,
         },
-        FabricClient, FabricClientBuilder, GatewayInformationResult, ServiceNotification,
+        FabricClient, GatewayInformationResult, ServiceNotification,
     },
     error::FabricErrorCode,
     types::{
@@ -120,7 +120,7 @@ async fn test_fabric_client() {
     let (sn_tx, mut sn_rx) = tokio::sync::mpsc::channel::<ServiceNotification>(1);
     // channel for client connection notification
     let (cc_tx, mut cc_rx) = tokio::sync::mpsc::channel::<GatewayInformationResult>(1);
-    let fc = FabricClientBuilder::new()
+    let fc = FabricClient::builder()
         .with_on_service_notification(move |notification| {
             sn_tx
                 .blocking_send(notification.clone())


### PR DESCRIPTION
Previously user client role is set as default, and it requires client cert to be also set.
Default client role should be unknown and no client cert required (or auto selected).
This implementation follows the csharp sdk logic to create fabric client.
