### PR TITLE
[FabricRuntime] impl get code package info from activation context

### DIFF
--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -1,0 +1,99 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::FabricRuntime::IFabricCodePackageActivationContext6;
+
+use crate::{strings::HSTRINGWrap, types::EndpointResourceDesc, Error, HSTRING, PCWSTR};
+
+use super::config::ConfigurationPackage;
+
+pub struct CodePackageActivationContext {
+    com_impl: IFabricCodePackageActivationContext6,
+}
+
+/// Info from the context
+#[derive(Debug, Clone)]
+pub struct CodePackageInfo {
+    pub context_id: HSTRING,
+    pub code_package_name: HSTRING,
+    pub code_package_version: HSTRING,
+    pub work_directory: HSTRING,
+    pub log_directory: HSTRING,
+    pub temp_directory: HSTRING,
+    pub application_name: HSTRING,
+    pub application_type_name: HSTRING,
+    pub service_listen_address: HSTRING,
+    pub service_publish_address: HSTRING,
+}
+
+impl CodePackageActivationContext {
+    pub fn create() -> Result<CodePackageActivationContext, Error> {
+        let com = super::get_com_activation_context::<IFabricCodePackageActivationContext6>()?;
+        Ok(Self::from(com))
+    }
+
+    pub fn get_endpoint_resource(
+        &self,
+        serviceendpointresourcename: &HSTRING,
+    ) -> crate::Result<EndpointResourceDesc> {
+        let rs = unsafe {
+            self.com_impl.GetServiceEndpointResource(PCWSTR::from_raw(
+                serviceendpointresourcename.as_ptr(),
+            ))?
+        };
+        let res_ref = unsafe { rs.as_ref().unwrap() };
+        let desc = EndpointResourceDesc::from(res_ref);
+        Ok(desc)
+    }
+
+    pub fn get_configuration_package(
+        &self,
+        configpackagename: &HSTRING,
+    ) -> crate::Result<ConfigurationPackage> {
+        let c = unsafe { self.com_impl.GetConfigurationPackage(configpackagename) }?;
+        Ok(ConfigurationPackage::from_com(c))
+    }
+
+    pub fn get_code_package_info(&self) -> CodePackageInfo {
+        CodePackageInfo {
+            context_id: HSTRINGWrap::from(unsafe { self.com_impl.get_ContextId() }).into(),
+            code_package_name: HSTRINGWrap::from(unsafe { self.com_impl.get_CodePackageName() })
+                .into(),
+            code_package_version: HSTRINGWrap::from(unsafe {
+                self.com_impl.get_CodePackageVersion()
+            })
+            .into(),
+            work_directory: HSTRINGWrap::from(unsafe { self.com_impl.get_WorkDirectory() }).into(),
+            log_directory: HSTRINGWrap::from(unsafe { self.com_impl.get_LogDirectory() }).into(),
+            temp_directory: HSTRINGWrap::from(unsafe { self.com_impl.get_TempDirectory() }).into(),
+            application_name: HSTRINGWrap::from(PCWSTR(unsafe {
+                self.com_impl.get_ApplicationName().0
+            }))
+            .into(),
+            application_type_name: HSTRINGWrap::from(unsafe {
+                self.com_impl.get_ApplicationTypeName()
+            })
+            .into(),
+            service_listen_address: HSTRINGWrap::from(unsafe {
+                self.com_impl.get_ServiceListenAddress()
+            })
+            .into(),
+            service_publish_address: HSTRINGWrap::from(unsafe {
+                self.com_impl.get_ServicePublishAddress()
+            })
+            .into(),
+        }
+    }
+
+    pub fn get_com(&self) -> IFabricCodePackageActivationContext6 {
+        self.com_impl.clone()
+    }
+}
+
+impl From<IFabricCodePackageActivationContext6> for CodePackageActivationContext {
+    fn from(value: IFabricCodePackageActivationContext6) -> Self {
+        CodePackageActivationContext { com_impl: value }
+    }
+}

--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -13,7 +13,10 @@ pub struct CodePackageActivationContext {
     com_impl: IFabricCodePackageActivationContext6,
 }
 
