### PR TITLE
Export LoadMetricReport type to external

### DIFF
--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -20,6 +20,7 @@ mod replica;
 use crate::HSTRING;
 pub use replica::*;
 mod metrics;
+pub use metrics::*;
 
 // FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS
 bitflags::bitflags! {


### PR DESCRIPTION
Previously LoadMetricReport type is introduced but not properly exported for external use. This PR exports the type for external use.