### PR TITLE
Enable ubuntu20 and azl3 container build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,10 +176,17 @@ jobs:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --privileged
     steps:
-      - name: tdnf
+      - name: tdnf init
         run: |
+          # Import the GPG key
+          rpm --import https://packages.microsoft.com/keys/microsoft.asc
+          # Clean and refresh repository metadata
+          tdnf clean all
+          tdnf makecache
           tdnf update -y
           tdnf install -y tar unzip
+      - name: tdnf install
+        run: tdnf install -y tar unzip
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,7 +181,7 @@ jobs:
       - name: tdnf install
         run: |
           tdnf update --noplugins --skipsignature -y
-          tdnf install --noplugins --skipsignature -y tar unzip ca-certificates gcc glibc-devel binutils
+          tdnf install --noplugins --skipsignature -y tar unzip ca-certificates gcc glibc-devel binutils make
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,3 +168,37 @@ jobs:
 
     - name: Run cargo test
       run: cargo test --all -- --nocapture
+
+  # Do not run test because SF onebox is not supported on azl3 yet.
+  build-azl3:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/azurelinux/base/core:3.0
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "3.21.2"
+
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.86.0
+          components: rustfmt, clippy
+      
+      - name: Run cargo check
+        run: cargo check
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+      
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings
+
+      - name: run cmake
+        run: > 
+          cmake . -DCMAKE_BUILD_TYPE=Debug -B build
+      - name: run build
+        run: cmake --build build --config Debug

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,11 +66,13 @@ jobs:
       run: cargo test --all -- --nocapture
 
   build-linux:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+      options: --privileged
     strategy:
       matrix:
         BUILD_TYPE: ["Debug"]
-        os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v4
     - name: apt-get

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,7 +181,7 @@ jobs:
       - name: tdnf install
         run: |
           tdnf update --noplugins --skipsignature -y
-          tdnf install --noplugins --skipsignature -y tar unzip
+          tdnf install --noplugins --skipsignature -y tar unzip ca-certificates
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,7 +179,7 @@ jobs:
       - name: tdnf
         run: |
           tdnf update -y
-          tdnf install -y tar
+          tdnf install -y tar unzip
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,9 @@ jobs:
         apt-get install -y sudo
 
     - name: apt-get
-      run: sudo apt-get update && sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang -y
+      run: |
+        sudo apt-get update 
+        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip -y
 
     - name: install sf
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
-      options: --privileged
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     strategy:
       matrix:
         BUILD_TYPE: ["Debug"]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -v /sys/fs/cgroup:/sys/fs/cgroup:ro 
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
     - uses: actions/checkout@v4
 
@@ -77,7 +77,7 @@ jobs:
     - name: apt-get
       run: |
         sudo apt-get update 
-        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip systemd systemd-sysv -y
+        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip -y
 
     - name: install sf
       run: |
@@ -128,42 +128,43 @@ jobs:
       run: sfctl --version
 
     # Cannot start this up due to running in container.
-    - name: start sf
-      run: sudo /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh
+    # TODO: fix running SF in container and enable tests
+    # - name: start sf
+    #   run: sudo /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh
 
-    - name: test cluster health
-      run: |
-        set +e # do not exit on error
-        counter=0
-        COMMAND_STATUS=1
-        until [ $COMMAND_STATUS -eq 0 ]; do
-          echo "attempt #${counter}"
-          sfctl cluster select
-          COMMAND_STATUS=$?
-          sleep 1
-          let counter=counter+1
-          if [[ $counter -eq 10 ]] ;
-          then
-            echo "Retry max reached" && exit 1
-          fi
-        done
-        sfctl cluster health
-
-    - name: run echo app
-      run: |
-        sleep 120 # wait for cluster to be up
-        sfctl application upload --path build/echoapp_root
-        sfctl application provision --application-type-build-path echoapp_root
-        sfctl application create --app-name fabric:/EchoApp --app-type EchoApp --app-version 0.0.1
-
-    # TODO: this fails in CI    
-    # - name: resolve service
+    # - name: test cluster health
     #   run: |
-    #     sleep 120 # wait for app to be up
-    #     sfctl service resolve --service-id EchoApp/EchoAppService
+    #     set +e # do not exit on error
+    #     counter=0
+    #     COMMAND_STATUS=1
+    #     until [ $COMMAND_STATUS -eq 0 ]; do
+    #       echo "attempt #${counter}"
+    #       sfctl cluster select
+    #       COMMAND_STATUS=$?
+    #       sleep 1
+    #       let counter=counter+1
+    #       if [[ $counter -eq 10 ]] ;
+    #       then
+    #         echo "Retry max reached" && exit 1
+    #       fi
+    #     done
+    #     sfctl cluster health
 
