### PR TITLE
Use reason = "reason_here" for allow lints

### DIFF
--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 #![cfg_attr(
     not(feature = "tokio_async"),
-    allow(unused_imports) // reason = "code configured out"
+    allow(unused_imports, reason = "code configured out")
 )]
 use std::{ffi::c_void, time::Duration};
 

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 #![cfg_attr(
     not(feature = "tokio_async"),
-    allow(unused_imports) // reason = "code configured out"
+    allow(unused_imports, reason = "code configured out")
 )]
 use std::{ffi::c_void, time::Duration};
 


### PR DESCRIPTION
The only reason I didn't do this in the previous PR was the Rust compiler version was slightly too old.

Now that the version is 1.84, fix it.