### PR TITLE
Change safe APIs to return mssf Error

### DIFF
--- a/crates/libs/core/src/api/mod.rs
+++ b/crates/libs/core/src/api/mod.rs
@@ -174,7 +174,7 @@ impl ApiTable {
         }
     }
 
-    pub fn fabric_get_last_error_message(&self) -> crate::Result<IFabricStringResult> {
+    pub fn fabric_get_last_error_message(&self) -> crate::WinResult<IFabricStringResult> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe { (self.fabric_get_last_error_message_fn)(std::ptr::addr_of_mut!(result)) }.ok()?;
         assert!(!result.is_null());
@@ -186,7 +186,7 @@ impl ApiTable {
         connectionstrings: &[windows_core::PCWSTR],
         service_notification_handler: Option<&IFabricServiceNotificationEventHandler>,
         client_connection_handler: Option<&IFabricClientConnectionEventHandler>,
-    ) -> crate::Result<T> {
+    ) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe {
             (self.fabric_create_client3_fn)(
@@ -206,7 +206,7 @@ impl ApiTable {
         &self,
         service_notification_handler: Option<&IFabricServiceNotificationEventHandler>,
         client_connection_handler: Option<&IFabricClientConnectionEventHandler>,
-    ) -> crate::Result<T> {
+    ) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe {
             (self.fabric_create_local_client3_fn)(
@@ -225,7 +225,7 @@ impl ApiTable {
         service_notification_handler: Option<&IFabricServiceNotificationEventHandler>,
         client_connection_handler: Option<&IFabricClientConnectionEventHandler>,
         clientrole: FABRIC_CLIENT_ROLE,
-    ) -> crate::Result<T> {
+    ) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe {
             (self.fabric_create_local_client4_fn)(
@@ -240,13 +240,13 @@ impl ApiTable {
         Ok(unsafe { T::from_raw(result) })
     }
 
-    pub fn fabric_create_runtime<T: Interface>(&self) -> crate::Result<T> {
+    pub fn fabric_create_runtime<T: Interface>(&self) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe { (self.fabric_create_runtime_fn)(&T::IID, std::ptr::addr_of_mut!(result)) }.ok()?;
         Ok(unsafe { T::from_raw(result) })
     }
 
-    pub fn fabric_get_activation_context<T: Interface>(&self) -> crate::Result<T> {
+    pub fn fabric_get_activation_context<T: Interface>(&self) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe { (self.fabric_get_activation_context_fn)(&T::IID, std::ptr::addr_of_mut!(result)) }
             .ok()?;
@@ -257,7 +257,7 @@ impl ApiTable {
         &self,
         timeoutmilliseconds: u32,
         callback: Option<&IFabricAsyncOperationCallback>,
-    ) -> crate::Result<IFabricAsyncOperationContext> {
+    ) -> crate::WinResult<IFabricAsyncOperationContext> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe {
             (self.fabric_begin_get_node_context_fn)(
@@ -273,7 +273,7 @@ impl ApiTable {
     pub fn fabric_end_get_node_context<T: Interface>(
         &self,
         context: Option<&IFabricAsyncOperationContext>,
-    ) -> crate::Result<T> {
+    ) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe {
             (self.fabric_end_get_node_context_fn)(
@@ -285,7 +285,7 @@ impl ApiTable {
         Ok(unsafe { T::from_raw(result) })
     }
 
-    pub fn fabric_get_node_context<T: Interface>(&self) -> crate::Result<T> {
+    pub fn fabric_get_node_context<T: Interface>(&self) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe { (self.fabric_get_node_context_fn)(std::ptr::addr_of_mut!(result)) }.ok()?;
         Ok(unsafe { T::from_raw(result) })
@@ -301,7 +301,7 @@ impl ApiTable {
         localstorekind: FABRIC_LOCAL_STORE_KIND,
         localstoresettings: *const core::ffi::c_void,
         storeeventhandler: Option<&IFabricStoreEventHandler>,
-    ) -> crate::Result<T> {
+    ) -> crate::WinResult<T> {
         let mut result = std::ptr::null_mut::<core::ffi::c_void>();
         unsafe {
             (self.fabric_create_key_value_store_replica_fn)(

--- a/crates/libs/core/src/client/connection.rs
+++ b/crates/libs/core/src/client/connection.rs
@@ -68,17 +68,21 @@ where
     fn OnConnected(
         &self,
         gw_info: windows_core::Ref<IFabricGatewayInformationResult>,
-    ) -> windows_core::Result<()> {
+    ) -> crate::WinResult<()> {
         let info = GatewayInformationResult::from(gw_info.unwrap());
-        self.inner.on_connected(&info)
+        self.inner
+            .on_connected(&info)
+            .map_err(crate::WinError::from)
     }
 
     fn OnDisconnected(
         &self,
         gw_info: windows_core::Ref<IFabricGatewayInformationResult>,
-    ) -> windows_core::Result<()> {
+    ) -> crate::WinResult<()> {
         let info = GatewayInformationResult::from(gw_info.unwrap());
-        self.inner.on_disconnected(&info)
+        self.inner
+            .on_disconnected(&info)
+            .map_err(crate::WinError::from)
     }
 }
 

--- a/crates/libs/core/src/client/health_client.rs
+++ b/crates/libs/core/src/client/health_client.rs
@@ -51,7 +51,7 @@ impl HealthClient {
     /// When a cluster is secured, the health client needs administrator permission to be able to send the reports.
     /// Read more about [connecting to a cluster using the FabricClient APIs](https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-connect-to-secure-cluster).
     /// For more information about health reporting, see [Service Fabric health monitoring](https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-health-introduction).
-    pub fn report_health(&self, health_report: &HealthReport) -> windows_core::Result<()> {
+    pub fn report_health(&self, health_report: &HealthReport) -> crate::Result<()> {
         match health_report {
             HealthReport::Invalid => {
                 let fabric_health_report = FABRIC_HEALTH_REPORT {
@@ -190,6 +190,6 @@ impl HealthClient {
                 };
                 unsafe { self.com.ReportHealth(&fabric_health_report) }
             }
-        }
+        }.map_err(crate::Error::from)
     }
 }

--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use crate::Interface;
 use connection::{ClientConnectionEventHandlerBridge, LambdaClientConnectionNotificationHandler};
 use health_client::HealthClient;
 use mssf_com::FabricClient::{
@@ -13,7 +14,6 @@ use notification::{
     LambdaServiceNotificationHandler, ServiceNotificationEventHandler,
     ServiceNotificationEventHandlerBridge,
 };
-use windows_core::Interface;
 
 use crate::types::ClientRole;
 

--- a/crates/libs/core/src/client/notification.rs
+++ b/crates/libs/core/src/client/notification.rs
@@ -118,7 +118,7 @@ impl ServiceEndpointsVersion {
     /// Ideally one should use mssf_core::client::svc_mgmt_client::ResolvedServicePartition instead, by
     /// doing an additional FabricClient resolve call to retrieve from FabricClient cache.
     pub fn compare(&self, other: &ServiceEndpointsVersion) -> crate::Result<i32> {
-        unsafe { self.com.Compare(&other.com) }
+        unsafe { self.com.Compare(&other.com) }.map_err(crate::Error::from)
     }
 }
 
@@ -175,10 +175,12 @@ where
     fn OnNotification(
         &self,
         notification: windows_core::Ref<IFabricServiceNotification>,
-    ) -> crate::Result<()> {
+    ) -> crate::WinResult<()> {
         let com = notification.unwrap();
         let msg = ServiceNotification::from(com.clone());
-        self.inner.on_notification(&msg)
+        self.inner
+            .on_notification(&msg)
+            .map_err(crate::WinError::from)
     }
 }
 

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -48,7 +48,7 @@ impl QueryClient {
         query_description: &FABRIC_NODE_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<CancellationToken>,
-    ) -> FabricReceiver2<::windows_core::Result<IFabricGetNodeListResult2>> {
+    ) -> FabricReceiver2<crate::WinResult<IFabricGetNodeListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
 
@@ -66,7 +66,7 @@ impl QueryClient {
         desc: &FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<CancellationToken>,
-    ) -> FabricReceiver2<crate::Result<IFabricGetPartitionListResult2>> {
+    ) -> FabricReceiver2<crate::WinResult<IFabricGetPartitionListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy2(
@@ -83,7 +83,7 @@ impl QueryClient {
         desc: &FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<CancellationToken>,
-    ) -> FabricReceiver2<crate::Result<IFabricGetReplicaListResult2>> {
+    ) -> FabricReceiver2<crate::WinResult<IFabricGetReplicaListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy2(
@@ -100,7 +100,7 @@ impl QueryClient {
         desc: &FABRIC_PARTITION_LOAD_INFORMATION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<CancellationToken>,
-    ) -> FabricReceiver2<crate::Result<IFabricGetPartitionLoadInformationResult>> {
+    ) -> FabricReceiver2<crate::WinResult<IFabricGetPartitionLoadInformationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy2(
@@ -133,7 +133,7 @@ impl QueryClient {
         desc: &NodeQueryDescription,
         timeout: Duration,
         cancellation_token: Option<crate::sync::CancellationToken>,
-    ) -> windows_core::Result<NodeList> {
+    ) -> crate::Result<NodeList> {
         // Note that the SF raw structs are scoped to avoid having them across await points.
         // This makes api Send. All FabricClient api should follow this pattern.
         let com = {

--- a/crates/libs/core/src/error/errorcode.rs
+++ b/crates/libs/core/src/error/errorcode.rs
@@ -3,10 +3,8 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use crate::HRESULT;
 use mssf_com::FabricTypes::FABRIC_ERROR_CODE;
-use windows_core::HRESULT;
-
-use super::FabricError;
 
 // Common HRESULT codes that SF reuses from windows.
 const S_OK: FABRIC_ERROR_CODE = FABRIC_ERROR_CODE(windows_core::Win32::Foundation::S_OK.0);
@@ -49,7 +47,7 @@ macro_rules! define_fabric_error_code{
         #[allow(non_camel_case_types)]
         #[derive(Debug, Clone, PartialEq)]
         #[repr(i32)]
-        pub enum FabricErrorCode {
+        pub enum ErrorCode {
             // Define windows error codes for SF
             $(
                 $code1 = $code1 .0,
@@ -61,7 +59,7 @@ macro_rules! define_fabric_error_code{
             )*
         }
 
-        impl TryFrom<FABRIC_ERROR_CODE> for FabricErrorCode {
+        impl TryFrom<FABRIC_ERROR_CODE> for ErrorCode {
             type Error = &'static str;
 
             fn try_from(value: FABRIC_ERROR_CODE) -> Result<Self, Self::Error> {
@@ -80,26 +78,26 @@ macro_rules! define_fabric_error_code{
     }
 }
 
-impl From<FabricErrorCode> for FabricError {
-    fn from(value: FabricErrorCode) -> Self {
-        FabricError(HRESULT(value as i32))
+impl From<ErrorCode> for crate::Error {
+    fn from(value: ErrorCode) -> Self {
+        crate::Error(HRESULT(value as i32))
     }
 }
 
-// other conversions goes through FabricError
-impl From<FabricErrorCode> for HRESULT {
-    fn from(value: FabricErrorCode) -> Self {
-        FabricError::from(value).into()
+// other conversions goes through crate::Error
+impl From<ErrorCode> for HRESULT {
+    fn from(value: ErrorCode) -> Self {
+        crate::Error::from(value).into()
     }
 }
 
-impl From<FabricErrorCode> for crate::Error {
-    fn from(value: FabricErrorCode) -> Self {
-        FabricError::from(value).into()
+impl From<ErrorCode> for crate::WinError {
+    fn from(value: ErrorCode) -> Self {
+        crate::Error::from(value).into()
     }
 }
 
-impl core::fmt::Display for FabricErrorCode {
+impl core::fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         core::write!(f, "{:?}", self) // use the debug string
     }

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -7,59 +7,64 @@ use crate::HRESULT;
 use mssf_com::FabricTypes::FABRIC_ERROR_CODE;
 
 mod errorcode;
-pub use errorcode::FabricErrorCode;
+pub use errorcode::ErrorCode;
+
+/// Result containing mssf Error.
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// Make passing error code to SF api easier.
 /// Provides conversion from windows errors or fabric error code
 /// to windows_core::Error.
-#[derive(Clone)]
-pub struct FabricError(super::HRESULT);
+/// All safe code uses this Error, and bridge and proxy code needs to
+/// convert this Error into/from WinError.
+#[derive(Clone, PartialEq)]
+pub struct Error(pub super::HRESULT);
 
-impl FabricError {
+impl Error {
     pub fn new(code: HRESULT) -> Self {
         Self(code)
     }
 
     /// Convert to fabric error code if possible.
-    pub fn try_as_fabric_error_code(&self) -> Result<FabricErrorCode, &str> {
-        FabricErrorCode::try_from(FABRIC_ERROR_CODE(self.0 .0))
+    pub fn try_as_fabric_error_code(&self) -> std::result::Result<ErrorCode, &str> {
+        ErrorCode::try_from(FABRIC_ERROR_CODE(self.0 .0))
     }
 }
 
-impl From<HRESULT> for FabricError {
+impl From<HRESULT> for Error {
     fn from(value: HRESULT) -> Self {
         Self::new(value)
     }
 }
 
-impl From<FABRIC_ERROR_CODE> for FabricError {
+impl From<FABRIC_ERROR_CODE> for Error {
     fn from(value: FABRIC_ERROR_CODE) -> Self {
         Self::new(HRESULT(value.0))
     }
 }
 
-impl From<FabricError> for super::Error {
-    fn from(val: FabricError) -> Self {
-        super::Error::from_hresult(val.0)
+impl From<Error> for super::WinError {
+    fn from(val: Error) -> Self {
+        super::WinError::from_hresult(val.0)
     }
 }
 
-impl From<FabricError> for HRESULT {
-    fn from(value: FabricError) -> Self {
+impl From<Error> for HRESULT {
+    fn from(value: Error) -> Self {
         value.0
     }
 }
 
-impl From<crate::Error> for FabricError {
-    fn from(error: crate::Error) -> Self {
+impl From<crate::WinError> for Error {
+    fn from(error: crate::WinError) -> Self {
         Self(error.into())
     }
 }
 
-impl core::fmt::Debug for FabricError {
+impl core::fmt::Debug for Error {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut debug = fmt.debug_struct("FabricError");
-        let str_code = match FabricErrorCode::try_from(FABRIC_ERROR_CODE(self.0 .0)) {
+        let str_code = match ErrorCode::try_from(FABRIC_ERROR_CODE(self.0 .0)) {
             Ok(c) => Some(c),
             Err(_) => None,
         };
@@ -73,9 +78,9 @@ impl core::fmt::Debug for FabricError {
     }
 }
 
-impl core::fmt::Display for FabricError {
+impl core::fmt::Display for Error {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let str_code = match FabricErrorCode::try_from(FABRIC_ERROR_CODE(self.0 .0)) {
+        let str_code = match ErrorCode::try_from(FABRIC_ERROR_CODE(self.0 .0)) {
             Ok(c) => Some(c),
             Err(_) => None,
         };
@@ -86,17 +91,19 @@ impl core::fmt::Display for FabricError {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[cfg(test)]
 mod test {
 
-    use super::{FabricError, FabricErrorCode};
+    use super::{Error, ErrorCode};
+    use crate::HRESULT;
     use mssf_com::FabricTypes::FABRIC_E_CODE_PACKAGE_NOT_FOUND;
     use windows_core::Win32::Foundation::{E_ACCESSDENIED, E_POINTER};
-    use windows_core::{Error, HRESULT};
 
     #[test]
     fn test_fabric_error() {
-        let fe = FabricError::from(FABRIC_E_CODE_PACKAGE_NOT_FOUND);
+        let fe = Error::from(FABRIC_E_CODE_PACKAGE_NOT_FOUND);
         // check debug string
         assert_eq!(
             format!("{:?}", fe),
@@ -107,26 +114,26 @@ mod test {
             format!("{}", fe),
             "FABRIC_E_CODE_PACKAGE_NOT_FOUND (-2147017733)"
         );
-        let e = crate::Error::from(fe.clone());
+        let e = crate::WinError::from(fe.clone());
         assert_eq!(e.code(), fe.into());
-        let ec = FabricError::from(e)
+        let ec = Error::from(e)
             .try_as_fabric_error_code()
             .expect("unknown code");
-        assert_eq!(ec, FabricErrorCode::FABRIC_E_CODE_PACKAGE_NOT_FOUND);
+        assert_eq!(ec, ErrorCode::FABRIC_E_CODE_PACKAGE_NOT_FOUND);
     }
 
     #[test]
     fn test_hresult_error() {
-        let err1: HRESULT = FabricError::from(FabricErrorCode::E_ACCESSDENIED).into();
+        let err1: HRESULT = Error::from(ErrorCode::E_ACCESSDENIED).into();
         let err2 = E_ACCESSDENIED;
         assert_eq!(err1, err2);
 
-        let e: Error = FabricErrorCode::E_POINTER.into();
+        let e: crate::WinError = ErrorCode::E_POINTER.into();
         assert_eq!(e, E_POINTER.into());
 
         const SEC_E_INTERNAL_ERROR: crate::HRESULT = crate::HRESULT(0x80090304_u32 as _);
         // use an error that is not fabric error
-        let fe = FabricError::from(SEC_E_INTERNAL_ERROR);
+        let fe = Error::from(SEC_E_INTERNAL_ERROR);
         // check display string
         assert_eq!(format!("{}", fe), "-2146893052");
         assert_eq!(

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -26,7 +26,8 @@ pub mod client;
 #[cfg(feature = "config_source")]
 pub mod conf;
 pub mod debug;
-pub mod error;
+mod error;
+pub use error::{Error, ErrorCode, Result};
 mod iter;
 pub mod runtime;
 pub mod strings;
@@ -34,5 +35,8 @@ pub mod sync;
 pub mod types;
 
 // re-export some windows types
-pub use windows_core::{Error, Interface, Result, WString, GUID, HRESULT, PCWSTR};
+pub use windows_core::{Interface, WString, GUID, HRESULT, PCWSTR};
 // Note cannot re-export windows_core::implement because the macro using it has hard coded mod name.
+/// Windows error type.
+pub use windows_core::Error as WinError;
+pub use windows_core::Result as WinResult;

--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -138,6 +138,7 @@ impl CodePackageActivationContext {
             None => std::ptr::null(),
         };
         unsafe { self.com_impl.ReportApplicationHealth2(&raw, raw_options) }
+            .map_err(crate::Error::from)
     }
 
     pub fn get_com(&self) -> IFabricCodePackageActivationContext6 {

--- a/crates/libs/core/src/runtime/config.rs
+++ b/crates/libs/core/src/runtime/config.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::{error::FabricErrorCode, WString};
+use crate::{error::ErrorCode, WString};
 use mssf_com::{
     FabricRuntime::IFabricConfigurationPackage,
     FabricTypes::{
@@ -108,7 +108,7 @@ impl ConfigurationPackage {
                 res.owner = Some(self.com.clone());
                 Ok(res)
             }
-            None => Err(FabricErrorCode::E_POINTER.into()),
+            None => Err(ErrorCode::E_POINTER.into()),
         }
     }
 
@@ -128,7 +128,7 @@ impl ConfigurationPackage {
         Ok((WStringWrap::from(raw).into(), is_encrypted != 0))
     }
 
-    pub fn decrypt_value(&self, encryptedvalue: &WString) -> windows_core::Result<WString> {
+    pub fn decrypt_value(&self, encryptedvalue: &WString) -> crate::Result<WString> {
         let s = unsafe { self.com.DecryptValue(encryptedvalue.as_pcwstr()) }?;
         Ok(WStringWrap::from(&s).into())
     }

--- a/crates/libs/core/src/runtime/error.rs
+++ b/crates/libs/core/src/runtime/error.rs
@@ -3,12 +3,12 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::{Error, WString, HRESULT};
+use crate::{WString, HRESULT};
 
 // Fills the error info as string for better debugging.
 // SF has separate last error set and get from windows.
 // Not all error strings are set by SF. This is not very useful in practice.
-pub fn fill_fabric_hresult(code: HRESULT) -> Error {
+pub fn fill_fabric_hresult(code: HRESULT) -> crate::WinError {
     // in rs, this function always succeed. The fail case is that the return ptr is null.
     let sf_err = crate::API_TABLE.fabric_get_last_error_message().unwrap();
     let err_str_raw = unsafe { sf_err.get_String() };
@@ -18,23 +18,23 @@ pub fn fill_fabric_hresult(code: HRESULT) -> Error {
         unsafe { err_str_raw.as_wide() }
     };
     println!("debug std: {}", WString::from_wide(err_str));
-    Error::new(code, WString::from_wide(err_str).to_string())
+    crate::WinError::new(code, WString::from_wide(err_str).to_string())
 }
 
-pub fn fill_fabric_error(e: Error) -> Error {
+pub fn fill_fabric_error(e: crate::WinError) -> crate::WinError {
     fill_fabric_hresult(e.code())
 }
 
 #[cfg(test)]
 #[cfg(windows)] // linux error propagate is not working yet
 mod test {
-    use crate::{Error, WString};
+    use crate::{WString, WinError};
     use mssf_com::FabricTypes::FABRIC_E_GATEWAY_NOT_REACHABLE;
 
     #[test]
     fn test_win_error() {
         let s = WString::from("MyError");
-        let e = Error::new(
+        let e = WinError::new(
             crate::HRESULT(FABRIC_E_GATEWAY_NOT_REACHABLE.0),
             s.clone().to_string(),
         );

--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use tokio::{runtime::Handle, sync::mpsc::channel};
 use tracing::info;
 
-use crate::error::FabricErrorCode;
+use crate::error::ErrorCode;
 
 // Executor is used by rs to post jobs to execute in the background
 // Sync is needed due to we use the executor across await boundary.
@@ -98,11 +98,11 @@ impl<T: Send> JoinHandle<T> for DefaultJoinHandle<T> {
             Err(e) => {
                 let e = if e.is_cancelled() {
                     // we never cancel in executor
-                    FabricErrorCode::E_ABORT
+                    ErrorCode::E_ABORT
                 } else if e.is_panic() {
-                    FabricErrorCode::E_UNEXPECTED
+                    ErrorCode::E_UNEXPECTED
                 } else {
-                    FabricErrorCode::E_FAIL
+                    ErrorCode::E_FAIL
                 };
                 tracing::error!("DefaultJoinHandle: background task failed: {e}");
                 Err(e.into())

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -3,10 +3,10 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use crate::Interface;
 #[cfg(feature = "tokio_async")]
 use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
 use mssf_com::FabricRuntime::IFabricRuntime;
-use windows_core::Interface;
 
 #[cfg(feature = "tokio_async")]
 pub use self::runtime_wrapper::Runtime;
@@ -41,9 +41,13 @@ pub use activation_context::{CodePackageActivationContext, CodePackageInfo};
 
 // creates fabric runtime
 pub fn create_com_runtime() -> crate::Result<IFabricRuntime> {
-    crate::API_TABLE.fabric_create_runtime()
+    crate::API_TABLE
+        .fabric_create_runtime()
+        .map_err(crate::Error::from)
 }
 
 pub fn get_com_activation_context<T: Interface>() -> crate::Result<T> {
-    crate::API_TABLE.fabric_get_activation_context::<T>()
+    crate::API_TABLE
+        .fabric_get_activation_context::<T>()
+        .map_err(crate::Error::from)
 }

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -12,7 +12,7 @@ use crate::{
 pub fn get_com_node_context(
     timeout_milliseconds: u32,
     cancellation_token: Option<CancellationToken>,
-) -> crate::sync::FabricReceiver2<::windows_core::Result<IFabricNodeContextResult>> {
+) -> crate::sync::FabricReceiver2<crate::WinResult<IFabricNodeContextResult>> {
     fabric_begin_end_proxy2(
         move |callback| {
             crate::API_TABLE.fabric_begin_get_node_context(timeout_milliseconds, callback)
@@ -50,7 +50,7 @@ impl NodeContext {
     }
 
     // Retrieves the directory path for the directory at node level.
-    pub fn get_directory(&self, logical_directory_name: &WString) -> windows_core::Result<WString> {
+    pub fn get_directory(&self, logical_directory_name: &WString) -> crate::Result<WString> {
         let com2 = self.com.cast::<IFabricNodeContextResult2>()?;
         let dir = unsafe { com2.GetDirectory(logical_directory_name.as_pcwstr()) }?;
         Ok(WStringWrap::from(&dir).into())

--- a/crates/libs/core/src/runtime/runtime_wrapper.rs
+++ b/crates/libs/core/src/runtime/runtime_wrapper.rs
@@ -41,6 +41,7 @@ where
             self.com_impl
                 .RegisterStatelessServiceFactory(servicetypename.as_pcwstr(), &bridge)
         }
+        .map_err(crate::Error::from)
     }
 
     pub fn register_stateful_service_factory(
@@ -55,5 +56,6 @@ where
             self.com_impl
                 .RegisterStatefulServiceFactory(servicetypename.as_pcwstr(), &bridge)
         }
+        .map_err(crate::Error::from)
     }
 }

--- a/crates/libs/core/src/runtime/store.rs
+++ b/crates/libs/core/src/runtime/store.rs
@@ -28,7 +28,7 @@ impl IFabricStoreEventHandler_Impl for DummyStoreEventHandler_Impl {
 
 pub fn create_com_key_value_store_replica(
     storename: &WString,
-    partitionid: ::windows_core::GUID,
+    partitionid: crate::GUID,
     replicaid: i64,
     replicatorsettings: &ReplicatorSettings,
     localstorekind: LocalStoreKind,
@@ -43,13 +43,15 @@ pub fn create_com_key_value_store_replica(
         Some(x) => &x,
         None => std::ptr::null(),
     };
-    crate::API_TABLE.fabric_create_key_value_store_replica::<IFabricKeyValueStoreReplica2>(
-        PCWSTR::from_raw(storename.as_ptr()),
-        partitionid,
-        replicaid,
-        &replicatorsettings.get_raw(),
-        kind,
-        local_settings_ptr as *const c_void,
-        Some(storeeventhandler),
-    )
+    crate::API_TABLE
+        .fabric_create_key_value_store_replica::<IFabricKeyValueStoreReplica2>(
+            PCWSTR::from_raw(storename.as_ptr()),
+            partitionid,
+            replicaid,
+            &replicatorsettings.get_raw(),
+            kind,
+            local_settings_ptr as *const c_void,
+            Some(storeeventhandler),
+        )
+        .map_err(crate::Error::from)
 }

--- a/crates/libs/core/src/runtime/store_proxy.rs
+++ b/crates/libs/core/src/runtime/store_proxy.rs
@@ -66,6 +66,7 @@ impl KVStoreProxy {
             self.com_impl
                 .Add(&tx.com_impl, PCWSTR::from_raw(key.as_ptr()), value)
         }
+        .map_err(crate::Error::from)
     }
 
     pub fn get(&self, tx: &TransactionProxy, key: &[u16]) -> crate::Result<KVStoreItemProxy> {
@@ -92,6 +93,7 @@ impl KVStoreProxy {
                 checksequencenumber,
             )
         }
+        .map_err(crate::Error::from)
     }
 }
 
@@ -117,7 +119,7 @@ impl TransactionProxy {
             move |ctx| unsafe { com2.EndCommit(ctx) },
             cancellation_token,
         );
-        rx.await?
+        rx.await?.map_err(crate::Error::from)
     }
 
     pub fn rollback(&self) {

--- a/crates/libs/core/src/strings.rs
+++ b/crates/libs/core/src/strings.rs
@@ -24,9 +24,9 @@ impl StringResult {
 }
 
 impl IFabricStringResult_Impl for StringResult_Impl {
-    fn get_String(&self) -> windows_core::PCWSTR {
+    fn get_String(&self) -> crate::PCWSTR {
         // This is some hack to get the raw pointer out.
-        windows_core::PCWSTR::from_raw(self.data.as_ptr())
+        crate::PCWSTR::from_raw(self.data.as_ptr())
     }
 }
 

--- a/crates/libs/core/src/sync/bridge_context.rs
+++ b/crates/libs/core/src/sync/bridge_context.rs
@@ -6,7 +6,7 @@
 use std::{cell::Cell, future::Future};
 
 use crate::{
-    error::FabricErrorCode,
+    error::ErrorCode,
     runtime::executor::{Executor, JoinHandle},
 };
 use mssf_com::FabricCommon::{
@@ -77,7 +77,7 @@ where
         self,
         rt: &impl Executor,
         future: F,
-    ) -> crate::Result<IFabricAsyncOperationContext>
+    ) -> crate::WinResult<IFabricAsyncOperationContext>
     where
         F: Future<Output = T> + Send + 'static,
     {
@@ -127,9 +127,9 @@ where
             true => self.content.take().expect("content is consumed twice."),
             false => {
                 if self.token.is_cancelled() {
-                    Err(FabricErrorCode::E_ABORT.into())
+                    Err(ErrorCode::E_ABORT.into())
                 } else {
-                    Err(FabricErrorCode::FABRIC_E_OPERATION_NOT_COMPLETE.into())
+                    Err(ErrorCode::FABRIC_E_OPERATION_NOT_COMPLETE.into())
                 }
             }
         }
@@ -159,12 +159,12 @@ impl<T> IFabricAsyncOperationContext_Impl for BridgeContext3_Impl<T> {
         self.is_completed_synchronously
     }
 
-    fn Callback(&self) -> crate::Result<IFabricAsyncOperationCallback> {
+    fn Callback(&self) -> crate::WinResult<IFabricAsyncOperationCallback> {
         let cp = self.callback.clone();
         Ok(cp)
     }
 
-    fn Cancel(&self) -> crate::Result<()> {
+    fn Cancel(&self) -> crate::WinResult<()> {
         self.token.cancel();
         Ok(())
     }

--- a/crates/libs/core/src/sync/cancel.rs
+++ b/crates/libs/core/src/sync/cancel.rs
@@ -257,8 +257,8 @@ mod test {
     use tokio_util::sync::CancellationToken;
 
     use crate::{
-        error::ErrorCode, runtime::executor::DefaultExecutor,
-        sync::bridge_context::BridgeContext3, sync::cancel::oneshot_channel,
+        error::ErrorCode, runtime::executor::DefaultExecutor, sync::bridge_context::BridgeContext3,
+        sync::cancel::oneshot_channel,
     };
 
     use super::fabric_begin_end_proxy2;

--- a/crates/libs/core/src/sync/cancel.rs
+++ b/crates/libs/core/src/sync/cancel.rs
@@ -12,7 +12,7 @@ use std::{
 use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
 pub use tokio_util::sync::CancellationToken;
 
-use crate::error::FabricErrorCode;
+use crate::error::ErrorCode;
 
 // proxy impl
 
@@ -42,7 +42,7 @@ impl<T> FabricReceiver2<T> {
     // pub fn blocking_recv(self) -> crate::Result<T> {
     //     if let Some(t) = self.token {
     //         if t.is_cancelled() {
-    //             return Err(FabricErrorCode::OperationCanceled.into());
+    //             return Err(ErrorCode::OperationCanceled.into());
     //         }
     //     }
     //     // sender must send stuff so that there is not error.
@@ -56,7 +56,7 @@ impl<T> FabricReceiver2<T> {
     }
 
     // Cancels the inner SF operation if exists, and reset the ctx.
-    fn cancel_inner_ctx(&mut self) -> crate::Result<()> {
+    fn cancel_inner_ctx(&mut self) -> crate::WinResult<()> {
         if let Some(ctx) = &self.ctx {
             if let Err(e) = unsafe { ctx.Cancel() } {
                 // fail to cancel inner operation.
@@ -81,7 +81,7 @@ impl<T> Future for FabricReceiver2<T> {
     // The error code should be OperationCanceled, unless cancellation
     // of SF ctx returns other errors.
     // (TODO: observe other error code from SF, maybe some code should be ignored).
-    type Output = crate::Result<T>;
+    type Output = crate::WinResult<T>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Poll the receiver first, if ready then return the output,
         // else poll the cancellation token, if cancelled propergate the cancel to SF ctx,
@@ -105,7 +105,7 @@ impl<T> Future for FabricReceiver2<T> {
                     if let Err(e) = self.cancel_inner_ctx() {
                         Poll::Ready(Err(e))
                     } else {
-                        Poll::Ready(Err(FabricErrorCode::E_ABORT.into()))
+                        Poll::Ready(Err(ErrorCode::E_ABORT.into()))
                     }
                 } else {
                     panic!("sender dropped without sending")
@@ -215,12 +215,12 @@ pub fn fabric_begin_end_proxy2<BEGIN, END, T>(
     begin: BEGIN,
     end: END,
     token: Option<CancellationToken>,
-) -> FabricReceiver2<::windows_core::Result<T>>
+) -> FabricReceiver2<crate::WinResult<T>>
 where
     BEGIN: FnOnce(
         Option<&IFabricAsyncOperationCallback>,
-    ) -> crate::Result<IFabricAsyncOperationContext>,
-    END: FnOnce(Option<&IFabricAsyncOperationContext>) -> crate::Result<T> + 'static,
+    ) -> crate::WinResult<IFabricAsyncOperationContext>,
+    END: FnOnce(Option<&IFabricAsyncOperationContext>) -> crate::WinResult<T> + 'static,
     T: 'static,
 {
     let (tx, mut rx) = oneshot_channel(token);
@@ -257,7 +257,7 @@ mod test {
     use tokio_util::sync::CancellationToken;
 
     use crate::{
-        error::FabricErrorCode, runtime::executor::DefaultExecutor,
+        error::ErrorCode, runtime::executor::DefaultExecutor,
         sync::bridge_context::BridgeContext3, sync::cancel::oneshot_channel,
     };
 
@@ -303,7 +303,7 @@ mod test {
             let (tx, rx) = oneshot_channel::<bool>(Some(token.clone()));
             token.cancel();
             std::mem::drop(tx);
-            assert_eq!(rx.await.unwrap_err(), FabricErrorCode::E_ABORT.into());
+            assert_eq!(rx.await.unwrap_err(), ErrorCode::E_ABORT.into());
         }
     }
 
@@ -322,14 +322,14 @@ mod test {
             delay: Duration,
             ignore_cancel: bool, // ignores the token
             token: Option<CancellationToken>,
-        ) -> crate::Result<String>;
+        ) -> crate::WinResult<String>;
 
         async fn set_data_delay(
             &self,
             input: String,
             delay: Duration,
             token: Option<CancellationToken>,
-        ) -> crate::Result<()>;
+        ) -> crate::WinResult<()>;
     }
 
     /// Test Obj for cancellation
@@ -345,7 +345,7 @@ mod test {
             delay: Duration,
             ignore_cancel: bool,
             token: Option<CancellationToken>,
-        ) -> crate::Result<String> {
+        ) -> crate::WinResult<String> {
             if self.panic.load(std::sync::atomic::Ordering::Relaxed) {
                 panic!("test panic is set")
             }
@@ -359,7 +359,7 @@ mod test {
                     select! {
                         _ = t.cancelled() => {
                             // The token was cancelled
-                            Err(FabricErrorCode::E_ABORT.into())
+                            Err(ErrorCode::E_ABORT.into())
                         }
                         _ = tokio::time::sleep(delay) => {
                             Ok(self.get_data())
@@ -379,7 +379,7 @@ mod test {
             input: String,
             delay: Duration,
             token: Option<CancellationToken>,
-        ) -> crate::Result<()> {
+        ) -> crate::WinResult<()> {
             if self.panic.load(std::sync::atomic::Ordering::Relaxed) {
                 panic!("test panic is set")
             }
@@ -394,7 +394,7 @@ mod test {
                     select! {
                         _ = t.cancelled() => {
                             // The token was cancelled
-                            Err(FabricErrorCode::E_ABORT.into())
+                            Err(ErrorCode::E_ABORT.into())
                         }
                         _ = tokio::time::sleep(delay) => {
                             self.set_data(input);
@@ -457,7 +457,7 @@ mod test {
             delay: Duration,
             ignore_cancel: bool,
             callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-        ) -> crate::Result<IFabricAsyncOperationContext> {
+        ) -> crate::WinResult<IFabricAsyncOperationContext> {
             let inner = self.inner.clone();
             let (ctx, token) = BridgeContext3::make(callback);
             ctx.spawn(&self.rt, async move {
@@ -470,7 +470,7 @@ mod test {
         pub fn end_get_data_delay(
             &self,
             context: windows_core::Ref<IFabricAsyncOperationContext>,
-        ) -> crate::Result<String> {
+        ) -> crate::WinResult<String> {
             BridgeContext3::result(context)?
         }
 
@@ -479,7 +479,7 @@ mod test {
             input: String,
             delay: Duration,
             callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-        ) -> crate::Result<IFabricAsyncOperationContext> {
+        ) -> crate::WinResult<IFabricAsyncOperationContext> {
             let inner = self.inner.clone();
             let (ctx, token) = BridgeContext3::make(callback);
             ctx.spawn(&self.rt, async move {
@@ -490,7 +490,7 @@ mod test {
         pub fn end_set_data_delay(
             &self,
             context: windows_core::Ref<IFabricAsyncOperationContext>,
-        ) -> crate::Result<()> {
+        ) -> crate::WinResult<()> {
             BridgeContext3::result(context)?
         }
     }
@@ -513,7 +513,7 @@ mod test {
     /// Returned ref has the same lifetime as the opt.
     fn option_to_ref<T>(opt: Option<&T>) -> windows_core::Ref<T>
     where
-        T: windows_core::Interface,
+        T: crate::Interface,
     {
         unsafe { core::mem::transmute_copy(opt.unwrap()) }
     }
@@ -525,7 +525,7 @@ mod test {
             delay: Duration,
             ignore_cancel: bool,
             token: Option<CancellationToken>,
-        ) -> crate::Result<String> {
+        ) -> crate::WinResult<String> {
             let com1 = &self.com;
             let com2 = self.com.clone();
             fabric_begin_end_proxy2(
@@ -543,7 +543,7 @@ mod test {
             input: String,
             delay: Duration,
             token: Option<CancellationToken>,
-        ) -> crate::Result<()> {
+        ) -> crate::WinResult<()> {
             let com1 = &self.com;
             let com2 = self.com.clone();
             fabric_begin_end_proxy2(
@@ -591,7 +591,7 @@ mod test {
             let fu = obj.get_data_delay(Duration::from_secs(5), false, Some(token.clone()));
             token.cancel();
             let err = fu.await.unwrap_err();
-            assert_eq!(err, FabricErrorCode::E_ABORT.into());
+            assert_eq!(err, ErrorCode::E_ABORT.into());
         }
         // get with cancel but ignore cancel from inner impl.
         // Because the cancel is ignored by inner implementation, success will be returned.
@@ -614,7 +614,7 @@ mod test {
             );
             token.cancel();
             let err = fu.await.unwrap_err();
-            assert_eq!(err, FabricErrorCode::E_ABORT.into());
+            assert_eq!(err, ErrorCode::E_ABORT.into());
         }
         // because of cancel, data should not be changed.
         {
@@ -740,7 +740,7 @@ mod test {
             let out = IMyObj::get_data_delay(&proxy, Duration::ZERO, false, None)
                 .await
                 .expect_err("should error out");
-            assert_eq!(out, FabricErrorCode::E_UNEXPECTED.into());
+            assert_eq!(out, ErrorCode::E_UNEXPECTED.into());
         }
     }
 }

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -91,8 +91,9 @@ mod async_tests {
     };
 
     use crate::Interface;
+    use crate::PCWSTR;
     use tokio::sync::oneshot::Sender;
-    use windows_core::{implement, PCWSTR};
+    use windows_core::implement;
 
     use super::channel::{oneshot_channel, FabricReceiver, SBox};
 
@@ -172,7 +173,7 @@ mod async_tests {
             , [<$param_opt _name>]: SBox<$param_opt>
         )*
 
-        ) -> crate::Result<$res> {
+        ) -> crate::WinResult<$res> {
             let ctx: SBox<IFabricAsyncOperationContext>;
             let token: AwaitableToken;
 
@@ -270,7 +271,7 @@ mod async_tests {
         pub async fn get_node_list_example(
             &self,
             p: SBox<FABRIC_NODE_QUERY_DESCRIPTION>,
-        ) -> crate::Result<IFabricGetNodeListResult> {
+        ) -> crate::WinResult<IFabricGetNodeListResult> {
             let ctx: SBox<IFabricAsyncOperationContext>;
             let token: AwaitableToken;
 
@@ -293,7 +294,7 @@ mod async_tests {
         pub fn get_node_list_example2(
             &self,
             querydescription: &FABRIC_NODE_QUERY_DESCRIPTION,
-        ) -> FabricReceiver<crate::Result<IFabricGetNodeListResult>> {
+        ) -> FabricReceiver<crate::WinResult<IFabricGetNodeListResult>> {
             let (tx, rx) = oneshot_channel();
 
             let com_cp = self.com.clone();
@@ -314,7 +315,7 @@ mod async_tests {
         pub fn get_node_list_sync_example(
             &self,
             querydescription: &FABRIC_NODE_QUERY_DESCRIPTION,
-        ) -> crate::Result<IFabricGetNodeListResult> {
+        ) -> crate::WinResult<IFabricGetNodeListResult> {
             let rx = self.get_node_list_example2(querydescription);
             rx.blocking_recv()
         }

--- a/crates/libs/core/src/sync/wait.rs
+++ b/crates/libs/core/src/sync/wait.rs
@@ -100,14 +100,14 @@ impl IFabricAsyncOperationContext_Impl for AsyncContext_Impl {
         true
     }
 
-    fn Callback(&self) -> crate::Result<IFabricAsyncOperationCallback> {
+    fn Callback(&self) -> crate::WinResult<IFabricAsyncOperationCallback> {
         debug!("AsyncContext::Callback");
         // get a view of the callback
         let callback_copy: IFabricAsyncOperationCallback = self.callback_.clone();
         Ok(callback_copy)
     }
 
-    fn Cancel(&self) -> crate::Result<()> {
+    fn Cancel(&self) -> crate::WinResult<()> {
         debug!("AsyncContext::Cancel");
         Ok(())
     }

--- a/crates/libs/core/src/types/client/health.rs
+++ b/crates/libs/core/src/types/client/health.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use windows_core::{WString, GUID};
+use crate::{WString, GUID};
 
 use crate::types::HealthInformation;
 

--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -7,10 +7,10 @@
 
 use std::time::SystemTime;
 
+use crate::WString;
 use mssf_com::{
     FabricClient::IFabricGetPartitionLoadInformationResult, FabricTypes::FABRIC_LOAD_METRIC_REPORT,
 };
-use windows_core::WString;
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -144,7 +144,7 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for Node {
             node_up_time_in_seconds: raw.NodeUpTimeInSeconds,
             is_seed_node: raw.IsSeedNode,
             upgrade_domain: WStringWrap::from(raw.UpgradeDomain).into(),
-            fault_domain: WStringWrap::from(windows_core::PCWSTR(raw.FaultDomain.0)).into(),
+            fault_domain: WStringWrap::from(crate::PCWSTR(raw.FaultDomain.0)).into(),
             node_instance_id: raw2.NodeInstanceId,
         }
     }

--- a/crates/libs/core/src/types/client/partition.rs
+++ b/crates/libs/core/src/types/client/partition.rs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use crate::{WString, GUID};
 use mssf_com::{
     FabricClient::{IFabricGetPartitionListResult2, IFabricGetPartitionLoadInformationResult},
     FabricTypes::{
@@ -19,7 +20,6 @@ use mssf_com::{
         FABRIC_STATELESS_SERVICE_PARTITION_QUERY_RESULT_ITEM, FABRIC_URI,
     },
 };
-use windows_core::{WString, GUID};
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},

--- a/crates/libs/core/src/types/runtime/health.rs
+++ b/crates/libs/core/src/types/runtime/health.rs
@@ -1,5 +1,5 @@
+use crate::PCWSTR;
 use mssf_com::FabricTypes::{FABRIC_HEALTH_INFORMATION, FABRIC_HEALTH_REPORT_SEND_OPTIONS};
-use windows_core::PCWSTR;
 
 use crate::{strings::WStringWrap, types::HealthState, WString};
 

--- a/crates/libs/core/src/types/runtime/stateful.rs
+++ b/crates/libs/core/src/types/runtime/stateful.rs
@@ -309,7 +309,7 @@ mod test {
             Id: id,
             Role: FABRIC_REPLICA_ROLE_PRIMARY,
             Status: FABRIC_REPLICA_STATUS_UP,
-            ReplicatorAddress: windows_core::PCWSTR::null(),
+            ReplicatorAddress: crate::PCWSTR::null(),
             CurrentProgress: 123,
             CatchUpCapability: 123,
             Reserved: std::ptr::null_mut(),

--- a/crates/libs/core/src/types/runtime/store.rs
+++ b/crates/libs/core/src/types/runtime/store.rs
@@ -65,7 +65,7 @@ impl From<LocalStoreKind> for FABRIC_LOCAL_STORE_KIND {
 #[derive(Default)]
 pub struct EseLocalStoreSettings {
     // FABRIC_ESE_LOCAL_STORE_SETTINGS
-    pub db_folder_path: ::windows_core::WString,
+    pub db_folder_path: crate::WString,
     pub log_file_size_in_kb: i32,
     pub log_buffer_size_in_kb: i32,
     pub max_cursors: i32,
@@ -77,7 +77,7 @@ pub struct EseLocalStoreSettings {
 impl EseLocalStoreSettings {
     pub fn get_raw(&self) -> FABRIC_ESE_LOCAL_STORE_SETTINGS {
         FABRIC_ESE_LOCAL_STORE_SETTINGS {
-            DbFolderPath: windows_core::PCWSTR::from_raw(self.db_folder_path.as_ptr()),
+            DbFolderPath: crate::PCWSTR::from_raw(self.db_folder_path.as_ptr()),
             LogFileSizeInKB: self.log_file_size_in_kb,
             LogBufferSizeInKB: self.log_buffer_size_in_kb,
             MaxCursors: self.max_cursors,

--- a/crates/samples/echomain-stateful/src/app.rs
+++ b/crates/samples/echomain-stateful/src/app.rs
@@ -67,7 +67,7 @@ impl IFabricStatefulServiceFactory_Impl for StatefulServiceFactory_Impl {
         initializationdata: *const u8,
         partitionid: &mssf_core::GUID,
         instanceid: i64,
-    ) -> mssf_core::Result<IFabricStatefulServiceReplica> {
+    ) -> mssf_core::WinResult<IFabricStatefulServiceReplica> {
         let mut init_data: String = "".to_string();
         if initializationdata.is_null() && initializationdatalength != 0 {
             init_data = unsafe {
@@ -113,7 +113,7 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
     fn BeginOpen(
         &self,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginOpen");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -124,7 +124,7 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
     fn EndOpen(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> mssf_core::Result<IFabricStringResult> {
+    ) -> mssf_core::WinResult<IFabricStringResult> {
         info!("AppFabricReplicator::EndOpen");
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
         info!("AppFabricReplicator::EndOpen {}", addr);
@@ -137,7 +137,7 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
         _epoch: *const FABRIC_EPOCH,
         _role: FABRIC_REPLICA_ROLE,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginChangeRole");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -148,7 +148,7 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
     fn EndChangeRole(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> mssf_core::Result<()> {
+    ) -> mssf_core::WinResult<()> {
         info!("AppFabricReplicator::EndChangeRole");
         Ok(())
     }
@@ -157,7 +157,7 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
         &self,
         _epoch: *const FABRIC_EPOCH,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginUpdateEpoch");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -167,14 +167,14 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
     fn EndUpdateEpoch(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppFabricReplicator::EndUpdateEpoch");
         Ok(())
     }
     fn BeginClose(
         &self,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginClose");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -184,19 +184,19 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
     fn EndClose(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppFabricReplicator::EndClose");
         Ok(())
     }
     fn Abort(&self) {
         info!("AppFabricReplicator::Abort");
     }
-    fn GetCurrentProgress(&self) -> ::mssf_core::Result<i64> {
+    fn GetCurrentProgress(&self) -> ::mssf_core::WinResult<i64> {
         info!("AppFabricReplicator::GetCurrentProgress");
         let v = 0;
         Ok(v)
     }
-    fn GetCatchUpCapability(&self) -> ::mssf_core::Result<i64> {
+    fn GetCatchUpCapability(&self) -> ::mssf_core::WinResult<i64> {
         info!("AppFabricReplicator::GetCatchUpCapability");
         let v = 0;
         Ok(v)
@@ -208,7 +208,7 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
     fn BeginOnDataLoss(
         &self,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginOnDataLoss");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -218,7 +218,7 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
     fn EndOnDataLoss(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<u8> {
+    ) -> ::mssf_core::WinResult<u8> {
         info!("AppFabricReplicator::EndOnDataLoss");
         let v = 0;
         Ok(v)
@@ -227,7 +227,7 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
         &self,
         _currentconfiguration: *const FABRIC_REPLICA_SET_CONFIGURATION,
         _previousconfiguration: *const FABRIC_REPLICA_SET_CONFIGURATION,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppFabricReplicator::UpdateCatchUpReplicaSetConfiguration");
         Ok(())
     }
@@ -235,7 +235,7 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
         &self,
         _catchupmode: FABRIC_REPLICA_SET_QUORUM_MODE,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginWaitForCatchUpQuorum");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -245,14 +245,14 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
     fn EndWaitForCatchUpQuorum(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppFabricReplicator::EndWaitForCatchUpQuorum");
         Ok(())
     }
     fn UpdateCurrentReplicaSetConfiguration(
         &self,
         _currentconfiguration: *const FABRIC_REPLICA_SET_CONFIGURATION,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppFabricReplicator::UpdateCurrentReplicaSetConfiguration");
         Ok(())
     }
@@ -260,7 +260,7 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
         &self,
         _replica: *const FABRIC_REPLICA_INFORMATION,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppFabricReplicator::BeginBuildReplica");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -270,11 +270,11 @@ impl IFabricPrimaryReplicator_Impl for AppFabricReplicator_Impl {
     fn EndBuildReplica(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppFabricReplicator::EndBuildReplica");
         Ok(())
     }
-    fn RemoveReplica(&self, replicaid: i64) -> ::mssf_core::Result<()> {
+    fn RemoveReplica(&self, replicaid: i64) -> ::mssf_core::WinResult<()> {
         info!(
             "AppFabricReplicator::UpdateCurrentReplicaSetConfiguration {} ",
             replicaid
@@ -313,7 +313,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
         openmode: FABRIC_REPLICA_OPEN_MODE,
         partition: windows_core::Ref<IFabricStatefulServicePartition>,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("echo_replica::BeginOpen");
 
         if openmode == FABRIC_REPLICA_OPEN_MODE_INVALID {
@@ -347,7 +347,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
     fn EndOpen(
         &self,
         context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<IFabricReplicator> {
+    ) -> ::mssf_core::WinResult<IFabricReplicator> {
         info!("AppInstance::EndOpen");
         let completed = unsafe { context.as_ref().expect("not ctx").CompletedSynchronously() };
         if !completed {
@@ -360,7 +360,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
     fn BeginClose(
         &self,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppInstance::BeginClose");
 
         // triggers shutdown to tokio
@@ -398,7 +398,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
     fn EndClose(
         &self,
         context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<()> {
+    ) -> ::mssf_core::WinResult<()> {
         info!("AppInstance::EndClose");
         let completed = unsafe { context.as_ref().expect("not ctx").CompletedSynchronously() };
         if !completed {
@@ -415,7 +415,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
         &self,
         _newrole: FABRIC_REPLICA_ROLE,
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> ::mssf_core::Result<IFabricAsyncOperationContext> {
+    ) -> ::mssf_core::WinResult<IFabricAsyncOperationContext> {
         info!("AppInstance::BeginChangeRole");
         let ctx: IFabricAsyncOperationContext = AsyncContext::new(callback.as_ref()).into();
         // invoke callback right away
@@ -426,7 +426,7 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
     fn EndChangeRole(
         &self,
         _context: windows_core::Ref<IFabricAsyncOperationContext>,
-    ) -> ::mssf_core::Result<IFabricStringResult> {
+    ) -> ::mssf_core::WinResult<IFabricStringResult> {
         info!("AppInstance::EndChangeRole");
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
         info!("AppInstance::EndChangeRole {}", addr);

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -13,7 +13,6 @@ use mssf_core::{
         },
         FabricClient,
     },
-    error::FabricErrorCode,
     types::{
         PartitionLoadInformation, PartitionLoadInformationQueryDescription,
         QueryServiceReplicaStatus, ReplicaRole, RestartReplicaDescription,
@@ -23,7 +22,7 @@ use mssf_core::{
         SingletonPartitionInfomation, StatefulServicePartitionQueryResult,
         StatefulServiceReplicaQueryResult,
     },
-    WString, GUID,
+    ErrorCode, WString, GUID,
 };
 
 static SVC_URI: &str = "fabric:/StatefulEchoApp/StatefulEchoAppService";
@@ -108,7 +107,7 @@ impl TestClient {
             .collect::<Vec<_>>();
         if replicas.len() < 3 {
             // replica are not ready.
-            return Err(FabricErrorCode::E_FAIL.into());
+            return Err(ErrorCode::E_FAIL.into());
         }
         let stateful = replicas
             .iter()
@@ -160,14 +159,14 @@ impl TestClient {
         let endpoints = partition.get_endpoint_list().iter().collect::<Vec<_>>();
         if endpoints.len() < 3 {
             // not available yet.
-            return Err(FabricErrorCode::E_FAIL.into());
+            return Err(ErrorCode::E_FAIL.into());
         }
         let primary = endpoints
             .iter()
             .find(|r| r.role == ServiceEndpointRole::StatefulPrimary);
         if primary.is_none() {
             // primary not available yet.
-            return Err(FabricErrorCode::E_FAIL.into());
+            return Err(ErrorCode::E_FAIL.into());
         }
         let secondary = endpoints
             .iter()

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use app::AppContext;
 use mssf_core::conf::{Config, FabricConfigSource};
 use mssf_core::debug::wait_for_debugger;
-use mssf_core::error::FabricError;
 use mssf_core::runtime::config::ConfigurationPackage;
 use mssf_core::runtime::executor::{DefaultExecutor, Executor};
 use mssf_core::runtime::node_context::NodeContext;
@@ -169,9 +168,6 @@ fn send_health_report(actctx: &CodePackageActivationContext) {
         &healthinfo,
         Some(&HealthReportSendOption { immediate: true }),
     ) {
-        error!(
-            "report application health failed: {:?}",
-            FabricError::from(e)
-        );
+        error!("report application health failed: {:?}", e);
     }
 }

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -13,7 +13,6 @@ use mssf_core::{
         },
         FabricClient, GatewayInformationResult, ServiceNotification,
     },
-    error::FabricErrorCode,
     types::{
         QueryServiceReplicaStatus, RemoveReplicaDescription, ServiceNotificationFilterDescription,
         ServiceNotificationFilterFlags, ServicePartitionInformation,
@@ -21,7 +20,7 @@ use mssf_core::{
         ServiceReplicaQueryDescription, ServiceReplicaQueryResult, SingletonPartitionInfomation,
         StatelessServiceInstanceQueryResult, StatelessServicePartitionQueryResult,
     },
-    WString, GUID,
+    ErrorCode, WString, GUID,
 };
 
 static ECHO_SVC_URI: &str = "fabric:/EchoApp/EchoAppService";
@@ -90,7 +89,7 @@ impl EchoTestClient {
                 _ => panic!("not stateless"),
             }),
             // replica might be restarting
-            None => Err(FabricErrorCode::E_FAIL.into()),
+            None => Err(ErrorCode::E_FAIL.into()),
         }
     }
 


### PR DESCRIPTION
mssf Error can be converted to ErrorCode enum easily and user app can check the enum to determine why API failed.
Raw api returns windows_core::Error and typically user converts to mssf Error all the time after mssf API call. This PR changes the return time of all safe APIs to mssf Error so it is easy to handle failures, and it displays human readable messages.
Renamed FabricError to Error and this is the mssf Error we will use. Renamed FabricErrorCode to ErrorCode since it is clear.

One part of this change that requires careful review is the Bridge layer code where the ctx from Begin and End functions are not type checked but casted. I checked them manually.