### PR TITLE
Fix mssf-com default features

### DIFF
--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -24,7 +24,13 @@ path = "../pal"
 version = "0.0.18"
 
 [features]
-default = ["bundled_libs"]
+default = [
+    "bundled_libs", 
+    "ServiceFabric_FabricClient",
+    "ServiceFabric_FabricCommon",
+    "ServiceFabric_FabricRuntime",
+    "ServiceFabric_FabricTypes"
+]
 bundled_libs = []
 Foundation = []
 # generated features


### PR DESCRIPTION
cargo publish fails when features not enabled.
The fixes were already published to crates.io.
This commit is the 0.0.18 release.
Further fixes will come in future PRs. It is hard to test cargo publish with multiple crates in the same repo.