### PR TITLE
Make the code compile on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ enabled = true
 ```
 
 ## Quick Build
-Build all Rust libraries and examples
+Build Rust libraries only:
+```sh 
+cargo build
+```
+
+Alternatively, build all Rust libraries and samples:
 ```sh
 cmake . -B build
 cmake --build build

--- a/crates/libs/core/src/debug/mod.rs
+++ b/crates/libs/core/src/debug/mod.rs
@@ -18,3 +18,7 @@ pub fn wait_for_debugger() {
 
 #[cfg(target_os = "linux")]
 pub fn wait_for_debugger() {}
+
+/// macOS is not supported. This is merely to make this library to compile on macOS.
+#[cfg(target_os = "macos")]
+pub fn wait_for_debugger() {}


### PR DESCRIPTION
With the optimization that build does not require Service Fabric runtime installed, building on any major platform is allowed. Here adding a small fix to make the code compile on macOS, though Service Fabric does not run natively on macOS.