### PR TITLE
Support convert mssf_core::Error to common Error types in std

### DIFF
--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -93,6 +93,22 @@ impl core::fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
+// conversion from common error types in std
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        // Use the windows implementation to convert
+        crate::WinError::from(value).into()
+    }
+}
+
+impl From<core::num::TryFromIntError> for Error {
+    fn from(value: core::num::TryFromIntError) -> Self {
+        // Use windows implementation
+        crate::WinError::from(value).into()
+    }
+}
+
 #[cfg(test)]
 mod test {
 

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -102,6 +102,13 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<Error> for std::io::Error {
+    fn from(value: Error) -> Self {
+        // Use windows implementation
+        Self::from(crate::WinError::from(value))
+    }
+}
+
 impl From<core::num::TryFromIntError> for Error {
     fn from(value: core::num::TryFromIntError) -> Self {
         // Use windows implementation


### PR DESCRIPTION
This allows simpler code converting between mssf_core::Error and std Error types like std::io::Error, where the OS Error code is preserved in the conversion. windows_result added these conversions some times back, we will utilize it for mssf_core::Error.