### PR TITLE
Rename hstring to wstring

### DIFF
--- a/crates/libs/core/src/client/connection.rs
+++ b/crates/libs/core/src/client/connection.rs
@@ -8,7 +8,7 @@ use mssf_com::FabricClient::{
     IFabricGatewayInformationResult,
 };
 
-use crate::{strings::HSTRINGWrap, types::NodeId};
+use crate::{strings::WStringWrap, types::NodeId};
 
 /// Internal trait that rust code implements that can be bridged into IFabricClientConnectionEventHandler.
 /// Not exposed to user.
@@ -21,20 +21,20 @@ pub trait ClientConnectionEventHandler: 'static {
 /// Traslated from IFabricGatewayInformationResult
 #[derive(Debug, Clone)]
 pub struct GatewayInformationResult {
-    pub node_address: crate::HSTRING,
+    pub node_address: crate::WString,
     pub node_id: NodeId,
     pub node_instance_id: u64,
-    pub node_name: crate::HSTRING,
+    pub node_name: crate::WString,
 }
 
 impl GatewayInformationResult {
     fn from_com(com: &IFabricGatewayInformationResult) -> Self {
         let info = unsafe { com.get_GatewayInformation().as_ref().unwrap() };
         Self {
-            node_address: HSTRINGWrap::from(info.NodeAddress).into(),
+            node_address: WStringWrap::from(info.NodeAddress).into(),
             node_id: info.NodeId.into(),
             node_instance_id: info.NodeInstanceId,
-            node_name: HSTRINGWrap::from(info.NodeName).into(),
+            node_name: WStringWrap::from(info.NodeName).into(),
         }
     }
 }

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -33,7 +33,7 @@ mod tests;
 
 /// Creates FabricClient com object using SF com API.
 fn create_local_client_internal<T: Interface>(
-    connection_strings: Option<&Vec<crate::HSTRING>>,
+    connection_strings: Option<&Vec<crate::WString>>,
     service_notification_handler: Option<&IFabricServiceNotificationEventHandler>,
     client_connection_handler: Option<&IFabricClientConnectionEventHandler>,
     client_role: Option<ClientRole>,
@@ -94,7 +94,7 @@ pub struct FabricClientBuilder {
     sn_handler: Option<IFabricServiceNotificationEventHandler>,
     cc_handler: Option<LambdaClientConnectionNotificationHandler>,
     client_role: ClientRole,
-    connection_strings: Option<Vec<crate::HSTRING>>,
+    connection_strings: Option<Vec<crate::WString>>,
 }
 
 impl Default for FabricClientBuilder {
@@ -175,7 +175,7 @@ impl FabricClientBuilder {
 
     /// Sets the client connection strings.
     /// Example value: localhost:19000
-    pub fn with_connection_strings(mut self, addrs: Vec<crate::HSTRING>) -> Self {
+    pub fn with_connection_strings(mut self, addrs: Vec<crate::WString>) -> Self {
         self.connection_strings = Some(addrs);
         self
     }

--- a/crates/libs/core/src/client/notification.rs
+++ b/crates/libs/core/src/client/notification.rs
@@ -13,7 +13,7 @@ use mssf_com::{
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
     types::ServicePartitionInformation,
 };
 
@@ -30,7 +30,7 @@ pub trait ServiceNotificationEventHandler: 'static {
 /// If endpoint list is empty, the service is removed.
 #[derive(Debug, Clone)]
 pub struct ServiceNotification {
-    pub service_name: crate::HSTRING,
+    pub service_name: crate::WString,
     pub partition_info: Option<ServicePartitionInformation>,
     pub partition_id: crate::GUID,
     pub endpoints: ServiceEndpointList,
@@ -42,7 +42,7 @@ impl ServiceNotification {
         // SF guarantees this is not null.
         let raw = unsafe { com.get_Notification().as_ref().unwrap() };
         Self {
-            service_name: HSTRINGWrap::from(crate::PCWSTR(raw.ServiceName.0)).into(),
+            service_name: WStringWrap::from(crate::PCWSTR(raw.ServiceName.0)).into(),
             partition_info: unsafe {
                 // It is possible for partition info to be null,
                 // that is why we make the field as an option.

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use mssf_com::FabricTypes::FABRIC_E_SERVICE_DOES_NOT_EXIST;
 use tokio_util::sync::CancellationToken;
-use windows_core::HSTRING;
+use windows_core::WString;
 
 use crate::{
     client::{svc_mgmt_client::PartitionKeyType, FabricClient},
@@ -81,7 +81,7 @@ async fn test_fabric_client() {
     {
         let res = smgr
             .resolve_service_partition(
-                &HSTRING::from("fabric:/EchoApp/EchoAppService"),
+                &WString::from("fabric:/EchoApp/EchoAppService"),
                 &PartitionKeyType::None,
                 None,
                 timeout,

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -33,7 +33,7 @@ pub mod sync;
 pub mod types;
 
 // re-export some windows types
-pub use windows_core::{Error, Interface, Result, GUID, HRESULT, HSTRING, PCWSTR};
+pub use windows_core::{Error, Interface, Result, WString, GUID, HRESULT, PCWSTR};
 // Note cannot re-export windows_core::implement because the macro using it has hard coded mod name.
 
 pub use windows_core::Win32::Foundation::BOOLEAN;

--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -9,9 +9,9 @@ use mssf_com::{
 };
 
 use crate::{
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
     types::{EndpointResourceDescription, HealthInformation, HealthReportSendOption},
-    Error, HSTRING, PCWSTR,
+    Error, WString, PCWSTR,
 };
 
 use super::config::ConfigurationPackage;
@@ -27,16 +27,16 @@ pub struct CodePackageActivationContext {
 /// about the code package and the local runtime environment.
 #[derive(Debug, Clone)]
 pub struct CodePackageInfo {
-    pub context_id: HSTRING,
-    pub code_package_name: HSTRING,
-    pub code_package_version: HSTRING,
-    pub work_directory: HSTRING,
-    pub log_directory: HSTRING,
-    pub temp_directory: HSTRING,
-    pub application_name: HSTRING,
-    pub application_type_name: HSTRING,
-    pub service_listen_address: HSTRING,
-    pub service_publish_address: HSTRING,
+    pub context_id: WString,
+    pub code_package_name: WString,
+    pub code_package_version: WString,
+    pub work_directory: WString,
+    pub log_directory: WString,
+    pub temp_directory: WString,
+    pub application_name: WString,
+    pub application_type_name: WString,
+    pub service_listen_address: WString,
+    pub service_publish_address: WString,
 }
 
 impl CodePackageActivationContext {
@@ -47,7 +47,7 @@ impl CodePackageActivationContext {
 
     pub fn get_endpoint_resource(
         &self,
-        serviceendpointresourcename: &HSTRING,
+        serviceendpointresourcename: &WString,
     ) -> crate::Result<EndpointResourceDescription> {
         let rs = unsafe {
             self.com_impl.GetServiceEndpointResource(PCWSTR::from_raw(
@@ -61,7 +61,7 @@ impl CodePackageActivationContext {
 
     pub fn get_configuration_package(
         &self,
-        configpackagename: &HSTRING,
+        configpackagename: &WString,
     ) -> crate::Result<ConfigurationPackage> {
         let c = unsafe {
             self.com_impl
@@ -72,29 +72,29 @@ impl CodePackageActivationContext {
 
     pub fn get_code_package_info(&self) -> CodePackageInfo {
         CodePackageInfo {
-            context_id: HSTRINGWrap::from(unsafe { self.com_impl.get_ContextId() }).into(),
-            code_package_name: HSTRINGWrap::from(unsafe { self.com_impl.get_CodePackageName() })
+            context_id: WStringWrap::from(unsafe { self.com_impl.get_ContextId() }).into(),
+            code_package_name: WStringWrap::from(unsafe { self.com_impl.get_CodePackageName() })
                 .into(),
-            code_package_version: HSTRINGWrap::from(unsafe {
+            code_package_version: WStringWrap::from(unsafe {
                 self.com_impl.get_CodePackageVersion()
             })
             .into(),
-            work_directory: HSTRINGWrap::from(unsafe { self.com_impl.get_WorkDirectory() }).into(),
-            log_directory: HSTRINGWrap::from(unsafe { self.com_impl.get_LogDirectory() }).into(),
-            temp_directory: HSTRINGWrap::from(unsafe { self.com_impl.get_TempDirectory() }).into(),
-            application_name: HSTRINGWrap::from(PCWSTR(unsafe {
+            work_directory: WStringWrap::from(unsafe { self.com_impl.get_WorkDirectory() }).into(),
+            log_directory: WStringWrap::from(unsafe { self.com_impl.get_LogDirectory() }).into(),
+            temp_directory: WStringWrap::from(unsafe { self.com_impl.get_TempDirectory() }).into(),
+            application_name: WStringWrap::from(PCWSTR(unsafe {
                 self.com_impl.get_ApplicationName().0
             }))
             .into(),
-            application_type_name: HSTRINGWrap::from(unsafe {
+            application_type_name: WStringWrap::from(unsafe {
                 self.com_impl.get_ApplicationTypeName()
             })
             .into(),
-            service_listen_address: HSTRINGWrap::from(unsafe {
+            service_listen_address: WStringWrap::from(unsafe {
                 self.com_impl.get_ServiceListenAddress()
             })
             .into(),
-            service_publish_address: HSTRINGWrap::from(unsafe {
+            service_publish_address: WStringWrap::from(unsafe {
                 self.com_impl.get_ServicePublishAddress()
             })
             .into(),

--- a/crates/libs/core/src/runtime/config.rs
+++ b/crates/libs/core/src/runtime/config.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 
 use crate::BOOLEAN;
-use crate::{error::FabricErrorCode, HSTRING};
+use crate::{error::FabricErrorCode, WString};
 use mssf_com::{
     FabricRuntime::IFabricConfigurationPackage,
     FabricTypes::{
@@ -16,7 +16,7 @@ use mssf_com::{
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
 };
 
 #[derive(Debug, Clone)]
@@ -25,10 +25,10 @@ pub struct ConfigurationPackage {
 }
 
 pub struct ConfigurationPackageDesc {
-    pub name: HSTRING,
-    pub service_manifest_name: HSTRING,
-    pub service_manifest_version: HSTRING,
-    pub version: HSTRING,
+    pub name: WString,
+    pub service_manifest_name: WString,
+    pub service_manifest_version: WString,
+    pub version: WString,
 }
 
 pub struct ConfigurationSettings {
@@ -72,10 +72,10 @@ impl ConfigurationPackage {
         let raw = unsafe { self.com.get_Description().as_ref().unwrap() };
 
         ConfigurationPackageDesc {
-            name: HSTRINGWrap::from(raw.Name).into(),
-            service_manifest_name: HSTRINGWrap::from(raw.ServiceManifestName).into(),
-            service_manifest_version: HSTRINGWrap::from(raw.ServiceManifestVersion).into(),
-            version: HSTRINGWrap::from(raw.Version).into(),
+            name: WStringWrap::from(raw.Name).into(),
+            service_manifest_name: WStringWrap::from(raw.ServiceManifestName).into(),
+            service_manifest_version: WStringWrap::from(raw.ServiceManifestVersion).into(),
+            version: WStringWrap::from(raw.Version).into(),
         }
     }
 
@@ -87,12 +87,12 @@ impl ConfigurationPackage {
         }
     }
 
-    pub fn get_path(&self) -> HSTRING {
+    pub fn get_path(&self) -> WString {
         let raw = unsafe { self.com.get_Path() };
-        HSTRINGWrap::from(raw).into()
+        WStringWrap::from(raw).into()
     }
 
-    pub fn get_section(&self, section_name: &HSTRING) -> crate::Result<ConfigurationSection> {
+    pub fn get_section(&self, section_name: &WString) -> crate::Result<ConfigurationSection> {
         let raw = unsafe { self.com.GetSection(section_name.as_pcwstr()) }?;
         let raw_ref = unsafe { raw.as_ref() };
         match raw_ref {
@@ -107,9 +107,9 @@ impl ConfigurationPackage {
 
     pub fn get_value(
         &self,
-        section_name: &HSTRING,
-        parameter_name: &HSTRING,
-    ) -> crate::Result<(HSTRING, bool)> {
+        section_name: &WString,
+        parameter_name: &WString,
+    ) -> crate::Result<(WString, bool)> {
         let mut is_encrypted: BOOLEAN = Default::default();
         let raw = unsafe {
             self.com.GetValue(
@@ -118,12 +118,12 @@ impl ConfigurationPackage {
                 std::ptr::addr_of_mut!(is_encrypted.0),
             )
         }?;
-        Ok((HSTRINGWrap::from(raw).into(), is_encrypted.as_bool()))
+        Ok((WStringWrap::from(raw).into(), is_encrypted.as_bool()))
     }
 
-    pub fn decrypt_value(&self, encryptedvalue: &HSTRING) -> windows_core::Result<HSTRING> {
+    pub fn decrypt_value(&self, encryptedvalue: &WString) -> windows_core::Result<WString> {
         let s = unsafe { self.com.DecryptValue(encryptedvalue.as_pcwstr()) }?;
-        Ok(HSTRINGWrap::from(&s).into())
+        Ok(WStringWrap::from(&s).into())
     }
 }
 
@@ -134,7 +134,7 @@ impl ConfigurationPackage {
 // TODO: find a way to make lifetime work.
 pub struct ConfigurationSection {
     owner: Option<IFabricConfigurationPackage>,
-    pub name: HSTRING,
+    pub name: WString,
     pub parameters: ConfigurationParameterList, // Note: the list has no lifetime tracking
 }
 
@@ -142,7 +142,7 @@ impl From<&FABRIC_CONFIGURATION_SECTION> for ConfigurationSection {
     fn from(value: &FABRIC_CONFIGURATION_SECTION) -> Self {
         Self {
             owner: None,
-            name: HSTRINGWrap::from(value.Name).into(),
+            name: WStringWrap::from(value.Name).into(),
             parameters: ConfigurationParameterList {
                 list: value.Parameters, // TODO: ownership/lifetime escaped here.
             },
@@ -183,9 +183,9 @@ impl FabricListAccessor<FABRIC_CONFIGURATION_PARAMETER> for ConfigurationParamet
 pub struct ConfigurationParameter {
     pub is_encrypted: bool,
     pub must_overrride: bool,
-    pub name: HSTRING,
-    pub value: HSTRING,
-    pub r#type: HSTRING,
+    pub name: WString,
+    pub value: WString,
+    pub r#type: WString,
 }
 
 impl From<&FABRIC_CONFIGURATION_PARAMETER> for ConfigurationParameter {
@@ -196,11 +196,11 @@ impl From<&FABRIC_CONFIGURATION_PARAMETER> for ConfigurationParameter {
                 .unwrap()
         };
         Self {
-            name: HSTRINGWrap::from(value.Name).into(),
+            name: WStringWrap::from(value.Name).into(),
             is_encrypted: value.IsEncrypted.as_bool(),
             must_overrride: value.MustOverride.as_bool(),
-            value: HSTRINGWrap::from(value.Value).into(),
-            r#type: HSTRINGWrap::from(raw1.Type).into(),
+            value: WStringWrap::from(value.Value).into(),
+            r#type: WStringWrap::from(raw1.Type).into(),
         }
     }
 }

--- a/crates/libs/core/src/runtime/error.rs
+++ b/crates/libs/core/src/runtime/error.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::{Error, HRESULT, HSTRING};
+use crate::{Error, WString, HRESULT};
 use mssf_com::FabricCommon::FabricGetLastErrorMessage;
 
 // Fills the error info as string for better debugging.
@@ -18,8 +18,8 @@ pub fn fill_fabric_hresult(code: HRESULT) -> Error {
     } else {
         unsafe { err_str_raw.as_wide() }
     };
-    println!("debug std: {}", HSTRING::from_wide(err_str));
-    Error::new(code, HSTRING::from_wide(err_str).to_string())
+    println!("debug std: {}", WString::from_wide(err_str));
+    Error::new(code, WString::from_wide(err_str).to_string())
 }
 
 pub fn fill_fabric_error(e: Error) -> Error {
@@ -29,12 +29,12 @@ pub fn fill_fabric_error(e: Error) -> Error {
 #[cfg(test)]
 #[cfg(windows)] // linux error propagate is not working yet
 mod test {
-    use crate::{Error, HSTRING};
+    use crate::{Error, WString};
     use mssf_com::FabricTypes::FABRIC_E_GATEWAY_NOT_REACHABLE;
 
     #[test]
     fn test_win_error() {
-        let s = HSTRING::from("MyError");
+        let s = WString::from("MyError");
         let e = Error::new(
             crate::HRESULT(FABRIC_E_GATEWAY_NOT_REACHABLE.0),
             s.clone().to_string(),

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -1,13 +1,13 @@
 use std::time::Duration;
 
-use crate::{Interface, HSTRING};
+use crate::{Interface, WString};
 use mssf_com::FabricRuntime::{
     FabricBeginGetNodeContext, FabricEndGetNodeContext, FabricGetNodeContext,
     IFabricNodeContextResult, IFabricNodeContextResult2,
 };
 
 use crate::{
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
     sync::{fabric_begin_end_proxy2, CancellationToken},
     types::NodeId,
 };
@@ -31,9 +31,9 @@ pub fn get_com_node_context(
 #[derive(Debug)]
 pub struct NodeContext {
     com: IFabricNodeContextResult,
-    pub node_name: HSTRING,
-    pub node_type: HSTRING,
-    pub ip_address_or_fqdn: HSTRING,
+    pub node_name: WString,
+    pub node_type: WString,
+    pub ip_address_or_fqdn: WString,
     pub node_instance_id: u64,
     pub node_id: NodeId,
 }
@@ -58,10 +58,10 @@ impl NodeContext {
     }
 
     // Retrieves the directory path for the directory at node level.
-    pub fn get_directory(&self, logical_directory_name: &HSTRING) -> windows_core::Result<HSTRING> {
+    pub fn get_directory(&self, logical_directory_name: &WString) -> windows_core::Result<WString> {
         let com2 = self.com.cast::<IFabricNodeContextResult2>()?;
         let dir = unsafe { com2.GetDirectory(logical_directory_name.as_pcwstr()) }?;
-        Ok(HSTRINGWrap::from(&dir).into())
+        Ok(WStringWrap::from(&dir).into())
     }
 }
 
@@ -72,9 +72,9 @@ impl From<&IFabricNodeContextResult> for NodeContext {
         let raw_ref = unsafe { raw.as_ref() }.unwrap();
         Self {
             com: value.clone(),
-            node_name: HSTRINGWrap::from(raw_ref.NodeName).into(),
-            node_type: HSTRINGWrap::from(raw_ref.NodeType).into(),
-            ip_address_or_fqdn: HSTRINGWrap::from(raw_ref.IPAddressOrFQDN).into(),
+            node_name: WStringWrap::from(raw_ref.NodeName).into(),
+            node_type: WStringWrap::from(raw_ref.NodeType).into(),
+            ip_address_or_fqdn: WStringWrap::from(raw_ref.IPAddressOrFQDN).into(),
             node_instance_id: raw_ref.NodeInstanceId,
             node_id: raw_ref.NodeId.into(),
         }

--- a/crates/libs/core/src/runtime/runtime_wrapper.rs
+++ b/crates/libs/core/src/runtime/runtime_wrapper.rs
@@ -1,4 +1,4 @@
-use crate::HSTRING;
+use crate::WString;
 /// safe wrapping for runtime
 use mssf_com::FabricRuntime::{
     IFabricRuntime, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory,
@@ -28,7 +28,7 @@ where
 
     pub fn register_stateless_service_factory<F>(
         &self,
-        servicetypename: &HSTRING,
+        servicetypename: &WString,
         factory: F,
     ) -> crate::Result<()>
     where
@@ -45,7 +45,7 @@ where
 
     pub fn register_stateful_service_factory(
         &self,
-        servicetypename: &HSTRING,
+        servicetypename: &WString,
         factory: impl StatefulServiceFactory + 'static,
     ) -> crate::Result<()> {
         let rt_cp = self.rt.clone();

--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -19,8 +19,8 @@ pub trait StatefulServiceFactory {
     /// Called by Service Fabric to create a stateful service replica for a particular service.
     fn create_replica(
         &self,
-        servicetypename: &crate::HSTRING,
-        servicename: &crate::HSTRING,
+        servicetypename: &crate::WString,
+        servicename: &crate::WString,
         initializationdata: &[u8],
         partitionid: &crate::GUID,
         replicaid: i64,
@@ -57,7 +57,7 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
         &self,
         newrole: ReplicaRole,
         cancellation_token: CancellationToken,
-    ) -> crate::Result<crate::HSTRING>;
+    ) -> crate::Result<crate::WString>;
 
     /// Closes the service replica gracefully when it is being shut down.
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
@@ -76,7 +76,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
     /// in ReplicaInformation.
     /// Remarks:
     /// Replicator does not have an assigned role yet and should setup listening endpoint.
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<crate::HSTRING>;
+    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<crate::WString>;
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
 
     /// Change the replicator role.

--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -30,7 +30,7 @@ use mssf_com::{
 };
 
 use crate::{
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
     sync::BridgeContext3,
     types::{Epoch, OpenMode, ReplicaInformation, ReplicaRole, ReplicaSetConfig},
 };
@@ -80,8 +80,8 @@ where
     ) -> crate::Result<IFabricStatefulServiceReplica> {
         debug!("StatefulServiceFactoryBridge::CreateReplica");
         let p_servicename = crate::PCWSTR::from_raw(servicename.0);
-        let h_servicename = HSTRINGWrap::from(p_servicename).into();
-        let h_servicetypename = HSTRINGWrap::from(*servicetypename).into();
+        let h_servicename = WStringWrap::from(p_servicename).into();
+        let h_servicetypename = WStringWrap::from(*servicetypename).into();
         let data = unsafe {
             if !initializationdata.is_null() {
                 std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
@@ -155,7 +155,7 @@ where
             inner
                 .open(token)
                 .await
-                .map(|s| IFabricStringResult::from(HSTRINGWrap::from(s)))
+                .map(|s| IFabricStringResult::from(WStringWrap::from(s)))
         })
     }
 
@@ -591,7 +591,7 @@ where
             inner
                 .change_role(newrole2, token)
                 .await
-                .map(|s| IFabricStringResult::from(HSTRINGWrap::from(s)))
+                .map(|s| IFabricStringResult::from(WStringWrap::from(s)))
         })
     }
 

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -13,11 +13,11 @@ use mssf_com::FabricRuntime::{
     IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
 };
 use tracing::debug;
-use windows_core::{Interface, HSTRING};
+use windows_core::{Interface, WString};
 
 use crate::{
     error::FabricErrorCode,
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
     sync::{fabric_begin_end_proxy2, CancellationToken},
     types::{
         FaultType, LoadMetric, LoadMetricListRef, MoveCost, ReplicaRole,
@@ -77,7 +77,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         &self,
         newrole: ReplicaRole,
         cancellation_token: CancellationToken,
-    ) -> crate::Result<HSTRING> {
+    ) -> crate::Result<WString> {
         // replica address
         debug!("StatefulServiceReplicaProxy::change_role {:?}", newrole);
         let com1 = &self.com_impl;
@@ -88,7 +88,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
             Some(cancellation_token),
         );
         let addr = rx.await??;
-        Ok(HSTRINGWrap::from(&addr).into())
+        Ok(WStringWrap::from(&addr).into())
     }
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
         debug!("StatefulServiceReplicaProxy::close");
@@ -118,7 +118,7 @@ impl ReplicatorProxy {
 }
 
 impl Replicator for ReplicatorProxy {
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<HSTRING> {
+    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<WString> {
         debug!("ReplicatorProxy::open");
         // replicator address
         let com1 = &self.com_impl;
@@ -129,7 +129,7 @@ impl Replicator for ReplicatorProxy {
             Some(cancellation_token),
         );
         let addr = rx.await??;
-        Ok(HSTRINGWrap::from(&addr).into())
+        Ok(WStringWrap::from(&addr).into())
     }
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
         debug!("ReplicatorProxy::close");
@@ -200,7 +200,7 @@ impl PrimaryReplicatorProxy {
 }
 
 impl Replicator for PrimaryReplicatorProxy {
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<HSTRING> {
+    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<WString> {
         self.parent.open(cancellation_token).await
     }
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {

--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -6,7 +6,7 @@
 #![deny(non_snake_case)] // this file is safe rust
 
 use crate::sync::CancellationToken;
-use crate::HSTRING;
+use crate::WString;
 use mssf_com::FabricRuntime::IFabricStatelessServicePartition;
 
 use crate::types::ServicePartitionInformation;
@@ -36,8 +36,8 @@ pub trait StatelessServiceFactory {
     /// Creates a stateless service instance for a particular service. This method is called by Service Fabric.
     fn create_instance(
         &self,
-        servicetypename: &HSTRING,
-        servicename: &HSTRING,
+        servicetypename: &WString,
+        servicename: &WString,
         initializationdata: &[u8],
         partitionid: &crate::GUID,
         instanceid: i64,
@@ -57,7 +57,7 @@ pub trait LocalStatelessServiceInstance: Send + Sync + 'static {
         &self,
         partition: &StatelessServicePartition,
         cancellation_token: CancellationToken,
-    ) -> crate::Result<HSTRING>;
+    ) -> crate::Result<WString>;
 
     /// Closes this service instance gracefully when the service instance is being shut down.
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use crate::{
-    runtime::stateless::StatelessServicePartition, strings::HSTRINGWrap, sync::BridgeContext3,
+    runtime::stateless::StatelessServicePartition, strings::WStringWrap, sync::BridgeContext3,
 };
 use mssf_com::{
     FabricCommon::IFabricStringResult,
@@ -64,8 +64,8 @@ where
         instanceid: i64,
     ) -> crate::Result<IFabricStatelessServiceInstance> {
         debug!("StatelessServiceFactoryBridge::CreateInstance");
-        let h_servicename = HSTRINGWrap::from(crate::PCWSTR(servicename.0)).into();
-        let h_servicetypename = HSTRINGWrap::from(*servicetypename).into();
+        let h_servicename = WStringWrap::from(crate::PCWSTR(servicename.0)).into();
+        let h_servicetypename = WStringWrap::from(*servicetypename).into();
         let data = unsafe {
             if !initializationdata.is_null() {
                 std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
@@ -135,7 +135,7 @@ where
             inner
                 .open(&partition_bridge, token)
                 .await
-                .map(|s| IFabricStringResult::from(HSTRINGWrap::from(s)))
+                .map(|s| IFabricStringResult::from(WStringWrap::from(s)))
         })
     }
 

--- a/crates/libs/core/src/runtime/store.rs
+++ b/crates/libs/core/src/runtime/store.rs
@@ -5,7 +5,7 @@
 
 use std::ffi::c_void;
 
-use crate::{Interface, HSTRING, PCWSTR};
+use crate::{Interface, WString, PCWSTR};
 use mssf_com::{
     FabricRuntime::{
         FabricCreateKeyValueStoreReplica, IFabricKeyValueStoreReplica2, IFabricStoreEventHandler,
@@ -28,7 +28,7 @@ impl IFabricStoreEventHandler_Impl for DummyStoreEventHandler_Impl {
 }
 
 pub fn create_com_key_value_store_replica(
-    storename: &HSTRING,
+    storename: &WString,
     partitionid: ::windows_core::GUID,
     replicaid: i64,
     replicatorsettings: &ReplicatorSettings,
@@ -60,65 +60,3 @@ pub fn create_com_key_value_store_replica(
     };
     Ok(unsafe { IFabricKeyValueStoreReplica2::from_raw(raw) })
 }
-
-// This requires intensive mocking.
-// #[cfg(test)]
-// mod test {
-//     use fabric_base::FabricCommon::FabricRuntime::{
-//         IFabricStatefulServiceReplica, IFabricStoreEventHandler,
-//     };
-//     use windows_core::{ComInterface, GUID, HSTRING};
-
-//     use crate::runtime::{
-//         proxy::{KVStoreProxy, StatefulServiceReplicaProxy},
-//         store::EseLocalStoreSettings,
-//     };
-
-//     use super::{create_com_key_value_store_replica, DummyStoreEventHandler, ReplicatorSettings};
-
-//     // mock the partition
-
-//     #[tokio::test]
-//     async fn test_kvstore_local() {
-//         let mut db_dir = std::env::temp_dir();
-//         db_dir.push("sfkvtest");
-//         // create db dir
-//         std::fs::create_dir_all(&db_dir).unwrap();
-
-//         let name = HSTRING::from("mykvstore");
-//         let guid = GUID::new().unwrap();
-//         let settings = ReplicatorSettings::default();
-//         let local_settings = EseLocalStoreSettings {
-//             DbFolderPath: HSTRING::from(db_dir.to_str().unwrap()),
-//             ..Default::default()
-//         };
-//         let evHander: IFabricStoreEventHandler = DummyStoreEventHandler {}.into();
-//         let kv = create_com_key_value_store_replica(
-//             &name,
-//             guid,
-//             123,
-//             &settings,
-//             super::LocalStoreKind::Ese,
-//             Some(&local_settings),
-//             &evHander,
-//         )
-//         .unwrap();
-
-//         let kv_replica: IFabricStatefulServiceReplica = kv.clone().cast().unwrap();
-//         let _proxy = StatefulServiceReplicaProxy::new(kv_replica);
-
-//         //proxy.open(OpenMode::New, partition);
-
-//         let kv_proxy = KVStoreProxy::new(kv);
-//         let tx = kv_proxy.create_transaction().unwrap();
-//         kv_proxy
-//             .add(
-//                 &tx,
-//                 HSTRING::from("mykey").as_wide(),
-//                 String::from("myval").as_bytes(),
-//             )
-//             .unwrap();
-//         // clean up
-//         std::fs::remove_dir_all(&db_dir).unwrap()
-//     }
-// }

--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -10,17 +10,17 @@ use std::time::SystemTime;
 use mssf_com::{
     FabricClient::IFabricGetPartitionLoadInformationResult, FabricTypes::FABRIC_LOAD_METRIC_REPORT,
 };
-use windows_core::HSTRING;
+use windows_core::WString;
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
 };
 
 /// Wrapper for FABRIC_LOAD_METRIC_REPORT
 #[derive(Debug, Clone)]
 pub struct LoadMetricReport {
-    pub name: HSTRING,
+    pub name: WString,
     pub value: u32,
     pub last_reported_utc: std::time::SystemTime,
 }
@@ -28,7 +28,7 @@ pub struct LoadMetricReport {
 impl From<&FABRIC_LOAD_METRIC_REPORT> for LoadMetricReport {
     fn from(value: &FABRIC_LOAD_METRIC_REPORT) -> Self {
         Self {
-            name: HSTRINGWrap::from(value.Name).into(),
+            name: WStringWrap::from(value.Name).into(),
             value: value.Value,
             last_reported_utc: SystemTime::UNIX_EPOCH, // TODO: convert Win32 FILETIME to SystemTime in Unix or Win32 depending on the platform
         }

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -17,7 +17,7 @@ pub use partition::*;
 mod node;
 pub use node::*;
 mod replica;
-use crate::HSTRING;
+use crate::WString;
 pub use replica::*;
 mod metrics;
 pub use metrics::*;
@@ -41,7 +41,7 @@ impl From<&ServiceNotificationFilterFlags> for FABRIC_SERVICE_NOTIFICATION_FILTE
 // FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION
 #[derive(Debug, Clone)]
 pub struct ServiceNotificationFilterDescription {
-    pub name: HSTRING,
+    pub name: WString,
     pub flags: ServiceNotificationFilterFlags,
 }
 

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -3,10 +3,10 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::HSTRING;
+use crate::WString;
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
 };
 use bitflags::bitflags;
 use mssf_com::{
@@ -23,20 +23,20 @@ use mssf_com::{
 };
 
 pub struct PagingStatus {
-    pub continuation_token: HSTRING,
+    pub continuation_token: WString,
 }
 
 impl From<&FABRIC_PAGING_STATUS> for PagingStatus {
     fn from(value: &FABRIC_PAGING_STATUS) -> Self {
         Self {
-            continuation_token: HSTRINGWrap::from(value.ContinuationToken).into(),
+            continuation_token: WStringWrap::from(value.ContinuationToken).into(),
         }
     }
 }
 
 #[derive(Default, Debug)]
 pub struct PagedQueryDescription {
-    pub continuation_token: Option<HSTRING>,
+    pub continuation_token: Option<WString>,
     pub max_results: Option<i32>,
 }
 
@@ -63,7 +63,7 @@ impl Default for NodeStatusFilter {
 
 #[derive(Default, Debug)]
 pub struct NodeQueryDescription {
-    pub node_name_filter: Option<HSTRING>,
+    pub node_name_filter: Option<WString>,
     pub node_status_filter: NodeStatusFilter,
     pub paged_query: PagedQueryDescription,
 }
@@ -103,17 +103,17 @@ type NodeListIter<'a> = FabricIter<'a, FABRIC_NODE_QUERY_RESULT_ITEM, Node, Node
 
 #[derive(Debug)]
 pub struct Node {
-    pub name: HSTRING,
-    pub ip_address_or_fqdn: HSTRING,
-    pub node_type: HSTRING,
-    pub code_version: HSTRING,
-    pub config_version: HSTRING,
+    pub name: WString,
+    pub ip_address_or_fqdn: WString,
+    pub node_type: WString,
+    pub code_version: WString,
+    pub config_version: WString,
     // pub node_status
     pub node_up_time_in_seconds: i64,
     // pub AggregatedHealthState
     pub is_seed_node: bool,
-    pub upgrade_domain: HSTRING,
-    pub fault_domain: HSTRING,
+    pub upgrade_domain: WString,
+    pub fault_domain: WString,
     pub node_instance_id: u64,
 }
 
@@ -132,15 +132,15 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for Node {
                 .unwrap()
         };
         Node {
-            name: HSTRINGWrap::from(raw.NodeName).into(),
-            ip_address_or_fqdn: HSTRINGWrap::from(raw.IpAddressOrFQDN).into(),
-            node_type: HSTRINGWrap::from(raw.NodeType).into(),
-            code_version: HSTRINGWrap::from(raw.CodeVersion).into(),
-            config_version: HSTRINGWrap::from(raw.ConfigVersion).into(),
+            name: WStringWrap::from(raw.NodeName).into(),
+            ip_address_or_fqdn: WStringWrap::from(raw.IpAddressOrFQDN).into(),
+            node_type: WStringWrap::from(raw.NodeType).into(),
+            code_version: WStringWrap::from(raw.CodeVersion).into(),
+            config_version: WStringWrap::from(raw.ConfigVersion).into(),
             node_up_time_in_seconds: raw.NodeUpTimeInSeconds,
             is_seed_node: raw.IsSeedNode.as_bool(),
-            upgrade_domain: HSTRINGWrap::from(raw.UpgradeDomain).into(),
-            fault_domain: HSTRINGWrap::from(windows_core::PCWSTR(raw.FaultDomain.0)).into(),
+            upgrade_domain: WStringWrap::from(raw.UpgradeDomain).into(),
+            fault_domain: WStringWrap::from(windows_core::PCWSTR(raw.FaultDomain.0)).into(),
             node_instance_id: raw2.NodeInstanceId,
         }
     }

--- a/crates/libs/core/src/types/client/partition.rs
+++ b/crates/libs/core/src/types/client/partition.rs
@@ -19,7 +19,7 @@ use mssf_com::{
         FABRIC_STATELESS_SERVICE_PARTITION_QUERY_RESULT_ITEM, FABRIC_URI,
     },
 };
-use windows_core::{GUID, HSTRING};
+use windows_core::{WString, GUID};
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
@@ -31,7 +31,7 @@ use super::metrics::{PrimaryLoadMetricReportList, SecondaryLoadMetricReportList}
 // Partition related types
 // FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION
 pub struct ServicePartitionQueryDescription {
-    pub service_name: HSTRING,
+    pub service_name: WString,
     pub partition_id_filter: Option<GUID>,
     // TODO: continuation token
 }

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -1,4 +1,4 @@
-use crate::{GUID, HSTRING, PCWSTR};
+use crate::{WString, GUID, PCWSTR};
 use mssf_com::{
     FabricClient::IFabricGetReplicaListResult2,
     FabricTypes::{
@@ -16,7 +16,7 @@ use mssf_com::{
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::HSTRINGWrap,
+    strings::WStringWrap,
     types::{HealthState, ReplicaRole},
 };
 
@@ -110,8 +110,8 @@ pub struct StatefulServiceReplicaQueryResult {
     pub replica_role: ReplicaRole,
     pub replica_status: QueryServiceReplicaStatus,
     pub aggregated_health_state: HealthState,
-    pub replica_address: HSTRING,
-    pub node_name: HSTRING,
+    pub replica_address: WString,
+    pub node_name: WString,
     pub last_in_build_duration_in_seconds: i64,
     // pub Reserved: *mut core::ffi::c_void,
 }
@@ -125,8 +125,8 @@ impl From<&FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM>
             replica_role: (&value.ReplicaRole).into(),
             replica_status: (&value.ReplicaStatus).into(),
             aggregated_health_state: (&value.AggregatedHealthState).into(),
-            replica_address: HSTRINGWrap::from(value.ReplicaAddress).into(),
-            node_name: HSTRINGWrap::from(value.NodeName).into(),
+            replica_address: WStringWrap::from(value.ReplicaAddress).into(),
+            node_name: WStringWrap::from(value.NodeName).into(),
             last_in_build_duration_in_seconds: value.LastInBuildDurationInSeconds,
         }
     }
@@ -163,8 +163,8 @@ pub struct StatelessServiceInstanceQueryResult {
     pub instance_id: i64,
     pub replica_status: QueryServiceReplicaStatus,
     pub aggregated_health_state: HealthState,
-    pub replica_address: HSTRING,
-    pub node_name: HSTRING,
+    pub replica_address: WString,
+    pub node_name: WString,
     pub last_in_build_duration_in_seconds: i64,
     // pub Reserved: *mut core::ffi::c_void,
 }
@@ -177,8 +177,8 @@ impl From<&FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM>
             instance_id: value.InstanceId,
             replica_status: (&value.ReplicaStatus).into(),
             aggregated_health_state: (&value.AggregatedHealthState).into(),
-            replica_address: HSTRINGWrap::from(value.ReplicaAddress).into(),
-            node_name: HSTRINGWrap::from(value.NodeName).into(),
+            replica_address: WStringWrap::from(value.ReplicaAddress).into(),
+            node_name: WStringWrap::from(value.NodeName).into(),
             last_in_build_duration_in_seconds: value.LastInBuildDurationInSeconds,
         }
     }
@@ -186,7 +186,7 @@ impl From<&FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM>
 
 // FABRIC_RESTART_REPLICA_DESCRIPTION
 pub struct RestartReplicaDescription {
-    pub node_name: HSTRING,
+    pub node_name: WString,
     pub partition_id: GUID,
     pub replica_or_instance_id: i64,
 }
@@ -204,7 +204,7 @@ impl From<&RestartReplicaDescription> for FABRIC_RESTART_REPLICA_DESCRIPTION {
 
 // FABRIC_REMOVE_REPLICA_DESCRIPTION
 pub struct RemoveReplicaDescription {
-    pub node_name: HSTRING,
+    pub node_name: WString,
     pub partition_id: GUID,
     pub replica_or_instance_id: i64,
     // TODO: support force flag

--- a/crates/libs/core/src/types/common/metrics.rs
+++ b/crates/libs/core/src/types/common/metrics.rs
@@ -5,7 +5,7 @@
 
 //! Module for handling fabric metrics
 
-use crate::{HSTRING, PCWSTR};
+use crate::{WString, PCWSTR};
 use mssf_com::FabricTypes::{
     FABRIC_LOAD_METRIC, FABRIC_MOVE_COST, FABRIC_MOVE_COST_HIGH, FABRIC_MOVE_COST_LOW,
     FABRIC_MOVE_COST_MEDIUM, FABRIC_MOVE_COST_ZERO,
@@ -15,12 +15,12 @@ use std::marker::PhantomData;
 /// FABRIC_LOAD_METRIC
 pub struct LoadMetric {
     // TODO: support static string without heap allocation
-    pub name: HSTRING,
+    pub name: WString,
     pub value: u32,
 }
 
 impl LoadMetric {
-    pub fn new(name: HSTRING, value: u32) -> Self {
+    pub fn new(name: WString, value: u32) -> Self {
         Self { name, value }
     }
 }

--- a/crates/libs/core/src/types/common/partition.rs
+++ b/crates/libs/core/src/types/common/partition.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::{GUID, HSTRING};
+use crate::{WString, GUID};
 use mssf_com::FabricTypes::{
     FABRIC_INT64_RANGE_PARTITION_INFORMATION, FABRIC_NAMED_PARTITION_INFORMATION,
     FABRIC_SERVICE_PARTITION_ACCESS_STATUS, FABRIC_SERVICE_PARTITION_ACCESS_STATUS_GRANTED,
@@ -16,7 +16,7 @@ use mssf_com::FabricTypes::{
     FABRIC_SERVICE_PARTITION_KIND_SINGLETON, FABRIC_SINGLETON_PARTITION_INFORMATION,
 };
 
-use crate::strings::HSTRINGWrap;
+use crate::strings::WStringWrap;
 
 // FABRIC_SERVICE_PARTITION_INFORMATION
 #[derive(Debug, Clone)]
@@ -42,7 +42,7 @@ pub struct Int64PartitionInfomation {
 #[derive(Debug, Clone)]
 pub struct NamedPartitionInfomation {
     pub id: GUID,
-    pub name: HSTRING,
+    pub name: WString,
 }
 
 impl From<&FABRIC_SINGLETON_PARTITION_INFORMATION> for SingletonPartitionInfomation {
@@ -65,7 +65,7 @@ impl From<&FABRIC_NAMED_PARTITION_INFORMATION> for NamedPartitionInfomation {
     fn from(value: &FABRIC_NAMED_PARTITION_INFORMATION) -> Self {
         Self {
             id: value.Id,
-            name: HSTRINGWrap::from(value.Name).into(),
+            name: WStringWrap::from(value.Name).into(),
         }
     }
 }

--- a/crates/libs/core/src/types/runtime/health.rs
+++ b/crates/libs/core/src/types/runtime/health.rs
@@ -1,7 +1,7 @@
 use mssf_com::FabricTypes::{FABRIC_HEALTH_INFORMATION, FABRIC_HEALTH_REPORT_SEND_OPTIONS};
 use windows_core::PCWSTR;
 
-use crate::{strings::HSTRINGWrap, types::HealthState, HSTRING};
+use crate::{strings::WStringWrap, types::HealthState, WString};
 
 pub type SequenceNumber = i64;
 
@@ -17,16 +17,16 @@ pub const AUTO_SEQUENCE_NUMBER: SequenceNumber = 0;
 #[derive(Debug, Clone)]
 pub struct HealthInformation {
     /// source name which identifies the watchdog/system component which generated the health information.
-    pub source_id: HSTRING,
+    pub source_id: WString,
     /// the property of the health report.
-    pub property: HSTRING,
+    pub property: WString,
     /// how long the health report is valid. Must be larger than TimeSpan.Zero.
     pub time_to_live_seconds: u32,
     /// health state that describes the severity of the monitored condition used for reporting.
     pub state: HealthState,
     /// description of the health information. It represents free text used to add human readable
     /// information about the monitored condition.
-    pub description: HSTRING,
+    pub description: WString,
     /// sequence number associated with the health information, used by the health store for staleness detection.
     /// Must be greater than UNKNOWN_SEQUENCE_NUMBER.
     pub sequence_number: SequenceNumber,
@@ -34,17 +34,17 @@ pub struct HealthInformation {
     /// If set to false, the report is treated as an error when expired.
     pub remove_when_expired: bool,
     // TODO: not in rust yet
-    // health_report_id: HSTRING,
+    // health_report_id: WString,
 }
 
 impl From<&FABRIC_HEALTH_INFORMATION> for HealthInformation {
     fn from(value: &FABRIC_HEALTH_INFORMATION) -> Self {
         Self {
-            source_id: HSTRINGWrap::from(value.SourceId).into(),
-            property: HSTRINGWrap::from(value.Property).into(),
+            source_id: WStringWrap::from(value.SourceId).into(),
+            property: WStringWrap::from(value.Property).into(),
             time_to_live_seconds: value.TimeToLiveSeconds,
             state: HealthState::from(&value.State),
-            description: HSTRINGWrap::from(value.Description).into(),
+            description: WStringWrap::from(value.Description).into(),
             sequence_number: value.SequenceNumber,
             remove_when_expired: value.RemoveWhenExpired.as_bool(),
         }

--- a/crates/libs/core/src/types/runtime/mod.rs
+++ b/crates/libs/core/src/types/runtime/mod.rs
@@ -11,25 +11,25 @@ pub mod store;
 
 use mssf_com::FabricTypes::FABRIC_ENDPOINT_RESOURCE_DESCRIPTION;
 
-use crate::{strings::HSTRINGWrap, HSTRING};
+use crate::{strings::WStringWrap, WString};
 
 #[derive(Debug)]
 pub struct EndpointResourceDescription {
-    pub name: HSTRING,
-    pub protocol: HSTRING,
-    pub r#type: HSTRING,
+    pub name: WString,
+    pub protocol: WString,
+    pub r#type: WString,
     pub port: u32,
-    pub certificate_name: HSTRING,
+    pub certificate_name: WString,
 }
 
 impl From<&FABRIC_ENDPOINT_RESOURCE_DESCRIPTION> for EndpointResourceDescription {
     fn from(e: &FABRIC_ENDPOINT_RESOURCE_DESCRIPTION) -> Self {
         EndpointResourceDescription {
-            name: HSTRINGWrap::from(e.Name).into(),
-            protocol: HSTRINGWrap::from(e.Protocol).into(),
-            r#type: HSTRINGWrap::from(e.Type).into(),
+            name: WStringWrap::from(e.Name).into(),
+            protocol: WStringWrap::from(e.Protocol).into(),
+            r#type: WStringWrap::from(e.Type).into(),
             port: e.Port,
-            certificate_name: HSTRINGWrap::from(e.CertificateName).into(),
+            certificate_name: WStringWrap::from(e.CertificateName).into(),
         }
     }
 }

--- a/crates/libs/core/src/types/runtime/stateful.rs
+++ b/crates/libs/core/src/types/runtime/stateful.rs
@@ -7,7 +7,7 @@
 
 use std::{ffi::c_void, marker::PhantomData};
 
-use crate::{HSTRING, PCWSTR};
+use crate::{WString, PCWSTR};
 use mssf_com::FabricTypes::{
     FABRIC_EPOCH, FABRIC_REPLICA_INFORMATION, FABRIC_REPLICA_INFORMATION_EX1,
     FABRIC_REPLICA_OPEN_MODE, FABRIC_REPLICA_OPEN_MODE_EXISTING, FABRIC_REPLICA_OPEN_MODE_INVALID,
@@ -17,7 +17,7 @@ use mssf_com::FabricTypes::{
     FABRIC_REPLICA_STATUS_INVALID, FABRIC_REPLICA_STATUS_UP,
 };
 
-use crate::{strings::HSTRINGWrap, types::ReplicaRole};
+use crate::{strings::WStringWrap, types::ReplicaRole};
 
 #[derive(Debug)]
 pub enum OpenMode {
@@ -208,7 +208,7 @@ pub struct ReplicaInformation {
     pub id: i64,
     pub role: ReplicaRole,
     pub status: ReplicaStatus,
-    pub replicator_address: HSTRING,
+    pub replicator_address: WString,
     pub current_progress: i64,
     pub catch_up_capability: i64,
     /// indicating whether the replica must be caught up as part of a WaitForQuorumCatchup
@@ -228,7 +228,7 @@ impl From<&FABRIC_REPLICA_INFORMATION> for ReplicaInformation {
             id: r.Id,
             role: (&r.Role).into(),
             status: r.Status.into(),
-            replicator_address: HSTRINGWrap::from(r.ReplicatorAddress).into(),
+            replicator_address: WStringWrap::from(r.ReplicatorAddress).into(),
             current_progress: r.CurrentProgress,
             catch_up_capability: r.CatchUpCapability,
             must_catch_up: must_catchup,
@@ -291,7 +291,7 @@ impl From<ReplicaSetQuorumMode> for FABRIC_REPLICA_SET_QUORUM_MODE {
 mod test {
     use std::ffi::c_void;
 
-    use crate::HSTRING;
+    use crate::WString;
     use mssf_com::FabricTypes::{
         FABRIC_REPLICA_INFORMATION, FABRIC_REPLICA_INFORMATION_EX1, FABRIC_REPLICA_ROLE_PRIMARY,
         FABRIC_REPLICA_STATUS_UP,
@@ -339,7 +339,7 @@ mod test {
             id: 1,
             role: super::ReplicaRole::Primary,
             status: super::ReplicaStatus::Up,
-            replicator_address: HSTRING::from("addr1"),
+            replicator_address: WString::from("addr1"),
             current_progress: 123,
             catch_up_capability: 123,
             must_catch_up: true,
@@ -349,7 +349,7 @@ mod test {
             id: 2,
             role: super::ReplicaRole::ActiveSecondary,
             status: super::ReplicaStatus::Up,
-            replicator_address: HSTRING::from("addr2"),
+            replicator_address: WString::from("addr2"),
             current_progress: 120,
             catch_up_capability: 120,
             must_catch_up: false,

--- a/crates/libs/core/src/types/runtime/store.rs
+++ b/crates/libs/core/src/types/runtime/store.rs
@@ -19,7 +19,7 @@ pub struct ReplicatorSettings {
     pub flags: u32,
     pub retry_interval_milliseconds: u32,
     pub batch_acknowledgement_interval_milliseconds: u32,
-    pub replicator_address: crate::HSTRING,
+    pub replicator_address: crate::WString,
     pub require_service_ack: bool,
     pub initial_replication_queue_size: u32,
     pub max_replication_queue_size: u32,
@@ -65,7 +65,7 @@ impl From<LocalStoreKind> for FABRIC_LOCAL_STORE_KIND {
 #[derive(Default)]
 pub struct EseLocalStoreSettings {
     // FABRIC_ESE_LOCAL_STORE_SETTINGS
-    pub db_folder_path: ::windows_core::HSTRING,
+    pub db_folder_path: ::windows_core::WString,
     pub log_file_size_in_kb: i32,
     pub log_buffer_size_in_kb: i32,
     pub max_cursors: i32,

--- a/crates/samples/client/src/main.rs
+++ b/crates/samples/client/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> mssf_core::Result<()> {
         let node: FABRIC_NODE_QUERY_RESULT_ITEM = unsafe { *node_list };
         println!(
             "node info: name: {}",
-            mssf_core::HSTRING::from(mssf_core::strings::HSTRINGWrap::from(node.NodeName))
+            mssf_core::WString::from(mssf_core::strings::WStringWrap::from(node.NodeName))
         );
     }
 

--- a/crates/samples/echomain-stateful/src/app/echo.rs
+++ b/crates/samples/echomain-stateful/src/app/echo.rs
@@ -7,13 +7,13 @@
 
 use std::io::Error;
 
-use mssf_core::HSTRING;
+use mssf_core::WString;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot::Receiver;
 use tracing::info;
 
-pub fn get_addr(port: u32, hostname: HSTRING) -> String {
+pub fn get_addr(port: u32, hostname: WString) -> String {
     let mut addr = String::new();
     addr.push_str(&hostname.to_string());
     addr.push(':');
@@ -58,7 +58,7 @@ async fn echo_loop(listener: TcpListener) -> Result<(), Error> {
 }
 
 #[tokio::main()]
-pub async fn start_echo(rx: Receiver<()>, port: u32, hostname: HSTRING) -> Result<(), Error> {
+pub async fn start_echo(rx: Receiver<()>, port: u32, hostname: WString) -> Result<(), Error> {
     let addr = get_addr(port, hostname);
 
     let listener = TcpListener::bind(&addr).await?;

--- a/crates/samples/echomain-stateful/src/main.rs
+++ b/crates/samples/echomain-stateful/src/main.rs
@@ -10,7 +10,7 @@ use mssf_com::FabricRuntime::{
     IFabricRuntime,
 };
 use mssf_core::sync::wait::WaitableCallback;
-use mssf_core::{Interface, HSTRING};
+use mssf_core::{Interface, WString};
 use std::sync::mpsc::channel;
 use tracing::info;
 pub mod app;
@@ -55,7 +55,7 @@ fn run_app(runtime: &IFabricRuntime, activation_ctx: &IFabricCodePackageActivati
 
 fn get_port(activation_ctx: &IFabricCodePackageActivationContext) -> u32 {
     info!("trying to get port");
-    let endpoint_name = mssf_core::HSTRING::from("ServiceEndpoint1");
+    let endpoint_name = mssf_core::WString::from("ServiceEndpoint1");
     let endpoint = unsafe {
         activation_ctx
             .GetServiceEndpointResource(endpoint_name.as_pcwstr())
@@ -64,7 +64,7 @@ fn get_port(activation_ctx: &IFabricCodePackageActivationContext) -> u32 {
     unsafe { (*endpoint).Port }
 }
 
-fn get_hostname() -> HSTRING {
+fn get_hostname() -> WString {
     let (token, callback) = WaitableCallback::channel();
 
     let callback_arg = callback
@@ -82,7 +82,7 @@ fn get_hostname() -> HSTRING {
 
     let hostname_raw = unsafe { (*node_ctx).IPAddressOrFQDN };
 
-    let ret = HSTRING::from_wide(unsafe { hostname_raw.as_wide() });
+    let ret = WString::from_wide(unsafe { hostname_raw.as_wide() });
     info!("got hostname: {:?}", ret);
     ret
 }

--- a/crates/samples/echomain-stateful2/src/echo.rs
+++ b/crates/samples/echomain-stateful2/src/echo.rs
@@ -9,14 +9,14 @@ use std::io::Error;
 
 use mssf_core::runtime::stateful_proxy::StatefulServicePartition;
 use mssf_core::types::LoadMetric;
-use mssf_core::HSTRING;
+use mssf_core::WString;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-pub fn get_addr(port: u32, hostname: HSTRING) -> String {
+pub fn get_addr(port: u32, hostname: WString) -> String {
     let mut addr = String::new();
     addr.push_str(&hostname.to_string());
     addr.push(':');
@@ -70,7 +70,7 @@ async fn echo_loop(listener: TcpListener, token: CancellationToken) -> Result<()
 /// Report load for the app via SF partition api periodically
 pub async fn report_load_loop(partition: StatefulServicePartition, token: CancellationToken) {
     let mut value = 0;
-    let metric_name = HSTRING::from("MyLoad");
+    let metric_name = WString::from("MyLoad");
     loop {
         // Default load is 0 set in the manifest.
         // Make report value changing betwen 2 or 1.
@@ -99,7 +99,7 @@ pub async fn report_load_loop(partition: StatefulServicePartition, token: Cancel
 pub async fn start_echo(
     token: CancellationToken,
     port: u32,
-    hostname: HSTRING,
+    hostname: WString,
     partition: StatefulServicePartition,
 ) -> Result<(), Error> {
     let addr = get_addr(port, hostname);

--- a/crates/samples/echomain-stateful2/src/main.rs
+++ b/crates/samples/echomain-stateful2/src/main.rs
@@ -8,7 +8,7 @@ use mssf_core::runtime::{
     executor::{DefaultExecutor, Executor},
     CodePackageActivationContext,
 };
-use mssf_core::HSTRING;
+use mssf_core::WString;
 use tracing::info;
 
 mod echo;
@@ -27,20 +27,20 @@ fn main() -> mssf_core::Result<()> {
     let runtime = mssf_core::runtime::Runtime::create(e.clone()).unwrap();
     let actctx = CodePackageActivationContext::create().unwrap();
     let endpoint = actctx
-        .get_endpoint_resource(&HSTRING::from("KvReplicatorEndpoint"))
+        .get_endpoint_resource(&WString::from("KvReplicatorEndpoint"))
         .unwrap();
     let hostname = get_hostname().expect("cannot get hostname");
 
     let factory = Factory::create(endpoint.port, hostname, e.clone());
     runtime
-        .register_stateful_service_factory(&HSTRING::from("StatefulEchoAppService"), factory)
+        .register_stateful_service_factory(&WString::from("StatefulEchoAppService"), factory)
         .unwrap();
 
     e.run_until_ctrl_c();
     Ok(())
 }
 
-fn get_hostname() -> mssf_core::Result<HSTRING> {
+fn get_hostname() -> mssf_core::Result<WString> {
     let node_ctx = mssf_core::runtime::node_context::NodeContext::get_sync()?;
     Ok(node_ctx.ip_address_or_fqdn)
 }

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -23,7 +23,7 @@ use mssf_core::{
         SingletonPartitionInfomation, StatefulServicePartitionQueryResult,
         StatefulServiceReplicaQueryResult,
     },
-    GUID, HSTRING,
+    WString, GUID,
 };
 
 static SVC_URI: &str = "fabric:/StatefulEchoApp/StatefulEchoAppService";
@@ -31,7 +31,7 @@ static SVC_URI: &str = "fabric:/StatefulEchoApp/StatefulEchoAppService";
 /// Test client for the stateful service
 pub struct TestClient {
     fc: FabricClient,
-    service_uri: HSTRING,
+    service_uri: WString,
     timeout: Duration,
 }
 
@@ -39,7 +39,7 @@ impl TestClient {
     fn new(fc: FabricClient) -> Self {
         Self {
             fc,
-            service_uri: HSTRING::from(SVC_URI),
+            service_uri: WString::from(SVC_URI),
             timeout: Duration::from_secs(1),
         }
     }
@@ -201,7 +201,7 @@ impl TestClient {
         // test get replica info
         let (p, _, _) = self.get_replicas(partition_id).await.unwrap();
         assert_eq!(p.replica_status, QueryServiceReplicaStatus::Ready);
-        assert_ne!(p.node_name, HSTRING::new());
+        assert_ne!(p.node_name, WString::new());
 
         // restart primary
         let desc = RestartReplicaDescription {
@@ -267,13 +267,13 @@ async fn test_partition_info() {
     // test get replica info
     let (p, _, _) = tc.get_replicas(single.id).await.unwrap();
     assert_eq!(p.replica_status, QueryServiceReplicaStatus::Ready);
-    assert_ne!(p.node_name, HSTRING::new());
+    assert_ne!(p.node_name, WString::new());
 
     let mgmt = fc.get_service_manager();
     // register service notification filter
     let filter_handle = {
         let desc = ServiceNotificationFilterDescription {
-            name: HSTRING::from(SVC_URI),
+            name: WString::from(SVC_URI),
             flags: ServiceNotificationFilterFlags::NamePrefix,
         };
         // register takes more than 1 sec.

--- a/crates/samples/echomain/src/echo.rs
+++ b/crates/samples/echomain/src/echo.rs
@@ -7,13 +7,13 @@
 
 use std::io::Error;
 
-use mssf_core::HSTRING;
+use mssf_core::WString;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot::Receiver;
 use tracing::info;
 
-pub fn get_addr(port: u32, hostname: HSTRING) -> String {
+pub fn get_addr(port: u32, hostname: WString) -> String {
     let mut addr = String::new();
     addr.push_str(&hostname.to_string());
     addr.push(':');
@@ -57,7 +57,7 @@ async fn echo_loop(listener: TcpListener) -> Result<(), Error> {
     }
 }
 
-pub async fn start_echo(rx: Receiver<()>, port: u32, hostname: HSTRING) -> Result<(), Error> {
+pub async fn start_echo(rx: Receiver<()>, port: u32, hostname: WString) -> Result<(), Error> {
     let addr = get_addr(port, hostname);
 
     let listener = TcpListener::bind(&addr).await?;

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -13,7 +13,7 @@ use mssf_core::runtime::executor::{DefaultExecutor, Executor};
 use mssf_core::runtime::node_context::NodeContext;
 use mssf_core::runtime::CodePackageActivationContext;
 use mssf_core::types::{HealthInformation, HealthReportSendOption};
-use mssf_core::HSTRING;
+use mssf_core::WString;
 use tracing::{error, info};
 
 use crate::config::MySettings;
@@ -55,7 +55,7 @@ fn main() -> mssf_core::Result<()> {
 
     // get listening port
     let endpoint = actctx
-        .get_endpoint_resource(&HSTRING::from("ServiceEndpoint1"))
+        .get_endpoint_resource(&WString::from("ServiceEndpoint1"))
         .unwrap();
     info!("Get ServiceEndpoint1: {:?}", endpoint);
     let port = endpoint.port;
@@ -71,7 +71,7 @@ fn main() -> mssf_core::Result<()> {
     let runtime = mssf_core::runtime::Runtime::create(e.clone()).unwrap();
     let factory = app::Factory::new(port, hostname, rt.handle().clone());
     runtime
-        .register_stateless_service_factory(&HSTRING::from("EchoAppService"), factory)
+        .register_stateless_service_factory(&WString::from("EchoAppService"), factory)
         .unwrap();
 
     e.run_until_ctrl_c();
@@ -82,7 +82,7 @@ fn main() -> mssf_core::Result<()> {
 fn validate_configs(actctx: &CodePackageActivationContext) {
     // loop and print all configs
     let config = actctx
-        .get_configuration_package(&HSTRING::from("Config"))
+        .get_configuration_package(&WString::from("Config"))
         .unwrap();
     let settings = config.get_settings();
     settings.sections.iter().for_each(|section| {
@@ -96,8 +96,8 @@ fn validate_configs(actctx: &CodePackageActivationContext) {
     // get the required config
     let (v, encrypt) = config
         .get_value(
-            &HSTRING::from("my_config_section"),
-            &HSTRING::from("my_string"),
+            &WString::from("my_config_section"),
+            &WString::from("my_string"),
         )
         .unwrap();
     assert_eq!(v.to_string_lossy(), "Value1");
@@ -124,11 +124,11 @@ fn validate_configs(actctx: &CodePackageActivationContext) {
 /// Send health ok to SF to validate health reporting code
 fn send_health_report(actctx: &CodePackageActivationContext) {
     let healthinfo = HealthInformation {
-        source_id: HSTRING::from("echoapp"),
-        property: HSTRING::from("echo-started"),
+        source_id: WString::from("echoapp"),
+        property: WString::from("echo-started"),
         time_to_live_seconds: 300,
         state: mssf_core::types::HealthState::Ok,
-        description: HSTRING::from("echo app started"),
+        description: WString::from("echo app started"),
         sequence_number: 1,
         remove_when_expired: true,
     };

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -21,7 +21,7 @@ use mssf_core::{
         ServiceReplicaQueryDescription, ServiceReplicaQueryResult, SingletonPartitionInfomation,
         StatelessServiceInstanceQueryResult, StatelessServicePartitionQueryResult,
     },
-    GUID, HSTRING,
+    WString, GUID,
 };
 
 static ECHO_SVC_URI: &str = "fabric:/EchoApp/EchoAppService";
@@ -31,7 +31,7 @@ static RETRY_DURATION_SHORT: Duration = Duration::from_secs(1);
 // Test client for echo server.
 pub struct EchoTestClient {
     fc: FabricClient,
-    service_uri: HSTRING,
+    service_uri: WString,
     timeout: Duration,
 }
 
@@ -39,7 +39,7 @@ impl EchoTestClient {
     pub fn new(fc: FabricClient) -> Self {
         Self {
             fc,
-            service_uri: HSTRING::from(ECHO_SVC_URI),
+            service_uri: WString::from(ECHO_SVC_URI),
             timeout: Duration::from_secs(1),
         }
     }
@@ -141,13 +141,13 @@ async fn test_fabric_client() {
             panic!("client disconnected");
         })
         .with_client_role(mssf_core::types::ClientRole::Unknown)
-        .with_connection_strings(vec![HSTRING::from("localhost:19000")])
+        .with_connection_strings(vec![WString::from("localhost:19000")])
         .build();
 
     let ec = EchoTestClient::new(fc.clone());
 
     let timeout = Duration::from_secs(1);
-    let service_uri = HSTRING::from(ECHO_SVC_URI);
+    let service_uri = WString::from(ECHO_SVC_URI);
 
     // Get partition info
     let (stateless, single) = ec.get_partition().await;
@@ -170,7 +170,7 @@ async fn test_fabric_client() {
         stateless_replica.replica_status,
         QueryServiceReplicaStatus::Ready
     );
-    assert_ne!(stateless_replica.node_name, HSTRING::new());
+    assert_ne!(stateless_replica.node_name, WString::new());
 
     let mgmt = fc.get_service_manager();
     // register service notification filter

--- a/crates/samples/kvstore/src/main.rs
+++ b/crates/samples/kvstore/src/main.rs
@@ -1,4 +1,4 @@
-use mssf_core::HSTRING;
+use mssf_core::WString;
 use mssf_core::{
     debug::wait_for_debugger,
     runtime::{
@@ -34,12 +34,12 @@ fn main() -> mssf_core::Result<()> {
     let runtime = mssf_core::runtime::Runtime::create(e.clone()).unwrap();
     let actctx = CodePackageActivationContext::create().unwrap();
     let endpoint = actctx
-        .get_endpoint_resource(&HSTRING::from("KvReplicatorEndpoint"))
+        .get_endpoint_resource(&WString::from("KvReplicatorEndpoint"))
         .unwrap();
 
     let factory = Factory::create(endpoint.port, e.clone());
     runtime
-        .register_stateful_service_factory(&HSTRING::from("KvStoreService"), factory)
+        .register_stateful_service_factory(&WString::from("KvStoreService"), factory)
         .unwrap();
 
     e.run_until_ctrl_c();


### PR DESCRIPTION
HSTRING was not available on linux anymore and in the previous PR it was rewritten in the mssf-pal crate using rust std lib. This PR renames HSTRING to WString in all places.