### PR TITLE
Remove lld linker option and dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-    "-C", "link-arg=-fuse-ld=lld",
-]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > ./rustup.sh
 RUN chmod u+x ./rustup.sh && ./rustup.sh -y
 
 # more tools for dev
-RUN apt-get install git clang lld -y
+RUN apt-get install git clang -y
 RUN pip install cmake --upgrade
 
 # expose sf shared libs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: apt-get
-      run: sudo apt-get update && sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang lld -y
+      run: sudo apt-get update && sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang -y
 
     - name: install sf
       run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,8 +32,4 @@ cmake --build build --target generate_rust
 cargo run -p tools_api
 ```
 
-## Notes
-1. GCC ld linker has problems with SF .so file so we use lld from LLVM/Clang which is configured in `.cargo/config.toml`
-2. `fabric_pal.so` is needed to be able to provide Windows C functions needed by windows-rs. Code is checked-in in `/bintemp` folder.
-
 


### PR DESCRIPTION
Originally lld was used for linking with SF shared libs due to SF shared libs incompatibility with ld.
Now SF shared libs are dynamically loaded instead of linked, there is no need to use lld anymore.
Removes cargo lld linker option.