### PR TITLE
Implement GetPartitionLoadInformation API for FabricQueryClient

### DIFF
--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -1,0 +1,127 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Module that defines metrics-related types through FabricClient
+
+use std::time::SystemTime;
+
+use mssf_com::{
+    FabricClient::IFabricGetPartitionLoadInformationResult, FabricTypes::FABRIC_LOAD_METRIC_REPORT,
+};
+use windows_core::HSTRING;
+
+use crate::{
+    iter::{FabricIter, FabricListAccessor},
+    strings::HSTRINGWrap,
+};
+
+/// Wrapper for FABRIC_LOAD_METRIC_REPORT
+#[derive(Debug, Clone)]
+pub struct LoadMetricReport {
+    pub name: HSTRING,
+    pub value: u32,
+    pub last_reported_utc: std::time::SystemTime,
+}
+
+impl From<&FABRIC_LOAD_METRIC_REPORT> for LoadMetricReport {
+    fn from(value: &FABRIC_LOAD_METRIC_REPORT) -> Self {
+        Self {
+            name: HSTRINGWrap::from(value.Name).into(),
+            value: value.Value,
+            last_reported_utc: SystemTime::UNIX_EPOCH, // TODO: convert Win32 FILETIME to SystemTime in Unix or Win32 depending on the platform
+        }
+    }
+}
+
+/// Wrapper of the load metric report list from the primary replica of the partition
+pub struct PrimaryLoadMetricReportList {
+    com: IFabricGetPartitionLoadInformationResult,
+}
+
+impl FabricListAccessor<FABRIC_LOAD_METRIC_REPORT> for PrimaryLoadMetricReportList {
+    fn get_count(&self) -> u32 {
+        unsafe {
+            self.com
+                .get_PartitionLoadInformation()
+                .as_ref()
+                .unwrap()
+                .PrimaryLoadMetricReports
+                .as_ref()
+                .unwrap()
+                .Count
+        }
+    }
+
+    fn get_first_item(&self) -> *const FABRIC_LOAD_METRIC_REPORT {
+        unsafe {
+            self.com
+                .get_PartitionLoadInformation()
+                .as_ref()
+                .unwrap()
+                .PrimaryLoadMetricReports
+                .as_ref()
+                .unwrap()
+                .Items
+        }
+    }
+}
+
+impl PrimaryLoadMetricReportList {
+    pub fn new(com: IFabricGetPartitionLoadInformationResult) -> Self {
+        Self { com }
+    }
+
+    pub fn iter(&self) -> PrimaryLoadMetricReportListIter {
+        PrimaryLoadMetricReportListIter::new(self, self)
+    }
+}
+
+/// Wrapper of the load metric report list from the secondary replicas of the partition
+pub struct SecondaryLoadMetricReportList {
+    com: IFabricGetPartitionLoadInformationResult,
+}
+
+impl FabricListAccessor<FABRIC_LOAD_METRIC_REPORT> for SecondaryLoadMetricReportList {
+    fn get_count(&self) -> u32 {
+        unsafe {
+            self.com
+                .get_PartitionLoadInformation()
+                .as_ref()
+                .unwrap()
+                .SecondaryLoadMetricReports
+                .as_ref()
+                .unwrap()
+                .Count
+        }
+    }
+
+    fn get_first_item(&self) -> *const FABRIC_LOAD_METRIC_REPORT {
+        unsafe {
+            self.com
+                .get_PartitionLoadInformation()
+                .as_ref()
+                .unwrap()
+                .SecondaryLoadMetricReports
+                .as_ref()
+                .unwrap()
+                .Items
+        }
+    }
+}
+
+impl SecondaryLoadMetricReportList {
+    pub fn new(com: IFabricGetPartitionLoadInformationResult) -> Self {
+        Self { com }
+    }
+
+    pub fn iter(&self) -> SecondaryLoadMetricReportListIter {
+        SecondaryLoadMetricReportListIter::new(self, self)
+    }
+}
+
+type PrimaryLoadMetricReportListIter<'a> =
+    FabricIter<'a, FABRIC_LOAD_METRIC_REPORT, LoadMetricReport, PrimaryLoadMetricReportList>;
+type SecondaryLoadMetricReportListIter<'a> =
+    FabricIter<'a, FABRIC_LOAD_METRIC_REPORT, LoadMetricReport, SecondaryLoadMetricReportList>;

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-// This mod contains fabric client related types
-mod partition;
 use mssf_com::FabricTypes::{
     FABRIC_CLIENT_ROLE, FABRIC_CLIENT_ROLE_ADMIN, FABRIC_CLIENT_ROLE_UNKNOWN,
     FABRIC_CLIENT_ROLE_USER, FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
@@ -12,12 +10,16 @@ use mssf_com::FabricTypes::{
     FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS_NONE,
     FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS_PRIMARY_ONLY, FABRIC_URI,
 };
+
+// This mod contains fabric client related types
+mod partition;
 pub use partition::*;
 mod node;
 pub use node::*;
 mod replica;
 use crate::HSTRING;
 pub use replica::*;
+mod metrics;
 
 // FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS
 bitflags::bitflags! {

--- a/crates/libs/core/src/types/common/metrics.rs
+++ b/crates/libs/core/src/types/common/metrics.rs
@@ -3,12 +3,13 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-// mod for handling fabric metrics
+//! Module for handling fabric metrics
+
 use crate::{HSTRING, PCWSTR};
 use mssf_com::FabricTypes::FABRIC_LOAD_METRIC;
 use std::marker::PhantomData;
 
-// FABRIC_LOAD_METRIC
+/// FABRIC_LOAD_METRIC
 pub struct LoadMetric {
     // TODO: support static string without heap allocation
     pub name: HSTRING,
@@ -32,8 +33,7 @@ impl From<&LoadMetric> for FABRIC_LOAD_METRIC {
     }
 }
 
-/// Temporary type to hold the buffer of raw metrics
-/// passed into SF api.
+/// Temporary type to hold the buffer of raw metrics passed into Service Fabric API call.
 pub struct LoadMetricListRef<'a> {
     metrics: Vec<FABRIC_LOAD_METRIC>,
     owner: PhantomData<&'a [LoadMetric]>,

--- a/crates/samples/echomain-stateful2/src/echo.rs
+++ b/crates/samples/echomain-stateful2/src/echo.rs
@@ -67,7 +67,7 @@ async fn echo_loop(listener: TcpListener, token: CancellationToken) -> Result<()
     }
 }
 
-// report load for the app via SF partition api periodically
+/// Report load for the app via SF partition api periodically
 pub async fn report_load_loop(partition: StatefulServicePartition, token: CancellationToken) {
     let mut value = 0;
     let metric_name = HSTRING::from("MyLoad");

--- a/scripts/echomain__stateful_ctl2.sh
+++ b/scripts/echomain__stateful_ctl2.sh
@@ -2,7 +2,7 @@
 
 sfctl application upload --path build/echoapp_root_stateful2
 
-sfctl application provision --application-type-build-path echoapp_root_stateful
+sfctl application provision --application-type-build-path echoapp_root_stateful2
 
 sfctl application create --app-name fabric:/StatefulEchoApp --app-type StatefulEchoApp --app-version 0.0.1
 


### PR DESCRIPTION
Implement FabricQueryClient's BeginPartitionLoadInformation and EndPartitionLoadInformation in Rust.

The two-step async calls are represented as a single async call in Rust called get_partition_load_information.

TODO: The partition's load report structure uses Win32 FILETIME for timestamp. We need to convert the Win32 FILETIME into Rust's SystemTime depending on the platform. The current implementation simply set it to unix epoch.