### PR TITLE
Support catchup_specific_quorum for PrimaryReplicator

### DIFF
--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -36,8 +36,6 @@ pub trait StatefulServiceFactory {
 pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
     /// Opens an initialized service replica so that additional actions can be taken.
     /// Returns PrimaryReplicator that is used by the stateful service.
-    // Note: we use async trait and cannot use dynamic dispatch to build a similar
-    // interface hierachy for COM objects. The return type is subject to change in future.
     async fn open(
         &self,
         openmode: OpenMode,
@@ -153,7 +151,3 @@ pub trait LocalPrimaryReplicator: Replicator {
     ) -> crate::Result<()>;
     fn remove_replica(&self, replicaid: i64) -> crate::Result<()>;
 }
-
-// IFabricReplicatorCatchupSpecificQuorum
-// replicator is checked to have this interface
-// implemented: https://github.com/microsoft/service-fabric/blob/9d25e17d9e19ca46bbd1142bfcbae8416ba45e61/src/prod/src/Reliability/Failover/ra/ComProxyReplicator.h#L25

--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -4,14 +4,14 @@
 // ------------------------------------------------------------
 
 // stateful contains rs definition of stateful traits that user needs to implement
-
-use crate::{GUID, HSTRING};
 use mssf_com::FabricRuntime::IFabricStatefulServicePartition;
 
 use crate::sync::CancellationToken;
 use crate::types::{LoadMetric, LoadMetricListRef, ReplicaRole};
 
-use super::stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode};
+use super::stateful_types::{
+    Epoch, OpenMode, ReplicaInformation, ReplicaSetConfig, ReplicaSetQuarumMode,
+};
 
 /// Represents a stateful service factory that is responsible for creating replicas
 /// of a specific type of stateful service. Stateful service factories are registered with
@@ -20,10 +20,10 @@ pub trait StatefulServiceFactory {
     /// Called by Service Fabric to create a stateful service replica for a particular service.
     fn create_replica(
         &self,
-        servicetypename: &HSTRING,
-        servicename: &HSTRING,
+        servicetypename: &crate::HSTRING,
+        servicename: &crate::HSTRING,
         initializationdata: &[u8],
-        partitionid: &GUID,
+        partitionid: &crate::GUID,
         replicaid: i64,
     ) -> crate::Result<impl StatefulServiceReplica>;
 }
@@ -36,6 +36,8 @@ pub trait StatefulServiceFactory {
 pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
     /// Opens an initialized service replica so that additional actions can be taken.
     /// Returns PrimaryReplicator that is used by the stateful service.
+    // Note: we use async trait and cannot use dynamic dispatch to build a similar
+    // interface hierachy for COM objects. The return type is subject to change in future.
     async fn open(
         &self,
         openmode: OpenMode,
@@ -54,7 +56,7 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
         &self,
         newrole: ReplicaRole,
         cancellation_token: CancellationToken,
-    ) -> crate::Result<HSTRING>;
+    ) -> crate::Result<crate::HSTRING>;
 
     /// Closes the service replica gracefully when it is being shut down.
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
@@ -95,7 +97,7 @@ impl From<&IFabricStatefulServicePartition> for StatefulServicePartition {
 /// TODO: replicator has no public documentation
 #[trait_variant::make(Replicator: Send)]
 pub trait LocalReplicator: Send + Sync + 'static {
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<HSTRING>; // replicator address
+    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<crate::HSTRING>; // replicator address
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
     async fn change_role(
         &self,
@@ -123,6 +125,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
 }
 
 /// TODO: primary replicator has no public documentation
+/// IFabricPrimaryReplicator com interface wrapper.
 #[trait_variant::make(PrimaryReplicator: Send)]
 pub trait LocalPrimaryReplicator: Replicator {
     // SF calls this to indicate that possible data loss has occurred (write quorum loss),
@@ -145,8 +148,12 @@ pub trait LocalPrimaryReplicator: Replicator {
     ) -> crate::Result<()>;
     async fn build_replica(
         &self,
-        replica: &ReplicaInfo,
+        replica: &ReplicaInformation,
         cancellation_token: CancellationToken,
     ) -> crate::Result<()>;
     fn remove_replica(&self, replicaid: i64) -> crate::Result<()>;
 }
+
+// IFabricReplicatorCatchupSpecificQuorum
+// replicator is checked to have this interface
+// implemented: https://github.com/microsoft/service-fabric/blob/9d25e17d9e19ca46bbd1142bfcbae8416ba45e61/src/prod/src/Reliability/Failover/ra/ComProxyReplicator.h#L25

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -195,10 +195,6 @@ impl PrimaryReplicatorProxy {
         let parent = ReplicatorProxy::new(com_impl.clone().cast().unwrap());
         PrimaryReplicatorProxy { com_impl, parent }
     }
-
-    pub fn get_com(&self) -> &IFabricPrimaryReplicator {
-        &self.com_impl
-    }
 }
 
 impl Replicator for PrimaryReplicatorProxy {

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -9,7 +9,8 @@
 use std::ffi::c_void;
 
 use mssf_com::FabricRuntime::{
-    IFabricPrimaryReplicator, IFabricReplicator, IFabricStatefulServiceReplica,
+    IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
+    IFabricStatefulServiceReplica,
 };
 use tracing::info;
 use windows_core::{Interface, HSTRING};
@@ -22,7 +23,7 @@ use crate::{
 
 use super::{
     stateful::{PrimaryReplicator, Replicator, StatefulServicePartition, StatefulServiceReplica},
-    stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode},
+    stateful_types::{Epoch, OpenMode, ReplicaInformation, ReplicaSetConfig, ReplicaSetQuarumMode},
 };
 
 pub struct StatefulServiceReplicaProxy {
@@ -53,9 +54,20 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
             Some(cancellation_token),
         );
         let rplctr = rx.await??;
+
+        // Check COM interface is implemented.
+        let catchup_specific_quorum = rplctr
+            .cast::<IFabricReplicatorCatchupSpecificQuorum>()
+            .is_ok();
+        assert!(
+            catchup_specific_quorum,
+            "mssf does not support replicator without catchup_specific_quorum interface"
+        );
+
         // TODO: cast without clone will cause access violation on AddRef in SF runtime.
         let p_rplctr: IFabricPrimaryReplicator = rplctr.clone().cast().unwrap(); // must work
                                                                                  // Replicator must impl primary replicator as well.
+
         let res = PrimaryReplicatorProxy::new(p_rplctr);
         Ok(res)
     }
