### PR TITLE
Enable info span for bridge functions

### DIFF
--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -73,7 +73,7 @@ impl<T: Send> JoinHandle<T> for DefaultJoinHandle<T> {
         match self.inner.await {
             Ok(x) => Ok(x),
             Err(e) => {
-                let e = if e.is_cancelled() {
+                let ec = if e.is_cancelled() {
                     // we never cancel in executor
                     ErrorCode::E_ABORT
                 } else if e.is_panic() {
@@ -82,8 +82,8 @@ impl<T: Send> JoinHandle<T> for DefaultJoinHandle<T> {
                     ErrorCode::E_FAIL
                 };
                 #[cfg(feature = "tracing")]
-                tracing::error!("DefaultJoinHandle: background task failed: {e}");
-                Err(e.into())
+                tracing::error!("DefaultJoinHandle: background task failed: {ec}, msg:{e}");
+                Err(ec.into())
             }
         }
     }

--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -82,7 +82,7 @@ impl<T: Send> JoinHandle<T> for DefaultJoinHandle<T> {
                     ErrorCode::E_FAIL
                 };
                 #[cfg(feature = "tracing")]
-                tracing::error!("DefaultJoinHandle: background task failed: {ec}, msg:{e}");
+                tracing::error!("DefaultJoinHandle: background task failed: {ec}, msg: {e}");
                 Err(ec.into())
             }
         }

--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -70,7 +70,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn CreateReplica(
         &self,
@@ -148,7 +148,7 @@ where
 {
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginOpen(
         &self,
@@ -167,7 +167,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndOpen(
         &self,
@@ -179,7 +179,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginChangeRole(
         &self,
@@ -201,7 +201,7 @@ where
     }
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndChangeRole(
         &self,
@@ -213,7 +213,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginUpdateEpoch(
         &self,
@@ -233,7 +233,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndUpdateEpoch(
         &self,
@@ -244,7 +244,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginClose(
         &self,
@@ -259,7 +259,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndClose(
         &self,
@@ -270,7 +270,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret)
+        tracing::instrument(skip_all, ret(level = "debug"))
     )]
     fn Abort(&self) {
         self.inner.abort();
@@ -278,7 +278,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn GetCurrentProgress(&self) -> crate::WinResult<i64> {
         let lsn = self.inner.get_current_progress();
@@ -287,7 +287,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn GetCatchUpCapability(&self) -> crate::WinResult<i64> {
         let lsn = self.inner.get_catch_up_capability();
@@ -431,7 +431,7 @@ where
 {
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginOnDataLoss(
         &self,
@@ -450,7 +450,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndOnDataLoss(
         &self,
@@ -462,7 +462,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn UpdateCatchUpReplicaSetConfiguration(
         &self,
@@ -478,7 +478,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginWaitForCatchUpQuorum(
         &self,
@@ -498,7 +498,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndWaitForCatchUpQuorum(
         &self,
@@ -510,7 +510,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn UpdateCurrentReplicaSetConfiguration(
         &self,
@@ -525,7 +525,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginBuildReplica(
         &self,
@@ -550,7 +550,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndBuildReplica(
         &self,
@@ -561,7 +561,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn RemoveReplica(&self, replicaid: i64) -> crate::WinResult<()> {
         self.inner
@@ -613,7 +613,7 @@ where
 {
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginOpen(
         &self,
@@ -645,7 +645,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndOpen(
         &self,
@@ -656,7 +656,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginChangeRole(
         &self,
@@ -677,7 +677,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndChangeRole(
         &self,
@@ -688,7 +688,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginClose(
         &self,
@@ -703,7 +703,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndClose(
         &self,
@@ -714,7 +714,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret)
+        tracing::instrument(skip_all, ret(level = "debug"))
     )]
     fn Abort(&self) {
         self.inner.as_ref().abort();

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -55,7 +55,7 @@ where
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn CreateInstance(
         &self,
@@ -125,7 +125,7 @@ where
 {
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginOpen(
         &self,
@@ -147,7 +147,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndOpen(
         &self,
@@ -158,7 +158,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn BeginClose(
         &self,
@@ -173,7 +173,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret, err)
+        tracing::instrument(skip_all, ret(level = "debug"), err)
     )]
     fn EndClose(
         &self,
@@ -184,7 +184,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, level = "debug", ret)
+        tracing::instrument(skip_all, ret(level = "debug"))
     )]
     fn Abort(&self) {
         self.inner.abort()

--- a/crates/libs/core/src/sync/bridge_context.rs
+++ b/crates/libs/core/src/sync/bridge_context.rs
@@ -84,7 +84,7 @@ where
         let self_cp: IFabricAsyncOperationContext = self.into();
         let self_cp2 = self_cp.clone();
         let rt_cp = rt.clone();
-        rt.spawn(async move {
+        let task = async move {
             // Run user code in a task and wait on its status.
             // If user code panics we propagate the error back to SF.
             let task_res = rt_cp.spawn(future).join().await;
@@ -95,7 +95,16 @@ where
             self_impl.set_content(task_res);
             let cb = unsafe { self_cp.Callback().unwrap() };
             unsafe { cb.Invoke(&self_cp) };
-        });
+        };
+        tracing::info!("debug span in context");
+        /// Propagate the span so that the executor has the right trace.
+        /// The trace would likely have BeginXXX as the function where spawn()
+        /// is called.
+        #[cfg(feature = "tracing")]
+        use tracing::Instrument;
+        #[cfg(feature = "tracing")]
+        let task = task.in_current_span();
+        rt.spawn(task);
         Ok(self_cp2)
     }
 

--- a/crates/libs/core/src/sync/bridge_context.rs
+++ b/crates/libs/core/src/sync/bridge_context.rs
@@ -96,7 +96,6 @@ where
             let cb = unsafe { self_cp.Callback().unwrap() };
             unsafe { cb.Invoke(&self_cp) };
         };
-        tracing::info!("debug span in context");
         /// Propagate the span so that the executor has the right trace.
         /// The trace would likely have BeginXXX as the function where spawn()
         /// is called.


### PR DESCRIPTION
Original instrument creates a debug level span that has no effect on traces of info level.
```rs
 tracing::instrument(skip_all, level = "debug", ret, err)
```
Changed the span level to be info by default. But trace the ret value only in debug trace.
```rs
 tracing::instrument(skip_all, ret(level = "debug"), err)
```
The executor trace is fixed up to contain the correct span and panic message.
For example
```log
025-04-09T21:35:26.812342Z ERROR BeginOpen: mssf_core::runtime::executor: DefaultJoinHandle: background task failed: E_UNEXPECTED, msg:task 18 panicked with message "test panic"
```