-/// Info from the context
+/// Code package information is propagated here from the ActivationContext
+/// provided when the service is started. This information can be used to setup
+/// log directories and other resources needed which require information
+/// about the code package and the local runtime environment.
 #[derive(Debug, Clone)]
 pub struct CodePackageInfo {
     pub context_id: HSTRING,

--- a/crates/libs/core/src/types/mod.rs
+++ b/crates/libs/core/src/types/mod.rs
@@ -8,3 +8,5 @@ mod common;
 pub use common::*;
 mod client;
 pub use client::*;
+mod runtime;
+pub use runtime::EndpointResourceDesc;

--- a/crates/libs/core/src/types/runtime/mod.rs
+++ b/crates/libs/core/src/types/runtime/mod.rs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+// Runtime related types.
+
+use mssf_com::FabricTypes::FABRIC_ENDPOINT_RESOURCE_DESCRIPTION;
+
+use crate::HSTRING;
+
+#[derive(Debug)]
+pub struct EndpointResourceDesc {
+    pub name: HSTRING,
+    pub protocol: HSTRING,
+    pub r#type: HSTRING,
+    pub port: u32,
+    pub certificate_name: HSTRING,
+    //pub Reserved: *mut ::core::ffi::c_void,
+}
+
+impl From<&FABRIC_ENDPOINT_RESOURCE_DESCRIPTION> for EndpointResourceDesc {
+    fn from(e: &FABRIC_ENDPOINT_RESOURCE_DESCRIPTION) -> Self {
+        EndpointResourceDesc {
+            name: HSTRING::from_wide(unsafe { e.Name.as_wide() }).unwrap(),
+            protocol: HSTRING::from_wide(unsafe { e.Protocol.as_wide() }).unwrap(),
+            r#type: HSTRING::from_wide(unsafe { e.Type.as_wide() }).unwrap(),
+            port: e.Port,
+            certificate_name: HSTRING::from_wide(unsafe { e.CertificateName.as_wide() }).unwrap(),
+        }
+    }
+}

--- a/crates/libs/core/src/types/runtime/mod.rs
+++ b/crates/libs/core/src/types/runtime/mod.rs
@@ -16,7 +16,6 @@ pub struct EndpointResourceDesc {
     pub r#type: HSTRING,
     pub port: u32,
     pub certificate_name: HSTRING,
-    //pub Reserved: *mut ::core::ffi::c_void,
 }
 
 impl From<&FABRIC_ENDPOINT_RESOURCE_DESCRIPTION> for EndpointResourceDesc {

--- a/crates/samples/echomain-stateful2/src/main.rs
+++ b/crates/samples/echomain-stateful2/src/main.rs
@@ -6,7 +6,7 @@
 use crate::statefulstore::Factory;
 use mssf_core::runtime::{
     executor::{DefaultExecutor, Executor},
-    ActivationContext,
+    CodePackageActivationContext,
 };
 use mssf_core::HSTRING;
 use tracing::info;
@@ -25,7 +25,7 @@ fn main() -> mssf_core::Result<()> {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let e = DefaultExecutor::new(rt.handle().clone());
     let runtime = mssf_core::runtime::Runtime::create(e.clone()).unwrap();
-    let actctx = ActivationContext::create().unwrap();
+    let actctx = CodePackageActivationContext::create().unwrap();
     let endpoint = actctx
         .get_endpoint_resource(&HSTRING::from("KvReplicatorEndpoint"))
         .unwrap();

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -10,7 +10,7 @@ use mssf_core::conf::{Config, FabricConfigSource};
 use mssf_core::debug::wait_for_debugger;
 use mssf_core::runtime::executor::{DefaultExecutor, Executor};
 use mssf_core::runtime::node_context::NodeContext;
-use mssf_core::runtime::ActivationContext;
+use mssf_core::runtime::CodePackageActivationContext;
 use mssf_core::HSTRING;
 use tracing::{error, info};
 
@@ -39,10 +39,13 @@ fn main() -> mssf_core::Result<()> {
     if has_debug_arg() {
         wait_for_debugger();
     }
-    let actctx = ActivationContext::create().inspect_err(|e| {
+    let actctx = CodePackageActivationContext::create().inspect_err(|e| {
         error!("Fail to create activation context: {e}");
     })?;
     validate_configs(&actctx);
+
+    let code_info = actctx.get_code_package_info();
+    info!("code package info: {:?}", code_info);
 
     // get listening port
     let endpoint = actctx
@@ -70,7 +73,7 @@ fn main() -> mssf_core::Result<()> {
 }
 
 // validates the configs in the config package have the right values.
-fn validate_configs(actctx: &ActivationContext) {
+fn validate_configs(actctx: &CodePackageActivationContext) {
     // loop and print all configs
     let config = actctx
         .get_configuration_package(&HSTRING::from("Config"))

--- a/crates/samples/kvstore/src/main.rs
+++ b/crates/samples/kvstore/src/main.rs
@@ -3,7 +3,7 @@ use mssf_core::{
     debug::wait_for_debugger,
     runtime::{
         executor::{DefaultExecutor, Executor},
-        ActivationContext,
+        CodePackageActivationContext,
     },
 };
 use tracing::info;
@@ -32,7 +32,7 @@ fn main() -> mssf_core::Result<()> {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let e = DefaultExecutor::new(rt.handle().clone());
     let runtime = mssf_core::runtime::Runtime::create(e.clone()).unwrap();
-    let actctx = ActivationContext::create().unwrap();
+    let actctx = CodePackageActivationContext::create().unwrap();
     let endpoint = actctx
         .get_endpoint_resource(&HSTRING::from("KvReplicatorEndpoint"))
         .unwrap();

--- a/crates/samples/no_default_features/src/lib.rs
+++ b/crates/samples/no_default_features/src/lib.rs
@@ -10,11 +10,11 @@
 //!
 //! This sample demonstrates it is possible to use the library with default-features = false and ensures that that scenario remains compiling as PRs go into the repository.
 //!
-use mssf_core::runtime::ActivationContext;
+use mssf_core::runtime::CodePackageActivationContext;
 #[no_mangle]
 fn test_fn() {
     // Make sure we link something
     //
-    let my_ctx = ActivationContext::create();
+    let my_ctx = CodePackageActivationContext::create();
     my_ctx.unwrap();
 }


### PR DESCRIPTION
code package info like work dir, log dir etc can be retrieved from activation context.
activation context is refactored to separate mod.