### PR TITLE
Support reporting app health

### DIFF
--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -98,6 +98,20 @@ impl CodePackageActivationContext {
         }
     }
 
+    /// The health information describes the report details, like the source ID, the property,
+    /// the health state and other relevant details. The code package activation context uses an
+    /// internal health client to send the reports to the health store. The client optimizes messages to
+    /// Health Manager by batching reports per a configured duration (Default: 30 seconds).
+    /// If the report has high priority, you can specify send options to send it immediately.
+    ///
+    /// Possible Errors:
+    ///     FABRIC_E_HEALTH_STALE_REPORT:
+    ///         HealthReport already exist for the same entity,
+    ///         SourceId and Property with same or higher SequenceNumber.
+    ///     FABRIC_E_HEALTH_MAX_REPORTS_REACHED:
+    ///         HeathClient has reached the maximum number of health reports
+    ///         that can accept for processing. More reports will be accepted when progress is done
+    ///         with the currently accepted reports. By default, the FabricClient.HealthClient can accept 10000 different reports.
     pub fn report_application_health(
         &self,
         healthinfo: &HealthInformation,

--- a/crates/libs/core/src/types/common/mod.rs
+++ b/crates/libs/core/src/types/common/mod.rs
@@ -41,6 +41,18 @@ impl From<&FABRIC_HEALTH_STATE> for HealthState {
     }
 }
 
+impl From<&HealthState> for FABRIC_HEALTH_STATE {
+    fn from(value: &HealthState) -> Self {
+        match *value {
+            HealthState::Invalid => FABRIC_HEALTH_STATE_INVALID,
+            HealthState::Ok => FABRIC_HEALTH_STATE_OK,
+            HealthState::Warning => FABRIC_HEALTH_STATE_WARNING,
+            HealthState::Error => FABRIC_HEALTH_STATE_ERROR,
+            HealthState::Unknown => FABRIC_HEALTH_STATE_UNKNOWN,
+        }
+    }
+}
+
 // FABRIC_FAULT_TYPE
 #[derive(Debug, Clone, PartialEq)]
 pub enum FaultType {

--- a/crates/libs/core/src/types/mod.rs
+++ b/crates/libs/core/src/types/mod.rs
@@ -9,4 +9,4 @@ pub use common::*;
 mod client;
 pub use client::*;
 mod runtime;
-pub use runtime::{stateful::*, store::*, EndpointResourceDescription};
+pub use runtime::{health::*, stateful::*, store::*, EndpointResourceDescription};

--- a/crates/libs/core/src/types/runtime/health.rs
+++ b/crates/libs/core/src/types/runtime/health.rs
@@ -1,0 +1,72 @@
+use mssf_com::FabricTypes::{FABRIC_HEALTH_INFORMATION, FABRIC_HEALTH_REPORT_SEND_OPTIONS};
+use windows_core::PCWSTR;
+
+use crate::{strings::HSTRINGWrap, types::HealthState, HSTRING};
+
+pub type SequenceNumber = i64;
+
+/// FABRIC_HEALTH_INFORMATION
+#[derive(Debug, Clone)]
+pub struct HealthInformation {
+    pub source_id: HSTRING,
+    pub property: HSTRING,
+    pub time_to_live_seconds: u32,
+    pub state: HealthState,
+    pub description: HSTRING,
+    pub sequence_number: SequenceNumber,
+    pub remove_when_expired: bool,
+    // TODO: not in rust yet
+    // health_report_id: HSTRING,
+}
+
+impl From<&FABRIC_HEALTH_INFORMATION> for HealthInformation {
+    fn from(value: &FABRIC_HEALTH_INFORMATION) -> Self {
+        Self {
+            source_id: HSTRINGWrap::from(value.SourceId).into(),
+            property: HSTRINGWrap::from(value.Property).into(),
+            time_to_live_seconds: value.TimeToLiveSeconds,
+            state: HealthState::from(&value.State),
+            description: HSTRINGWrap::from(value.Description).into(),
+            sequence_number: value.SequenceNumber,
+            remove_when_expired: value.RemoveWhenExpired.as_bool(),
+        }
+    }
+}
+
+/// Result has the same life time as self.
+impl From<&HealthInformation> for FABRIC_HEALTH_INFORMATION {
+    fn from(value: &HealthInformation) -> Self {
+        Self {
+            SourceId: PCWSTR(value.source_id.as_ptr()),
+            Property: PCWSTR(value.property.as_ptr()),
+            TimeToLiveSeconds: value.time_to_live_seconds,
+            State: (&value.state).into(),
+            Description: PCWSTR(value.description.as_ptr()),
+            SequenceNumber: value.sequence_number,
+            RemoveWhenExpired: value.remove_when_expired.into(),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HealthReportSendOption {
+    pub immediate: bool,
+}
+
+impl From<&FABRIC_HEALTH_REPORT_SEND_OPTIONS> for HealthReportSendOption {
+    fn from(value: &FABRIC_HEALTH_REPORT_SEND_OPTIONS) -> Self {
+        Self {
+            immediate: value.Immediate.into(),
+        }
+    }
+}
+
+impl From<&HealthReportSendOption> for FABRIC_HEALTH_REPORT_SEND_OPTIONS {
+    fn from(value: &HealthReportSendOption) -> Self {
+        Self {
+            Immediate: value.immediate.into(),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}

--- a/crates/libs/core/src/types/runtime/health.rs
+++ b/crates/libs/core/src/types/runtime/health.rs
@@ -5,15 +5,33 @@ use crate::{strings::HSTRINGWrap, types::HealthState, HSTRING};
 
 pub type SequenceNumber = i64;
 
+/// Unknown sequence number, which is an invalid sequence number that is not accepted by the health store.
+pub const UNKNOWN_SEQUENCE_NUMBER: SequenceNumber = -1;
+
+/// When a health client receives a report with Auto sequence number,
+/// it replaces the auto sequence number with a valid sequence number.
+/// The sequence number is guaranteed to increase in the same process.
+pub const AUTO_SEQUENCE_NUMBER: SequenceNumber = 0;
+
 /// FABRIC_HEALTH_INFORMATION
 #[derive(Debug, Clone)]
 pub struct HealthInformation {
+    /// source name which identifies the watchdog/system component which generated the health information.
     pub source_id: HSTRING,
+    /// the property of the health report.
     pub property: HSTRING,
+    /// how long the health report is valid. Must be larger than TimeSpan.Zero.
     pub time_to_live_seconds: u32,
+    /// health state that describes the severity of the monitored condition used for reporting.
     pub state: HealthState,
+    /// description of the health information. It represents free text used to add human readable
+    /// information about the monitored condition.
     pub description: HSTRING,
+    /// sequence number associated with the health information, used by the health store for staleness detection.
+    /// Must be greater than UNKNOWN_SEQUENCE_NUMBER.
     pub sequence_number: SequenceNumber,
+    /// whether the report is removed from health store when it expires.
+    /// If set to false, the report is treated as an error when expired.
     pub remove_when_expired: bool,
     // TODO: not in rust yet
     // health_report_id: HSTRING,

--- a/crates/libs/core/src/types/runtime/mod.rs
+++ b/crates/libs/core/src/types/runtime/mod.rs
@@ -5,6 +5,7 @@
 
 // Runtime related types.
 
+pub mod health;
 pub mod stateful;
 pub mod store;
 


### PR DESCRIPTION
App health can be reported from the activation context.
It shows in the SF health store.
![image](https://github.com/user-attachments/assets/da6fba49-a1a5-4650-b198-5db12004f457)
