### PR TITLE
[FabricClient] Fix service notification nullptr panic

### DIFF
--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -97,7 +97,8 @@ impl FabricClientBuilder {
     /// Configures the service notification handler.
     /// See details in `register_service_notification_filter` API.
     /// If the service endpoint change matches the registered filter,
-    /// this notification is invoked
+    /// this notification is invoked.
+    ///
     pub fn with_on_service_notification<T>(self, f: T) -> Self
     where
         T: Fn(&ServiceNotification) -> crate::Result<()> + 'static,

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -217,7 +217,11 @@ impl ServiceManagementClient {
     /// pass null for the ResolvedServicePartition argument during resolution.
     /// This will always return the endpoints in the client cache updated by the latest notification.
     /// The notification mechanism itself will keep the client cache updated when service endpoints change.
-    /// TODO: explore the relation to IFabricServiceNotification.
+    ///
+    /// Notification callback is delivered on `FabricClientBuilder::with_on_service_notification` as well.
+    /// The callback contains minimum info only as a signal, user can call resolve_service_partition()
+    /// again to retrieve full info from the cache.
+    ///
     /// This is observed to have 1~4 secs delay compared with brute force complaint based resolve.
     pub async fn register_service_notification_filter(
         &self,


### PR DESCRIPTION
PartitionInfo in IFabricServiceNotification can be nullptr, so we should not unwrap but need to make rust field as optional.