### PR TITLE
Add a AutoConfigurationPackageChangeCallbackHandle RAII Type

### DIFF
--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -144,6 +144,8 @@ impl CodePackageActivationContext {
         self.com_impl.clone()
     }
 
+    /// Register a configuration package change handler callback
+    /// Consider using [`AutoConfigurationPackageChangeCallbackHandle::new`] instead of this directly.
     pub fn register_configuration_package_change_handler<T>(
         &self,
         handler: T,


### PR DESCRIPTION
Add a useful RAII type to ensure handle is unregistered when type is dropped.

With more work, it could handle lambdas that aren't 'static too, but leaving that for future.