### PR TITLE
Support IFabricReplicatorCatchupSpecificQuorum for replicator

### DIFF
--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -7,8 +7,8 @@ use mssf_core::{
     runtime::{
         executor::{DefaultExecutor, Executor},
         stateful::{
-            PrimaryReplicator, Replicator, StatefulServiceFactory, StatefulServicePartition,
-            StatefulServiceReplica,
+            PrimaryReplicator, Replicator, ReplicatorKind, StatefulServiceFactory,
+            StatefulServicePartition, StatefulServiceReplica,
         },
         stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode},
     },
@@ -241,11 +241,14 @@ impl StatefulServiceReplica for Replica {
         openmode: OpenMode,
         partition: &StatefulServicePartition,
         _: CancellationToken,
-    ) -> mssf_core::Result<impl PrimaryReplicator + 'static> {
+    ) -> mssf_core::Result<(impl PrimaryReplicator, ReplicatorKind)> {
         // should be primary replicator
         info!("Replica::open {:?}", openmode);
         self.svc.start_loop_in_background(partition);
-        Ok(AppFabricReplicator::new(self.port_, self.hostname_.clone()))
+        Ok((
+            AppFabricReplicator::new(self.port_, self.hostname_.clone()),
+            ReplicatorKind::CatchupSpecificQuorum,
+        ))
     }
     async fn change_role(
         &self,

--- a/crates/samples/kvstore/src/kvstore.rs
+++ b/crates/samples/kvstore/src/kvstore.rs
@@ -10,7 +10,7 @@ use mssf_core::{
     runtime::{
         executor::{DefaultExecutor, Executor},
         stateful::{
-            PrimaryReplicator, StatefulServiceFactory, StatefulServicePartition,
+            PrimaryReplicator, ReplicatorKind, StatefulServiceFactory, StatefulServicePartition,
             StatefulServiceReplica,
         },
         stateful_proxy::StatefulServiceReplicaProxy,
@@ -189,7 +189,7 @@ impl StatefulServiceReplica for Replica {
         openmode: OpenMode,
         partition: &StatefulServicePartition,
         cancellation_token: CancellationToken,
-    ) -> mssf_core::Result<impl PrimaryReplicator> {
+    ) -> mssf_core::Result<(impl PrimaryReplicator, ReplicatorKind)> {
         // should be primary replicator
         info!("Replica::open {:?}", openmode);
         self.kv.open(openmode, partition, cancellation_token).await


### PR DESCRIPTION
This makes the replicator bridge overly complicated.
I may not complete this PR. The easier change is to force IFabricReplicatorCatchupSpecificQuorum for all replicators in rust. All known replicators in cpp all implement this.

#86 