### PR TITLE
Replace debug trace with trace instrument macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ members = [
 
 [workspace.dependencies]
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3",  default-features = false, features = ["fmt"]}
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "fmt",
+] }
 tokio-util = "0.7"
 ctrlc = { version = "3.0", features = ["termination"] }
 tokio = { version = "1", features = ["full"] }
-windows = {version = "0.60", features = ["implement"]}
+windows = { version = "0.60", features = ["implement"] }
 windows-core = "0.60"
 windows-bindgen = "0.60"
 trait-variant = "0.1"
@@ -22,4 +24,4 @@ serde = "*"
 serde_derive = "*"
 # crates in this repo
 mssf-com = { path = "./crates/libs/com" }
-mssf-core = { path = "./crates/libs/core", default-features = true}
+mssf-core = { path = "./crates/libs/core", default-features = true }

--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -8,10 +8,7 @@ documentation = "https://learn.microsoft.com/en-us/azure/service-fabric/"
 repository = "https://github.com/Azure/service-fabric-rs"
 readme = "README.md"
 authors = ["youyuanwu@outlook.com"]
-include = [
-    "**/*.rs",
-    "Cargo.toml",
-]
+include = ["**/*.rs", "Cargo.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -8,10 +8,7 @@ documentation = "https://learn.microsoft.com/en-us/azure/service-fabric/"
 repository = "https://github.com/Azure/service-fabric-rs"
 readme = "README.md"
 authors = ["youyuanwu@outlook.com"]
-include = [
-    "**/*.rs",
-    "Cargo.toml",
-]
+include = ["**/*.rs", "Cargo.toml"]
 
 [features]
 default = ["config_source", "tokio_async", "tracing"]
@@ -23,24 +20,30 @@ config_source = ["dep:config"]
 tracing = ["dep:tracing"]
 
 [dependencies]
-tracing= { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 tokio = { version = "1", features = ["sync", "rt"], optional = true }
 tokio-util = { version = "0.7", optional = true }
 trait-variant = "0.1"
 bitflags = "2"
-config = { version = "0.14",  default-features = false, optional = true }
+config = { version = "0.14", default-features = false, optional = true }
 libloading = "0.8"
 lazy_static = "1"
 
 [dev-dependencies]
 # need time for testing
-tokio = { version = "1", features = ["sync" , "rt-multi-thread", "rt", "macros", "time"] }
+tokio = { version = "1", features = [
+    "sync",
+    "rt-multi-thread",
+    "rt",
+    "macros",
+    "time",
+] }
 
 # windows dep is only enabled on windows os.
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.60"
 features = [
-    "Win32_System_Diagnostics_Debug_Extensions" # for debug api
+    "Win32_System_Diagnostics_Debug_Extensions", # for debug api
 ]
 
 # treat pal as the windows core.
@@ -54,4 +57,9 @@ version = "0.0.22"
 path = "../com"
 version = "0.0.22"
 default-features = false
-features = ["ServiceFabric_FabricClient", "ServiceFabric_FabricCommon", "ServiceFabric_FabricTypes", "ServiceFabric_FabricRuntime"]
+features = [
+    "ServiceFabric_FabricClient",
+    "ServiceFabric_FabricCommon",
+    "ServiceFabric_FabricTypes",
+    "ServiceFabric_FabricRuntime",
+]

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -14,15 +14,16 @@ include = [
 ]
 
 [features]
-default = ["config_source", "tokio_async"]
+default = ["config_source", "tokio_async", "tracing"]
 # Required for a lot of callback functionality.
 # Also requires ctrlc for signal handling
 tokio_async = ["dep:tokio", "dep:tokio-util"]
 # Config crate required to implement its interface. 
 config_source = ["dep:config"]
+tracing = ["dep:tracing"]
 
 [dependencies]
-tracing.workspace = true
+tracing= { workspace = true, optional = true }
 tokio = { version = "1", features = ["sync", "rt"], optional = true }
 tokio-util = { version = "0.7", optional = true }
 trait-variant = "0.1"

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -329,7 +329,7 @@ impl From<&PartitionKeyType> for FABRIC_PARTITION_KEY_TYPE {
     }
 }
 
-#[cfg(feature="tokio_async")]
+#[cfg(feature = "tokio_async")]
 impl PartitionKeyType {
     // get raw ptr to pass in com api
     fn get_raw_opt(&self) -> Option<*const c_void> {

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -284,6 +284,7 @@ impl ServiceManagementClient {
 }
 
 // Handle to the registered service notification filter
+#[cfg(feature = "tokio_async")]
 pub struct FilterIdHandle {
     id: i64,
 }
@@ -328,6 +329,7 @@ impl From<&PartitionKeyType> for FABRIC_PARTITION_KEY_TYPE {
     }
 }
 
+#[cfg(feature="tokio_async")]
 impl PartitionKeyType {
     // get raw ptr to pass in com api
     fn get_raw_opt(&self) -> Option<*const c_void> {

--- a/crates/libs/core/src/conf/mod.rs
+++ b/crates/libs/core/src/conf/mod.rs
@@ -9,7 +9,6 @@
 // features of config-rs.
 
 use config::{ConfigError, Source};
-use tracing::debug;
 
 use crate::runtime::config::ConfigurationPackage;
 pub use config::Config;
@@ -43,11 +42,11 @@ impl Source for FabricConfigSource {
         let settings = self.inner.get_settings();
         settings.sections.iter().for_each(|section| {
             let section_name = section.name.to_string();
-            debug!("Section: {}", section_name);
             section.parameters.iter().for_each(|p| {
                 let param_name = p.name.to_string();
                 let param_val = p.value.to_string();
-                debug!("Param: {} Val: {}", param_name, param_val);
+                #[cfg(feature="tracing")]
+                tracing::debug!("Section: {} Param: {} Val: {}", section_name, param_name, param_val);
                 let val =
                     config::Value::new(Some(&uri_origion), config::ValueKind::String(param_val));
                 // section and param is separated by a dot.

--- a/crates/libs/core/src/conf/mod.rs
+++ b/crates/libs/core/src/conf/mod.rs
@@ -45,8 +45,13 @@ impl Source for FabricConfigSource {
             section.parameters.iter().for_each(|p| {
                 let param_name = p.name.to_string();
                 let param_val = p.value.to_string();
-                #[cfg(feature="tracing")]
-                tracing::debug!("Section: {} Param: {} Val: {}", section_name, param_name, param_val);
+                #[cfg(feature = "tracing")]
+                tracing::debug!(
+                    "Section: {} Param: {} Val: {}",
+                    section_name,
+                    param_name,
+                    param_val
+                );
                 let val =
                     config::Value::new(Some(&uri_origion), config::ValueKind::String(param_val));
                 // section and param is separated by a dot.

--- a/crates/libs/core/src/debug/mod.rs
+++ b/crates/libs/core/src/debug/mod.rs
@@ -7,11 +7,11 @@
 pub fn wait_for_debugger() {
     loop {
         if unsafe { windows::Win32::System::Diagnostics::Debug::IsDebuggerPresent().as_bool() } {
-            #[cfg(feature="tracing")]
+            #[cfg(feature = "tracing")]
             tracing::info!("Debugger found.");
             break;
         } else {
-            #[cfg(feature="tracing")]
+            #[cfg(feature = "tracing")]
             tracing::info!("Waiting for debugger.");
             std::thread::sleep(std::time::Duration::from_secs(5));
         }

--- a/crates/libs/core/src/debug/mod.rs
+++ b/crates/libs/core/src/debug/mod.rs
@@ -7,9 +7,11 @@
 pub fn wait_for_debugger() {
     loop {
         if unsafe { windows::Win32::System::Diagnostics::Debug::IsDebuggerPresent().as_bool() } {
+            #[cfg(feature="tracing")]
             tracing::info!("Debugger found.");
             break;
         } else {
+            #[cfg(feature="tracing")]
             tracing::info!("Waiting for debugger.");
             std::thread::sleep(std::time::Duration::from_secs(5));
         }

--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -81,6 +81,7 @@ impl<T: Send> JoinHandle<T> for DefaultJoinHandle<T> {
                 } else {
                     ErrorCode::E_FAIL
                 };
+                #[cfg(feature = "tracing")]
                 tracing::error!("DefaultJoinHandle: background task failed: {e}");
                 Err(e.into())
             }

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -13,7 +13,6 @@ use mssf_com::FabricRuntime::{
     IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
     IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
 };
-use tracing::debug;
 
 use crate::{
     error::ErrorCode,
@@ -39,13 +38,16 @@ impl StatefulServiceReplicaProxy {
 }
 
 impl StatefulServiceReplica for StatefulServiceReplicaProxy {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", err) // TODO: trace ret
+    )]
     async fn open(
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
         cancellation_token: CancellationToken,
     ) -> crate::Result<impl PrimaryReplicator> {
-        debug!("StatefulServiceReplicaProxy::open with mode {:?}", openmode);
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -73,13 +75,17 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         let res = PrimaryReplicatorProxy::new(p_rplctr);
         Ok(res)
     }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn change_role(
         &self,
         newrole: ReplicaRole,
         cancellation_token: CancellationToken,
     ) -> crate::Result<WString> {
         // replica address
-        debug!("StatefulServiceReplicaProxy::change_role {:?}", newrole);
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -90,8 +96,12 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         let addr = rx.await??;
         Ok(WStringWrap::from(&addr).into())
     }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
-        debug!("StatefulServiceReplicaProxy::close");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -101,8 +111,11 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret)
+    )]
     fn abort(&self) {
-        debug!("StatefulServiceReplicaProxy::abort");
         unsafe { self.com_impl.Abort() }
     }
 }
@@ -118,8 +131,11 @@ impl ReplicatorProxy {
 }
 
 impl Replicator for ReplicatorProxy {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<WString> {
-        debug!("ReplicatorProxy::open");
         // replicator address
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -131,8 +147,11 @@ impl Replicator for ReplicatorProxy {
         let addr = rx.await??;
         Ok(WStringWrap::from(&addr).into())
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
-        debug!("ReplicatorProxy::close");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -142,13 +161,16 @@ impl Replicator for ReplicatorProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn change_role(
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
         cancellation_token: CancellationToken,
     ) -> crate::Result<()> {
-        debug!("ReplicatorProxy::change_role");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -158,12 +180,15 @@ impl Replicator for ReplicatorProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn update_epoch(
         &self,
         epoch: &Epoch,
         cancellation_token: CancellationToken,
     ) -> crate::Result<()> {
-        debug!("ReplicatorProxy::update_epoch");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -173,16 +198,29 @@ impl Replicator for ReplicatorProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn get_current_progress(&self) -> crate::Result<i64> {
-        debug!("ReplicatorProxy::get_current_progress");
         unsafe { self.com_impl.GetCurrentProgress() }.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn get_catch_up_capability(&self) -> crate::Result<i64> {
-        debug!("ReplicatorProxy::get_catch_up_capability");
         unsafe { self.com_impl.GetCatchUpCapability() }.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret)
+    )]
     fn abort(&self) {
-        debug!("ReplicatorProxy::abort");
         unsafe { self.com_impl.Abort() }
     }
 }
@@ -235,8 +273,11 @@ impl Replicator for PrimaryReplicatorProxy {
 }
 
 impl PrimaryReplicator for PrimaryReplicatorProxy {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn on_data_loss(&self, cancellation_token: CancellationToken) -> crate::Result<u8> {
-        debug!("PrimaryReplicatorProxy::on_data_loss");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -246,12 +287,15 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn update_catch_up_replica_set_configuration(
         &self,
         currentconfiguration: &ReplicaSetConfig,
         previousconfiguration: &ReplicaSetConfig,
     ) -> crate::Result<()> {
-        debug!("PrimaryReplicatorProxy::update_catch_up_replica_set_configuration");
         let cc_view = currentconfiguration.get_view();
         let pc_view = previousconfiguration.get_view();
         unsafe {
@@ -260,12 +304,15 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
         }
         .map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
         cancellation_token: CancellationToken,
     ) -> crate::Result<()> {
-        debug!("PrimaryReplicatorProxy::wait_for_catch_up_quorum: catchupmode {catchupmode:?}");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -275,23 +322,29 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn update_current_replica_set_configuration(
         &self,
         currentconfiguration: &ReplicaSetConfig,
     ) -> crate::Result<()> {
-        debug!("PrimaryReplicatorProxy::update_current_replica_set_configuration");
         unsafe {
             self.com_impl
                 .UpdateCurrentReplicaSetConfiguration(currentconfiguration.get_view().get_raw())
         }
         .map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
         cancellation_token: CancellationToken,
     ) -> crate::Result<()> {
-        debug!("PrimaryReplicatorProxy::build_replica");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -305,8 +358,11 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
         );
         rx.await?.map_err(crate::Error::from)
     }
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn remove_replica(&self, replicaid: i64) -> crate::Result<()> {
-        debug!("PrimaryReplicatorProxy::remove_replica");
         unsafe { self.com_impl.RemoveReplica(replicaid) }.map_err(crate::Error::from)
     }
 }

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -20,7 +20,6 @@ use mssf_com::{
     },
     FabricTypes::FABRIC_URI,
 };
-use tracing::debug;
 use windows_core::implement;
 
 use super::{
@@ -54,6 +53,10 @@ where
     F: StatelessServiceFactory,
 {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn CreateInstance(
         &self,
         servicetypename: &crate::PCWSTR,
@@ -63,7 +66,6 @@ where
         partitionid: &crate::GUID,
         instanceid: i64,
     ) -> crate::WinResult<IFabricStatelessServiceInstance> {
-        debug!("StatelessServiceFactoryBridge::CreateInstance");
         let h_servicename = WStringWrap::from(crate::PCWSTR(servicename.0)).into();
         let h_servicetypename = WStringWrap::from(*servicetypename).into();
         let data = unsafe {
@@ -121,12 +123,15 @@ where
     E: Executor,
     S: StatelessServiceInstance + 'static,
 {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn BeginOpen(
         &self,
         partition: windows_core::Ref<IFabricStatelessServicePartition>,
         callback: windows_core::Ref<super::IFabricAsyncOperationCallback>,
     ) -> crate::WinResult<super::IFabricAsyncOperationContext> {
-        debug!("IFabricStatelessServiceInstanceBridge::BeginOpen");
         let partition_cp = partition.unwrap().clone();
         let partition_bridge = StatelessServicePartition::new(partition_cp);
         let inner = self.inner.clone();
@@ -140,19 +145,25 @@ where
         })
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn EndOpen(
         &self,
         context: windows_core::Ref<super::IFabricAsyncOperationContext>,
     ) -> crate::WinResult<IFabricStringResult> {
-        debug!("IFabricStatelessServiceInstanceBridge::EndOpen");
         BridgeContext::result(context)?
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn BeginClose(
         &self,
         callback: windows_core::Ref<super::IFabricAsyncOperationCallback>,
     ) -> crate::WinResult<super::IFabricAsyncOperationContext> {
-        debug!("IFabricStatelessServiceInstanceBridge::BeginClose");
         let inner = self.inner.clone();
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
@@ -160,16 +171,22 @@ where
         })
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     fn EndClose(
         &self,
         context: windows_core::Ref<super::IFabricAsyncOperationContext>,
     ) -> crate::WinResult<()> {
-        debug!("IFabricStatelessServiceInstanceBridge::EndClose");
         BridgeContext::result(context)?
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret)
+    )]
     fn Abort(&self) {
-        debug!("IFabricStatelessServiceInstanceBridge::Abort");
         self.inner.abort()
     }
 }

--- a/crates/libs/core/src/runtime/store.rs
+++ b/crates/libs/core/src/runtime/store.rs
@@ -24,8 +24,7 @@ impl IFabricStoreEventHandler_Impl for DummyStoreEventHandler_Impl {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret)
     )]
-    fn OnDataLoss(&self) {
-    }
+    fn OnDataLoss(&self) {}
 }
 
 pub fn create_com_key_value_store_replica(

--- a/crates/libs/core/src/runtime/store.rs
+++ b/crates/libs/core/src/runtime/store.rs
@@ -12,7 +12,6 @@ use mssf_com::{
     },
     FabricTypes::{FABRIC_ESE_LOCAL_STORE_SETTINGS, FABRIC_LOCAL_STORE_KIND},
 };
-use tracing::info;
 use windows_core::implement;
 
 use crate::types::{EseLocalStoreSettings, LocalStoreKind, ReplicatorSettings};
@@ -21,8 +20,11 @@ use crate::types::{EseLocalStoreSettings, LocalStoreKind, ReplicatorSettings};
 pub struct DummyStoreEventHandler {}
 
 impl IFabricStoreEventHandler_Impl for DummyStoreEventHandler_Impl {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret)
+    )]
     fn OnDataLoss(&self) {
-        info!("DummyStoreEventHandler::OnDataLoss");
     }
 }
 

--- a/crates/libs/core/src/runtime/store_proxy.rs
+++ b/crates/libs/core/src/runtime/store_proxy.rs
@@ -10,7 +10,6 @@ use mssf_com::{
     },
     FabricTypes::{FABRIC_KEY_VALUE_STORE_ITEM, FABRIC_KEY_VALUE_STORE_ITEM_METADATA},
 };
-use tracing::debug;
 
 use crate::sync::{fabric_begin_end_proxy, CancellationToken};
 
@@ -106,12 +105,15 @@ impl TransactionProxy {
         unsafe { self.com_impl.get_IsolationLevel().into() }
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, level = "debug", ret, err)
+    )]
     pub async fn commit(
         &self,
         timeoutmilliseconds: u32,
         cancellation_token: Option<CancellationToken>,
     ) -> crate::Result<i64> {
-        debug!("TransactionProxy::commit");
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(

--- a/crates/libs/core/src/sync/wait.rs
+++ b/crates/libs/core/src/sync/wait.rs
@@ -10,7 +10,6 @@ use mssf_com::FabricCommon::{
     IFabricAsyncOperationCallback, IFabricAsyncOperationCallback_Impl,
     IFabricAsyncOperationContext, IFabricAsyncOperationContext_Impl,
 };
-use tracing::debug;
 use windows_core::implement;
 
 #[derive(Debug)]
@@ -82,7 +81,6 @@ impl AsyncContext {
     // construct ctx. Note: caller needs to invoke callback.
     // This is different from cpp impl.
     pub fn new(callback: core::option::Option<&IFabricAsyncOperationCallback>) -> AsyncContext {
-        debug!("AsyncContext::new");
         let callback_copy: IFabricAsyncOperationCallback = callback.expect("msg").clone();
 
         AsyncContext {
@@ -101,14 +99,12 @@ impl IFabricAsyncOperationContext_Impl for AsyncContext_Impl {
     }
 
     fn Callback(&self) -> crate::WinResult<IFabricAsyncOperationCallback> {
-        debug!("AsyncContext::Callback");
         // get a view of the callback
         let callback_copy: IFabricAsyncOperationCallback = self.callback_.clone();
         Ok(callback_copy)
     }
 
     fn Cancel(&self) -> crate::WinResult<()> {
-        debug!("AsyncContext::Cancel");
         Ok(())
     }
 }

--- a/crates/libs/pal/Cargo.toml
+++ b/crates/libs/pal/Cargo.toml
@@ -7,10 +7,7 @@ description = "mssf-pal enables service fabric rust to run on linux"
 documentation = "https://learn.microsoft.com/en-us/azure/service-fabric/"
 repository = "https://github.com/Azure/service-fabric-rs"
 readme = "README.md"
-include = [
-    "**/*.rs",
-    "Cargo.toml",
-]
+include = ["**/*.rs", "Cargo.toml"]
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
Added feature trace to enable tracing.
The bridge and proxy layer traces are instrumented by macro. The importance of the trace at bridge and proxy layer is to capture the return and error values. Users of mssf should do their own tracing with more verbosities.
Formatted all toml files.