@@ -183,6 +195,10 @@ impl PrimaryReplicatorProxy {
         let parent = ReplicatorProxy::new(com_impl.clone().cast().unwrap());
         PrimaryReplicatorProxy { com_impl, parent }
     }
+
+    pub fn get_com(&self) -> &IFabricPrimaryReplicator {
+        &self.com_impl
+    }
 }
 
 impl Replicator for PrimaryReplicatorProxy {
@@ -272,7 +288,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
     }
     async fn build_replica(
         &self,
-        replica: &ReplicaInfo,
+        replica: &ReplicaInformation,
         cancellation_token: CancellationToken,
     ) -> crate::Result<()> {
         info!("PrimaryReplicatorProxy::build_replica");

--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -10,7 +10,9 @@ use mssf_core::{
             PrimaryReplicator, Replicator, StatefulServiceFactory, StatefulServicePartition,
             StatefulServiceReplica,
         },
-        stateful_types::{Epoch, OpenMode, ReplicaInfo, ReplicaSetConfig, ReplicaSetQuarumMode},
+        stateful_types::{
+            Epoch, OpenMode, ReplicaInformation, ReplicaSetConfig, ReplicaSetQuarumMode,
+        },
     },
     types::ReplicaRole,
 };
@@ -138,7 +140,7 @@ impl PrimaryReplicator for AppFabricReplicator {
 
     async fn build_replica(
         &self,
-        _replica: &ReplicaInfo,
+        _replica: &ReplicaInformation,
         _: CancellationToken,
     ) -> mssf_core::Result<()> {
         info!("AppFabricReplicator2::PrimaryReplicator::build_replica");
@@ -241,7 +243,7 @@ impl StatefulServiceReplica for Replica {
         openmode: OpenMode,
         partition: &StatefulServicePartition,
         _: CancellationToken,
-    ) -> mssf_core::Result<impl PrimaryReplicator + 'static> {
+    ) -> mssf_core::Result<impl PrimaryReplicator> {
         // should be primary replicator
         info!("Replica::open {:?}", openmode);
         self.svc.start_loop_in_background(partition);

--- a/crates/samples/kvstore/manifests/ApplicationManifest.xml
+++ b/crates/samples/kvstore/manifests/ApplicationManifest.xml
@@ -12,7 +12,7 @@
   </ServiceManifestImport>
   <DefaultServices>
     <Service Name="KvStoreService">
-      <StatefulService ServiceTypeName="KvStoreService" TargetReplicaSetSize="1" MinReplicaSetSize="1">
+      <StatefulService ServiceTypeName="KvStoreService" TargetReplicaSetSize="3" MinReplicaSetSize="3">
         <SingletonPartition />
       </StatefulService>
     </Service>


### PR DESCRIPTION
#88 
mssf-core now (only) supports replicator with catchup_specific_quorum enabled. Not enabling this feature has not been seen in any of the existing replicators in cpp or csharp.

See [dotnet](https://learn.microsoft.com/en-us/dotnet/api/system.fabric.ireplicatorcatchupspecificquorum?view=azure-dotnet) for feature documentation.