### PR TITLE
Check crate packaging in ci

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -40,4 +40,4 @@ jobs:
       run: cmake --build build --config ${{ matrix.BUILD_TYPE }}
 
     - name: check crate packaging
-      run: cargo package -p mssf-pal -p mssf-com -p mssf-core
+      run: cargo package -p mssf-pal -p mssf-com -p mssf-core --allow-dirty

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -38,3 +38,6 @@ jobs:
 
     - name: build rust code
       run: cmake --build build --config ${{ matrix.BUILD_TYPE }}
+
+    - name: check crate packaging
+      run: cargo package -p mssf-pal -p mssf-com -p mssf-core

--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -24,14 +24,7 @@ path = "../pal"
 version = "0.0.18"
 
 [features]
-default = [
-    "bundled_libs", 
-    "ServiceFabric_FabricClient",
-    "ServiceFabric_FabricCommon",
-    "ServiceFabric_FabricRuntime",
-    "ServiceFabric_FabricTypes"
-]
-bundled_libs = []
+default = []
 Foundation = []
 # generated features
 ServiceFabric = ["Foundation"]

--- a/crates/libs/com/src/lib.rs
+++ b/crates/libs/com/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod Microsoft;
 
 // expose mod directly
+#[cfg(feature = "ServiceFabric")]
 pub use Microsoft::ServiceFabric::*;
 
 // Special usage for mssf_pal.

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -14,13 +14,12 @@ include = [
 ]
 
 [features]
-default = ["config_source", "tokio_async", "bundled_libs"]
+default = ["config_source", "tokio_async"]
 # Required for a lot of callback functionality.
 # Also requires ctrlc for signal handling
 tokio_async = ["dep:tokio", "dep:tokio-util", "dep:ctrlc"]
 # Config crate required to implement its interface. 
 config_source = ["dep:config"]
-bundled_libs = ["mssf-com/bundled_libs"]
 
 [dependencies]
 tracing.workspace = true
@@ -42,8 +41,7 @@ tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros",
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.59"
 features = [
-    "Win32_System_Kernel", # for debug api
-    "Win32_System_Diagnostics_Debug_Extensions"
+    "Win32_System_Diagnostics_Debug_Extensions" # for debug api
 ]
 
 # treat pal as the windows core.


### PR DESCRIPTION
Cargo publish or package builds crates from clean state and previously caught some bugs.
Enable the check in generate.yml ci to prevent future breaks. This does not prolong overall ci time because it runs in parallel to the build.yaml ci which takes much more time.

All so cleans up the feature usages in mssf. Removing bundled_libs feature since fabric-metadata crate deps has been removed.