-    - name: Run cargo test
-      run: cargo test --all -- --nocapture
+    # - name: run echo app
+    #   run: |
+    #     sleep 120 # wait for cluster to be up
+    #     sfctl application upload --path build/echoapp_root
+    #     sfctl application provision --application-type-build-path echoapp_root
+    #     sfctl application create --app-name fabric:/EchoApp --app-type EchoApp --app-version 0.0.1
+
+    # # TODO: this fails in CI    
+    # # - name: resolve service
+    # #   run: |
+    # #     sleep 120 # wait for app to be up
+    # #     sfctl service resolve --service-id EchoApp/EchoAppService
+
+    # - name: Run cargo test
+    #   run: cargo test --all -- --nocapture
 
   # Do not run test because SF onebox is not supported on azl3 yet.
   build-azl3:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,7 +181,7 @@ jobs:
       - name: tdnf install
         run: |
           tdnf update --noplugins --skipsignature -y
-          tdnf install --noplugins --skipsignature -y tar unzip ca-certificates
+          tdnf install --noplugins --skipsignature -y tar unzip ca-certificates gcc glibc-devel binutils
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: apt-get
       run: |
         sudo apt-get update 
-        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip -y
+        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip systemd -y
 
     - name: install sf
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,6 +126,8 @@ jobs:
 
     - name: install sfctl
       run: |
+        sudo apt-get install python3-pip -y
+        python3 -m pip install --upgrade pip
         pip3 install -I sfctl==11.1.0
         echo "~/.local/bin" >> $GITHUB_PATH
     

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -186,7 +186,7 @@ jobs:
           tdnf clean all
           tdnf makecache
           tdnf update -y
-          tdnf install -y tar unzip
+
       - name: tdnf install
         run: tdnf install -y tar unzip
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -178,17 +178,10 @@ jobs:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --privileged
     steps:
-      - name: tdnf init
-        run: |
-          # Import the GPG key
-          rpm --import https://packages.microsoft.com/keys/microsoft.asc
-          # Clean and refresh repository metadata
-          tdnf clean all
-          tdnf makecache
-          tdnf update -y
-
       - name: tdnf install
-        run: tdnf install -y tar unzip
+        run: |
+          tdnf update --noplugins --skipsignature -y
+          tdnf install --noplugins --skipsignature -y tar unzip
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,11 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        BUILD_TYPE: ["Debug"]
-        os: [ windows-latest ]
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -33,9 +29,9 @@ jobs:
 
     - name: run cmake
       run: > 
-        cmake . -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -B build
+        cmake . -DCMAKE_BUILD_TYPE=Debug -B build
     - name: run build
-      run: cmake --build build --config ${{ matrix.BUILD_TYPE }}
+      run: cmake --build build --config Debug
 
     # mysql bin has conflicting dlls with fabric than prevents fabric from starting
     - name: Remove conflict dll paths
@@ -65,14 +61,11 @@ jobs:
     - name: Run cargo test
       run: cargo test --all -- --nocapture
 
-  build-linux:
+  build-u20:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
-      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0
-    strategy:
-      matrix:
-        BUILD_TYPE: ["Debug"]
+      options: --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -v /sys/fs/cgroup:/sys/fs/cgroup:ro 
     steps:
     - uses: actions/checkout@v4
 
@@ -84,7 +77,7 @@ jobs:
     - name: apt-get
       run: |
         sudo apt-get update 
-        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip systemd -y
+        sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang unzip systemd systemd-sysv -y
 
     - name: install sf
       run: |
@@ -120,9 +113,9 @@ jobs:
 
     - name: run cmake
       run: > 
-        cmake . -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -B build
+        cmake . -DCMAKE_BUILD_TYPE=Debug -B build
     - name: run build
-      run: cmake --build build --config ${{ matrix.BUILD_TYPE }}
+      run: cmake --build build --config Debug
 
     - name: install sfctl
       run: |
@@ -134,6 +127,7 @@ jobs:
     - name: test sfctl
       run: sfctl --version
 
+    # Cannot start this up due to running in container.
     - name: start sf
       run: sudo /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,6 +176,11 @@ jobs:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --privileged
     steps:
+      - name: tdnf
+        run: |
+          tdnf update -y
+          tdnf install -y tar
+
       - uses: actions/checkout@v4
 
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,12 @@ jobs:
         BUILD_TYPE: ["Debug"]
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install sudo
+      run: |
+        apt-get update
+        apt-get install -y sudo
+
     - name: apt-get
       run: sudo apt-get update && sudo apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils clang -y
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 project(service-fabric-rs LANGUAGES)
 
+if(WIN32)
 message(STATUS "fetching fabric_metadata")
 include(FetchContent)
 FetchContent_Declare(fabric_metadata
@@ -13,6 +14,7 @@ if(NOT fabric_metadata_POPULATED)
     FetchContent_Populate(fabric_metadata)
     # do not add to cmake build since we only need winmd file to generate code.
 endif()
+endif(WIN32)
 
 # generate rust code
 find_program (


### PR DESCRIPTION
Ubuntu20 VM image is deprecated in github action, and the ci job is failing.
Moved to use container u20 to build. 
Added azl3 container build.
The linux tests cannot run yet, more PRs needed to run SF in container.