### PR TITLE
Prepare 0.0.19 Release with CI Packaging fix

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -19,9 +19,7 @@ jobs:
       uses: lukka/get-cmake@v3.21.2
 
     - name: Install rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: cmake configure
       run: > 
@@ -39,5 +37,9 @@ jobs:
     - name: build rust code
       run: cmake --build build --config ${{ matrix.BUILD_TYPE }}
 
+    - name: Install rust nightly
+      uses: dtolnay/rust-toolchain@nightly
+
     - name: check crate packaging
-      run: cargo package -p mssf-pal -p mssf-com -p mssf-core --allow-dirty
+      # TODO: move back to stable once package-workspace is stabilized
+      run: cargo +nightly -Z package-workspace package -p mssf-pal -p mssf-com -p mssf-core --allow-dirty 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,14 +223,14 @@ dependencies = [
 
 [[package]]
 name = "mssf-com"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "mssf-pal",
 ]
 
 [[package]]
 name = "mssf-core"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bitflags",
  "config",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-pal"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "windows-core",
 ]

--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-com"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 license = "MIT"
 description = "Rust for Azure Service Fabric. The COM base layer."
@@ -21,7 +21,7 @@ targets = []
 
 [dependencies.mssf-pal]
 path = "../pal"
-version = "0.0.18"
+version = "0.0.19"
 
 [features]
 default = []

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 license = "MIT"
 description = "Rust for Azure Service Fabric. Rust safe APIs."
@@ -49,10 +49,10 @@ features = [
 [dependencies.windows-core]
 package = "mssf-pal"
 path = "../pal"
-version = "0.0.18"
+version = "0.0.19"
 
 [dependencies.mssf-com]
 path = "../com"
-version = "0.0.18"
+version = "0.0.19"
 default-features = false
 features = ["ServiceFabric_FabricClient", "ServiceFabric_FabricCommon", "ServiceFabric_FabricTypes", "ServiceFabric_FabricRuntime"]

--- a/crates/libs/pal/Cargo.toml
+++ b/crates/libs/pal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-pal"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 license = "MIT"
 description = "mssf-pal enables service fabric rust to run on linux"


### PR DESCRIPTION
Prepare for 0.0.19 release

#120 added CI packaging. Unfortunately, ```cargo package``` in 1.84 stable toolchain doesn't handle unpublished packages in the same workspace (but cargo publish does)

This results in CI failures when bumping version (see #128).

The solution is to use nightly feature ```-Z package-workspace```, which takes unpublished local versions into account.
A call for testing (```https://github.com/rust-lang/cargo/issues/10948#issuecomment-2540365225```) went out for 1.85.0-nightly (2024-12-01) and newer.

So install nightly as well and do that. Will need to be tweaked in a few months when that setting hopefully stabilizes.

Also, replace action-rs/toolchain with dtolnay/rust-toolchain, since action-rs/toolchain is no longer maintained.
