### PR TITLE
Slightly simplify Client Example

### DIFF
--- a/crates/samples/client/src/main.rs
+++ b/crates/samples/client/src/main.rs
@@ -4,10 +4,8 @@
 // ------------------------------------------------------------
 
 use mssf_com::FabricClient::IFabricQueryClient;
-use mssf_com::FabricCommon::IFabricAsyncOperationCallback;
 use mssf_com::FabricTypes::{FABRIC_NODE_QUERY_DESCRIPTION, FABRIC_NODE_QUERY_RESULT_ITEM};
 use mssf_core::sync::wait::WaitableCallback;
-use windows_core::Interface;
 
 fn main() -> mssf_core::Result<()> {
     println!("GetNodeCli");
@@ -18,12 +16,10 @@ fn main() -> mssf_core::Result<()> {
 
     let (token, callback) = WaitableCallback::channel();
 
-    let callback_arg: IFabricAsyncOperationCallback = callback.cast().expect("castfailed");
-
     let querydescription = FABRIC_NODE_QUERY_DESCRIPTION::default();
 
     let ctx = unsafe {
-        c.BeginGetNodeList(&querydescription, 1000, &callback_arg)
+        c.BeginGetNodeList(&querydescription, 1000, &callback)
             .expect("cannot get ctx")
     };
 


### PR DESCRIPTION
The example of interacting with the client contains an unnecessary explicit cast and unwrap that windows_core::Param seems more than happy to handle for us (probably a Deref implementation hiding somewhere).

So make it a bit cleaner of an example.