### PR TITLE
impl compare for ResolvedServicePartition

### DIFF
--- a/crates/libs/core/src/client/notification.rs
+++ b/crates/libs/core/src/client/notification.rs
@@ -127,15 +127,7 @@ impl PartialOrd for ServiceEndpointsVersion {
     /// a is newer and up to date.
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match self.compare(other) {
-            Ok(i) => {
-                if i == 0 {
-                    Some(std::cmp::Ordering::Equal)
-                } else if i > 0 {
-                    Some(std::cmp::Ordering::Greater)
-                } else {
-                    Some(std::cmp::Ordering::Less)
-                }
-            }
+            Ok(i) => Some(i.cmp(&0)),
             // If you compare version of different service you get error
             Err(_) => None,
         }

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -405,6 +405,36 @@ impl ResolvedServicePartition {
     }
 }
 
+impl PartialEq for ResolvedServicePartition {
+    fn eq(&self, other: &Self) -> bool {
+        match self.compare_version(other) {
+            Ok(i) => i == 0,
+            Err(_) => false, // error comparing different services
+        }
+    }
+}
+
+impl PartialOrd for ResolvedServicePartition {
+    /// Compare the version of the resolved result.
+    /// a > b means partial_cmp(a,b) == Some(Greater) i.e. a.compare_version(b) > 0.
+    /// a is newer and up to date.
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.compare_version(other) {
+            Ok(i) => {
+                if i == 0 {
+                    Some(std::cmp::Ordering::Equal)
+                } else if i > 0 {
+                    Some(std::cmp::Ordering::Greater)
+                } else {
+                    Some(std::cmp::Ordering::Less)
+                }
+            }
+            // If you compare version of different service you get error
+            Err(_) => None,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum ServiceEndpointRole {
     Invalid,

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -420,15 +420,7 @@ impl PartialOrd for ResolvedServicePartition {
     /// a is newer and up to date.
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match self.compare_version(other) {
-            Ok(i) => {
-                if i == 0 {
-                    Some(std::cmp::Ordering::Equal)
-                } else if i > 0 {
-                    Some(std::cmp::Ordering::Greater)
-                } else {
-                    Some(std::cmp::Ordering::Less)
-                }
-            }
+            Ok(i) => Some(i.cmp(&0)),
             // If you compare version of different service you get error
             Err(_) => None,
         }


### PR DESCRIPTION
Implement comparison trait for ResolvedServicePartition. U can use operators to compare them instead of calling the compare function.