### PR TITLE
Make NodeContext and NodeContext::get_sync available without Tokio

### DIFF
--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -15,7 +15,6 @@ pub mod config;
 pub mod error;
 #[cfg(feature = "tokio_async")]
 pub mod executor;
-#[cfg(feature = "tokio_async")]
 pub mod node_context;
 
 pub mod package_change;

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -5,10 +5,13 @@ use mssf_com::FabricRuntime::{IFabricNodeContextResult, IFabricNodeContextResult
 
 use crate::{
     strings::WStringWrap,
-    sync::{fabric_begin_end_proxy2, CancellationToken},
     types::NodeId,
 };
 
+#[cfg(feature = "tokio_async")]
+use crate::sync::{fabric_begin_end_proxy2, CancellationToken};
+
+#[cfg(feature = "tokio_async")]
 pub fn get_com_node_context(
     timeout_milliseconds: u32,
     cancellation_token: Option<CancellationToken>,
@@ -32,6 +35,7 @@ pub struct NodeContext {
     pub node_id: NodeId,
 }
 
+#[cfg(feature = "tokio_async")]
 impl NodeContext {
     // Get the node context from SF runtime
     pub async fn get(
@@ -42,7 +46,9 @@ impl NodeContext {
             .await??;
         Ok(Self::from(&com))
     }
+}
 
+impl NodeContext {
     // Get the node context synchronously
     pub fn get_sync() -> crate::Result<Self> {
         let com = crate::API_TABLE.fabric_get_node_context()?;

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -1,12 +1,14 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+#[cfg(feature = "tokio_async")]
 use std::time::Duration;
 
 use crate::{Interface, WString};
 use mssf_com::FabricRuntime::{IFabricNodeContextResult, IFabricNodeContextResult2};
 
-use crate::{
-    strings::WStringWrap,
-    types::NodeId,
-};
+use crate::{strings::WStringWrap, types::NodeId};
 
 #[cfg(feature = "tokio_async")]
 use crate::sync::{fabric_begin_end_proxy2, CancellationToken};

--- a/crates/libs/core/src/types/mockifabricclientsettings.rs
+++ b/crates/libs/core/src/types/mockifabricclientsettings.rs
@@ -31,9 +31,7 @@ pub(crate) mod test_utilities {
     use crate::strings::WStringWrap;
 
     /// # SAFETY
-    /// * This is test code, intended to be used with Miri
-    /// to validate that all reads SF might do of a
-    /// pointer / length pair are defined behavior
+    /// * This is test code, intended to be used with Miri to validate that all reads SF might do of a pointer / length pair are defined behavior
     /// * Caller is responsible for ensuring that the actual_len and actual_values_start parameters go together
     /// * Caller is responsible for ensuring that actual_values_start is valid for dereference for N elements at the time of the call, if non-null
     pub unsafe fn check_array_parameter<const N: usize>(

--- a/crates/libs/core/src/types/mockifabricclientsettings.rs
+++ b/crates/libs/core/src/types/mockifabricclientsettings.rs
@@ -48,7 +48,7 @@ pub(crate) mod test_utilities {
             return;
         }
         if expected_len == actual_len {
-            for i in 0..N {
+            for (i, expected_value) in expected_values.iter().enumerate() {
                 // SAFETY: caller promises that actual_values_start is valid for deference for N elements
                 let actual_value_ptr = unsafe { actual_values_start.add(i) };
                 assert!(
@@ -67,11 +67,11 @@ pub(crate) mod test_utilities {
                     .into_wstring()
                     .to_string_lossy();
                 assert_eq!(
-                    expected_values[i],
+                    *expected_value,
                     actual_val_str.as_str(),
                     "String at index {} should have had value {}, but had value {}",
                     i,
-                    expected_values[i],
+                    *expected_value,
                     actual_val_str.as_str()
                 )
             }


### PR DESCRIPTION
Make NodeContext and NodeContext::get_sync available without Tokio. 
Only the async functionality needed to be gated behind the feature.
Fix a few clippy warnings while I'm at it.