### PR TITLE
Allow using FabricClient in non-tokio projects and refactor interface.

### DIFF
--- a/crates/libs/core/src/client/health_client.rs
+++ b/crates/libs/core/src/client/health_client.rs
@@ -33,6 +33,10 @@ pub struct HealthClient {
 
 // Public implementation block
 impl HealthClient {
+    pub fn get_com(&self) -> IFabricHealthClient4 {
+        self.com.clone()
+    }
+
     pub fn from_com(com: IFabricHealthClient4) -> Self {
         Self { com: com.clone() }
     }

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -202,21 +202,16 @@ impl FabricClientBuilder {
 // https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Api/src/System/Fabric/FabricClient.cs
 #[derive(Debug, Clone)]
 pub struct FabricClient {
-    com_property_client: IFabricPropertyManagementClient2,
-    com_service_client: IFabricServiceManagementClient6,
-    com_query_client: IFabricQueryClient10,
-    com_health_client: IFabricHealthClient4,
+    property_client: PropertyManagementClient,
+    service_client: ServiceManagementClient,
+    query_client: QueryClient,
+    health_client: HealthClient,
 }
 
 impl FabricClient {
     /// Get a builder
     pub fn builder() -> FabricClientBuilder {
         FabricClientBuilder::new()
-    }
-
-    /// Get a copy of COM object
-    pub fn get_com(&self) -> IFabricPropertyManagementClient2 {
-        self.com_property_client.clone()
     }
 
     /// Creates from com directly. This gives the user freedom to create com from
@@ -231,36 +226,45 @@ impl FabricClient {
         let com_query_client = com.clone().cast::<IFabricQueryClient10>().unwrap();
         let com_health_client = com.clone().cast::<IFabricHealthClient4>().unwrap();
         Self {
-            com_property_client,
-            com_service_client,
-            com_query_client,
-            com_health_client,
+            property_client: PropertyManagementClient::from_com(com_property_client),
+            service_client: ServiceManagementClient::from_com(com_service_client),
+            query_client: QueryClient::from_com(com_query_client),
+            health_client: HealthClient::from_com(com_health_client),
         }
     }
 
     /// Get the client for managing Fabric Properties in Naming Service
-    pub fn get_property_manager(&self) -> PropertyManagementClient {
-        PropertyManagementClient {
-            _com: self.com_property_client.clone(),
-        }
+    pub fn get_property_manager(&self) -> &PropertyManagementClient {
+        &self.property_client
     }
 
     /// Get the client for quering Service Fabric information.
-    pub fn get_query_manager(&self) -> QueryClient {
-        QueryClient::from_com(self.com_query_client.clone())
+    pub fn get_query_manager(&self) -> &QueryClient {
+        &self.query_client
     }
 
     /// Get the client for managing service information and lifecycles.
-    pub fn get_service_manager(&self) -> ServiceManagementClient {
-        ServiceManagementClient::from_com(self.com_service_client.clone())
+    pub fn get_service_manager(&self) -> &ServiceManagementClient {
+        &self.service_client
     }
 
     /// Get the client for get/set Service Fabric health properties.
-    pub fn get_health_manager(&self) -> HealthClient {
-        HealthClient::from_com(self.com_health_client.clone())
+    pub fn get_health_manager(&self) -> &HealthClient {
+        &self.health_client
     }
 }
 
 pub struct PropertyManagementClient {
-    _com: IFabricPropertyManagementClient2,
+    com: IFabricPropertyManagementClient2,
+}
+
+impl PropertyManagementClient {
+    /// Get a copy of COM object
+    pub fn get_com(&self) -> IFabricPropertyManagementClient2 {
+        self.com.clone()
+    }
+
+    fn from_com(com: IFabricPropertyManagementClient2) -> Self {
+        Self { com }
+    }
 }

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -254,6 +254,7 @@ impl FabricClient {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PropertyManagementClient {
     com: IFabricPropertyManagementClient2,
 }

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -41,8 +41,8 @@ pub struct QueryClient {
 // Internal implementation block
 // Internal functions focuses on changing SF callback to async future,
 // while the public apis impl focuses on type conversion.
+#[cfg(feature = "tokio_async")]
 impl QueryClient {
-    #[cfg(feature = "tokio_async")]
     pub fn get_node_list_internal(
         &self,
         query_description: &FABRIC_NODE_QUERY_DESCRIPTION,
@@ -61,7 +61,6 @@ impl QueryClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn get_partition_list_internal(
         &self,
         desc: &FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION,
@@ -79,7 +78,6 @@ impl QueryClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn get_replica_list_internal(
         &self,
         desc: &FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
@@ -97,7 +95,6 @@ impl QueryClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn get_partition_load_information_internal(
         &self,
         desc: &FABRIC_PARTITION_LOAD_INFORMATION_QUERY_DESCRIPTION,
@@ -124,8 +121,10 @@ impl QueryClient {
     pub fn from_com(com: IFabricQueryClient10) -> Self {
         Self { com: com.clone() }
     }
+}
 
-    #[cfg(feature = "tokio_async")]
+#[cfg(feature = "tokio_async")]
+impl QueryClient {
     // List nodes in the cluster
     pub async fn get_node_list(
         &self,
@@ -165,7 +164,6 @@ impl QueryClient {
         Ok(NodeList::from_com(com))
     }
 
-    #[cfg(feature = "tokio_async")]
     pub async fn get_partition_list(
         &self,
         desc: &ServicePartitionQueryDescription,
@@ -181,7 +179,6 @@ impl QueryClient {
         Ok(ServicePartitionList::new(com))
     }
 
-    #[cfg(feature = "tokio_async")]
     pub async fn get_replica_list(
         &self,
         desc: &ServiceReplicaQueryDescription,
@@ -197,7 +194,6 @@ impl QueryClient {
         Ok(ServiceReplicaList::new(com))
     }
 
-    #[cfg(feature = "tokio_async")]
     pub async fn get_partition_load_information(
         &self,
         desc: &PartitionLoadInformationQueryDescription,

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -117,6 +117,10 @@ impl QueryClient {
 }
 
 impl QueryClient {
+    pub fn get_com(&self) -> IFabricQueryClient10 {
+        self.com.clone()
+    }
+    
     pub fn from_com(com: IFabricQueryClient10) -> Self {
         Self { com: com.clone() }
     }

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -2,7 +2,10 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-#![cfg_attr(not(feature = "tokio_async"), allow(unused_imports, reason = "code configured out"))]
+#![cfg_attr(
+    not(feature = "tokio_async"),
+    allow(unused_imports, reason = "code configured out")
+)]
 use std::{ffi::c_void, time::Duration};
 
 use mssf_com::{

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -41,8 +41,8 @@ pub struct QueryClient {
 // Internal implementation block
 // Internal functions focuses on changing SF callback to async future,
 // while the public apis impl focuses on type conversion.
-#[cfg(feature = "tokio_async")]
 impl QueryClient {
+    #[cfg(feature = "tokio_async")]
     pub fn get_node_list_internal(
         &self,
         query_description: &FABRIC_NODE_QUERY_DESCRIPTION,
@@ -61,6 +61,7 @@ impl QueryClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn get_partition_list_internal(
         &self,
         desc: &FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION,
@@ -78,6 +79,7 @@ impl QueryClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn get_replica_list_internal(
         &self,
         desc: &FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
@@ -95,6 +97,7 @@ impl QueryClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn get_partition_load_information_internal(
         &self,
         desc: &FABRIC_PARTITION_LOAD_INFORMATION_QUERY_DESCRIPTION,

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 #![cfg_attr(
     not(feature = "tokio_async"),
-    allow(unused_imports, reason = "code configured out")
+    allow(unused_imports) // reason = "code configured out"
 )]
 use std::{ffi::c_void, time::Duration};
 

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -120,7 +120,7 @@ impl QueryClient {
     pub fn get_com(&self) -> IFabricQueryClient10 {
         self.com.clone()
     }
-    
+
     pub fn from_com(com: IFabricQueryClient10) -> Self {
         Self { com: com.clone() }
     }

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-
+#![cfg_attr(not(feature = "tokio_async"), allow(unused_imports, reason = "code configured out"))]
 use std::{ffi::c_void, time::Duration};
 
 use mssf_com::{
@@ -19,9 +19,10 @@ use mssf_com::{
     },
 };
 
+#[cfg(feature = "tokio_async")]
+use crate::sync::{fabric_begin_end_proxy2, CancellationToken, FabricReceiver2};
 use crate::{
     strings::get_pcwstr_from_opt,
-    sync::{fabric_begin_end_proxy2, CancellationToken, FabricReceiver2},
     types::{
         NodeList, NodeQueryDescription, PartitionLoadInformation,
         PartitionLoadInformationQueryDescription, ServicePartitionList,
@@ -37,6 +38,7 @@ pub struct QueryClient {
 // Internal implementation block
 // Internal functions focuses on changing SF callback to async future,
 // while the public apis impl focuses on type conversion.
+#[cfg(feature = "tokio_async")]
 impl QueryClient {
     pub fn get_node_list_internal(
         &self,
@@ -113,6 +115,7 @@ impl QueryClient {
         Self { com: com.clone() }
     }
 
+    #[cfg(feature = "tokio_async")]
     // List nodes in the cluster
     pub async fn get_node_list(
         &self,
@@ -152,6 +155,7 @@ impl QueryClient {
         Ok(NodeList::from_com(com))
     }
 
+    #[cfg(feature = "tokio_async")]
     pub async fn get_partition_list(
         &self,
         desc: &ServicePartitionQueryDescription,
@@ -167,6 +171,7 @@ impl QueryClient {
         Ok(ServicePartitionList::new(com))
     }
 
+    #[cfg(feature = "tokio_async")]
     pub async fn get_replica_list(
         &self,
         desc: &ServiceReplicaQueryDescription,
@@ -182,6 +187,7 @@ impl QueryClient {
         Ok(ServiceReplicaList::new(com))
     }
 
+    #[cfg(feature = "tokio_async")]
     pub async fn get_partition_load_information(
         &self,
         desc: &PartitionLoadInformationQueryDescription,

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -2,7 +2,10 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-#![cfg_attr(not(feature = "tokio_async"), allow(unused_imports, reason = "code configured out"))]
+#![cfg_attr(
+    not(feature = "tokio_async"),
+    allow(unused_imports, reason = "code configured out")
+)]
 use std::{ffi::c_void, time::Duration};
 
 use mssf_com::{

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-
+#![cfg_attr(not(feature = "tokio_async"), allow(unused_imports, reason = "code configured out"))]
 use std::{ffi::c_void, time::Duration};
 
 use mssf_com::{
@@ -22,10 +22,12 @@ use mssf_com::{
 };
 use windows_core::{WString, PCWSTR};
 
+#[cfg(feature = "tokio_async")]
+use crate::sync::{fabric_begin_end_proxy2, CancellationToken, FabricReceiver2};
+
 use crate::{
     iter::{FabricIter, FabricListAccessor},
     strings::WStringWrap,
-    sync::{fabric_begin_end_proxy2, CancellationToken, FabricReceiver2},
     types::{
         RemoveReplicaDescription, RestartReplicaDescription, ServiceNotificationFilterDescription,
     },
@@ -39,6 +41,7 @@ pub struct ServiceManagementClient {
 
 // internal implementation block
 impl ServiceManagementClient {
+    #[cfg(feature = "tokio_async")]
     fn resolve_service_partition_internal(
         &self,
         name: FABRIC_URI,
@@ -66,6 +69,7 @@ impl ServiceManagementClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn restart_replica_internal(
         &self,
         desc: &FABRIC_RESTART_REPLICA_DESCRIPTION,
@@ -83,6 +87,7 @@ impl ServiceManagementClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn remove_replica_internal(
         &self,
         desc: &FABRIC_REMOVE_REPLICA_DESCRIPTION,
@@ -100,6 +105,7 @@ impl ServiceManagementClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn register_service_notification_filter_internal(
         &self,
         desc: &FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
@@ -117,6 +123,7 @@ impl ServiceManagementClient {
         )
     }
 
+    #[cfg(feature = "tokio_async")]
     fn unregister_service_notification_filter_internal(
         &self,
         filterid: i64,
@@ -146,6 +153,7 @@ impl ServiceManagementClient {
     }
 
     // Resolve service partition
+    #[cfg(feature = "tokio_async")]
     pub async fn resolve_service_partition(
         &self,
         name: &WString,
@@ -179,6 +187,7 @@ impl ServiceManagementClient {
     /// closing the replica, and then reopening it. Use this to test your service for problems
     /// along the replica reopen path. This helps simulate the report fault temporary path through client APIs.
     /// This is only valid for replicas that belong to stateful persisted services.
+    #[cfg(feature = "tokio_async")]
     pub async fn restart_replica(
         &self,
         desc: &RestartReplicaDescription,
@@ -197,6 +206,7 @@ impl ServiceManagementClient {
     /// Incorrect use of this API can lead to data loss for stateful services.
     /// Remarks:
     /// For stateless services, Instance Abort is called.
+    #[cfg(feature = "tokio_async")]
     pub async fn remove_replica(
         &self,
         desc: &RemoveReplicaDescription,
@@ -224,6 +234,7 @@ impl ServiceManagementClient {
     /// again to retrieve full info from the cache.
     ///
     /// This is observed to have 1~4 secs delay compared with brute force complaint based resolve.
+    #[cfg(feature = "tokio_async")]
     pub async fn register_service_notification_filter(
         &self,
         desc: &ServiceNotificationFilterDescription,
@@ -245,6 +256,7 @@ impl ServiceManagementClient {
     /// It's not necessary to unregister individual filters if the client itself
     /// will no longer be used since all ServiceNotificationFilterDescription
     /// objects registered by the FabricClient will be automatically unregistered when client is disposed.
+    #[cfg(feature = "tokio_async")]
     pub async fn unregister_service_notification_filter(
         &self,
         filter_id_handle: FilterIdHandle,

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -42,13 +42,14 @@ pub struct ServiceManagementClient {
     com: IFabricServiceManagementClient6,
 }
 
-// internal implementation block
 impl ServiceManagementClient {
     pub fn get_com(&self) -> IFabricServiceManagementClient6 {
         self.com.clone()
     }
-
-    #[cfg(feature = "tokio_async")]
+}
+// internal implementation block
+#[cfg(feature = "tokio_async")]
+impl ServiceManagementClient {
     fn resolve_service_partition_internal(
         &self,
         name: FABRIC_URI,
@@ -76,7 +77,6 @@ impl ServiceManagementClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn restart_replica_internal(
         &self,
         desc: &FABRIC_RESTART_REPLICA_DESCRIPTION,
@@ -94,7 +94,6 @@ impl ServiceManagementClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn remove_replica_internal(
         &self,
         desc: &FABRIC_REMOVE_REPLICA_DESCRIPTION,
@@ -112,7 +111,6 @@ impl ServiceManagementClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn register_service_notification_filter_internal(
         &self,
         desc: &FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
@@ -130,7 +128,6 @@ impl ServiceManagementClient {
         )
     }
 
-    #[cfg(feature = "tokio_async")]
     fn unregister_service_notification_filter_internal(
         &self,
         filterid: i64,
@@ -158,9 +155,12 @@ impl ServiceManagementClient {
     pub fn from_com(com: IFabricServiceManagementClient6) -> Self {
         Self { com: com.clone() }
     }
+}
 
+// public implementation block - tokio required
+#[cfg(feature = "tokio_async")]
+impl ServiceManagementClient {
     // Resolve service partition
-    #[cfg(feature = "tokio_async")]
     pub async fn resolve_service_partition(
         &self,
         name: &WString,
@@ -194,7 +194,6 @@ impl ServiceManagementClient {
     /// closing the replica, and then reopening it. Use this to test your service for problems
     /// along the replica reopen path. This helps simulate the report fault temporary path through client APIs.
     /// This is only valid for replicas that belong to stateful persisted services.
-    #[cfg(feature = "tokio_async")]
     pub async fn restart_replica(
         &self,
         desc: &RestartReplicaDescription,
@@ -213,7 +212,6 @@ impl ServiceManagementClient {
     /// Incorrect use of this API can lead to data loss for stateful services.
     /// Remarks:
     /// For stateless services, Instance Abort is called.
-    #[cfg(feature = "tokio_async")]
     pub async fn remove_replica(
         &self,
         desc: &RemoveReplicaDescription,
@@ -241,7 +239,6 @@ impl ServiceManagementClient {
     /// again to retrieve full info from the cache.
     ///
     /// This is observed to have 1~4 secs delay compared with brute force complaint based resolve.
-    #[cfg(feature = "tokio_async")]
     pub async fn register_service_notification_filter(
         &self,
         desc: &ServiceNotificationFilterDescription,
@@ -263,7 +260,6 @@ impl ServiceManagementClient {
     /// It's not necessary to unregister individual filters if the client itself
     /// will no longer be used since all ServiceNotificationFilterDescription
     /// objects registered by the FabricClient will be automatically unregistered when client is disposed.
-    #[cfg(feature = "tokio_async")]
     pub async fn unregister_service_notification_filter(
         &self,
         filter_id_handle: FilterIdHandle,

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 #![cfg_attr(
     not(feature = "tokio_async"),
-    allow(unused_imports, reason = "code configured out")
+    allow(unused_imports) // reason = "code configured out"
 )]
 use std::{ffi::c_void, time::Duration};
 

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -44,6 +44,10 @@ pub struct ServiceManagementClient {
 
 // internal implementation block
 impl ServiceManagementClient {
+    pub fn get_com(&self) -> IFabricServiceManagementClient6 {
+        self.com.clone()
+    }
+
     #[cfg(feature = "tokio_async")]
     fn resolve_service_partition_internal(
         &self,

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -22,7 +22,6 @@
 // SF lib entrypoint apis.
 pub mod api;
 pub use api::API_TABLE;
-#[cfg(feature = "tokio_async")]
 pub mod client;
 #[cfg(feature = "config_source")]
 pub mod conf;


### PR DESCRIPTION
While you still end up needing to drop back down to the com level at least today, not having to write casts by hand is nice.

Also, it's unnecessary to clone the COM level interface all the time. Make FabricClient own the high level wrappers; if you need it to live longer, you can clone it. This is a breaking change, so may warrant a version bump.
