### PR TITLE
FabricClient: Add create delete service api

### DIFF
--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -34,6 +34,8 @@ mod health;
 pub use health::*;
 mod settings;
 pub use settings::*;
+mod service;
+pub use service::{ServiceDescription, StatefulServiceDescription, StatelessServiceDescription};
 
 // FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS
 bitflags::bitflags! {

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -34,6 +34,7 @@ mod health;
 pub use health::*;
 mod settings;
 pub use settings::*;
+
 mod service;
 pub use service::{ServiceDescription, StatefulServiceDescription, StatelessServiceDescription};
 

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
 use std::time::SystemTime;
 
 use crate::{types::ServicePartitionAccessStatus, WString, GUID, PCWSTR};

--- a/crates/libs/core/src/types/client/service.rs
+++ b/crates/libs/core/src/types/client/service.rs
@@ -1,0 +1,244 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::ffi::c_void;
+
+use mssf_com::FabricTypes::{
+    FABRIC_SERVICE_DESCRIPTION, FABRIC_SERVICE_DESCRIPTION_KIND_STATEFUL,
+    FABRIC_SERVICE_DESCRIPTION_KIND_STATELESS, FABRIC_STATEFUL_SERVICE_DESCRIPTION,
+    FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX1, FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX2,
+    FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX3, FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX4,
+    FABRIC_STATELESS_SERVICE_DESCRIPTION, FABRIC_STATELESS_SERVICE_DESCRIPTION_EX1,
+    FABRIC_STATELESS_SERVICE_DESCRIPTION_EX2, FABRIC_STATELESS_SERVICE_DESCRIPTION_EX3,
+    FABRIC_STATELESS_SERVICE_DESCRIPTION_EX4, FABRIC_URI,
+};
+use windows_core::WString;
+
+use crate::types::{MoveCost, PartitionSchemeDescription, ServicePackageActivationMode};
+
+pub enum ServiceDescription {
+    // Invalid,
+    Stateful(StatefulServiceDescription), // FABRIC_STATEFUL_SERVICE_DESCRIPTION
+    Stateless(StatelessServiceDescription), // FABRIC_STATELESS_SERVICE_DESCRIPTION
+}
+
+pub struct StatefulServiceDescription {
+    // common
+    pub application_name: WString,
+    pub service_name: WString,
+    pub service_type_name: WString,
+    pub initialization_data: Vec<u8>,
+    pub partition_scheme_description: PartitionSchemeDescription,
+    // stateful
+    pub min_replica_set_size: i32,
+    pub target_replica_set_size: i32,
+    // common
+    pub placement_contraints: WString,
+    pub correlations: Vec<WString>, // TODO: FABRIC_SERVICE_CORRELATION_DESCRIPTION
+    pub metrics: Vec<WString>,      // TODO: FABRIC_SERVICE_LOAD_METRIC_DESCRIPTION
+    pub has_persistent_state: bool,
+    // ex1
+    pub policy_list: Vec<WString>, // TODO: FABRIC_SERVICE_PLACEMENT_POLICY_DESCRIPTION
+    pub failover_settings: WString, // TODO: FABRIC_SERVICE_PARTITION_KIND
+    // ex2
+    pub default_move_cost: Option<MoveCost>, // TODO: FABRIC_MOVE_COST
+    // ex3
+    pub service_package_activation_mode: ServicePackageActivationMode,
+    pub service_dns_name: WString, // TODO: FABRIC_SERVICE_DNS_NAME
+    // ex4
+    pub service_scaling_policys: Vec<WString>, // TODO: FABRIC_SERVICE_SCALING_POLICY
+}
+
+pub(crate) struct StatefulServiceDescriptionRaw {
+    internal: Box<FABRIC_STATEFUL_SERVICE_DESCRIPTION>,
+    _internal_ex1: Box<FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX1>,
+    _internal_ex2: Box<FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX2>,
+    _internal_ex3: Box<FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX3>,
+    _internal_ex4: Box<FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX4>,
+}
+
+impl StatefulServiceDescriptionRaw {
+    pub fn as_raw(&self) -> &FABRIC_STATEFUL_SERVICE_DESCRIPTION {
+        self.internal.as_ref()
+    }
+}
+
+impl StatefulServiceDescription {
+    // Initializes the internal struct
+    fn build_raw(&self) -> StatefulServiceDescriptionRaw {
+        let ex4 = Box::new(FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX4 {
+            ServiceScalingPolicies: std::ptr::null_mut(), // TODO: support scaling policies
+            ScalingPolicyCount: 0,
+            Reserved: std::ptr::null_mut(),
+        });
+        let ex3 = Box::new(FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX3 {
+            ServiceDnsName: self.service_dns_name.as_pcwstr(),
+            ServicePackageActivationMode: self.service_package_activation_mode.clone().into(),
+            Reserved: ex4.as_ref() as *const _ as *mut c_void,
+        });
+        let ex2 = Box::new(FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX2 {
+            IsDefaultMoveCostSpecified: self.default_move_cost.is_some(),
+            DefaultMoveCost: self
+                .default_move_cost
+                .clone()
+                .unwrap_or(MoveCost::Zero)
+                .into(),
+            Reserved: ex3.as_ref() as *const _ as *mut c_void,
+        });
+        let ex1 = Box::new(FABRIC_STATEFUL_SERVICE_DESCRIPTION_EX1 {
+            PolicyList: std::ptr::null_mut(),       // TODO:
+            FailoverSettings: std::ptr::null_mut(), // TODO:
+            Reserved: ex2.as_ref() as *const _ as *mut c_void,
+        });
+
+        let internal = Box::new(FABRIC_STATEFUL_SERVICE_DESCRIPTION {
+            ApplicationName: FABRIC_URI(self.application_name.as_ptr() as *mut u16),
+            ServiceName: FABRIC_URI(self.service_name.as_ptr() as *mut u16),
+            ServiceTypeName: self.service_type_name.as_pcwstr(),
+            InitializationDataSize: self.initialization_data.len() as u32,
+            InitializationData: self.initialization_data.as_ptr() as *mut u8,
+            PartitionScheme: self.partition_scheme_description.as_raw().0,
+            PartitionSchemeDescription: self.partition_scheme_description.as_raw().1,
+            TargetReplicaSetSize: self.target_replica_set_size,
+            MinReplicaSetSize: self.min_replica_set_size,
+            PlacementConstraints: self.placement_contraints.as_pcwstr(), // TODO:
+            CorrelationCount: 0,
+            Correlations: std::ptr::null_mut(), // TODO: FABRIC_SERVICE_CORRELATION_DESCRIPTION
+            Metrics: std::ptr::null_mut(),      // TODO:
+            MetricCount: 0,
+            HasPersistedState: self.has_persistent_state,
+            Reserved: ex1.as_ref() as *const _ as *mut c_void,
+        });
+
+        StatefulServiceDescriptionRaw {
+            internal,
+            _internal_ex1: ex1,
+            _internal_ex2: ex2,
+            _internal_ex3: ex3,
+            _internal_ex4: ex4,
+        }
+    }
+}
+
+pub struct StatelessServiceDescription {
+    // common
+    pub application_name: WString,
+    pub service_name: WString,
+    pub service_type_name: WString,
+    pub initialization_data: Vec<u8>,
+    pub partition_scheme_description: PartitionSchemeDescription,
+    // stateless
+    pub instance_count: i32,
+    // common
+    pub placement_contraints: WString,
+    pub correlations: Vec<WString>, // TODO: FABRIC_SERVICE_CORRELATION_DESCRIPTION
+    pub metrics: Vec<WString>,      // TODO: FABRIC_SERVICE_LOAD_METRIC_DESCRIPTION
+    // ex1
+    pub policy_list: Vec<WString>, // TODO: FABRIC_SERVICE_PLACEMENT_POLICY_DESCRIPTION
+    // ex2
+    pub default_move_cost: Option<MoveCost>, // TODO: FABRIC_MOVE_COST
+    // ex3
+    pub service_package_activation_mode: ServicePackageActivationMode, // TODO: FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE
+    pub service_dns_name: WString, // TODO: FABRIC_SERVICE_DNS_NAME
+    // ex4
+    pub service_scaling_policys: Vec<WString>, // TODO: FABRIC_SERVICE_SCALING_POLICY
+}
+
+pub(crate) struct StatelessServiceDescriptionRaw {
+    internal: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION>,
+    _internal_ex1: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX1>,
+    _internal_ex2: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX2>,
+    _internal_ex3: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX3>,
+    _internal_ex4: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX4>,
+}
+impl StatelessServiceDescriptionRaw {
+    pub fn as_raw(&self) -> &FABRIC_STATELESS_SERVICE_DESCRIPTION {
+        self.internal.as_ref()
+    }
+}
+
+impl StatelessServiceDescription {
+    fn build_raw(&self) -> StatelessServiceDescriptionRaw {
+        let ex4 = Box::new(FABRIC_STATELESS_SERVICE_DESCRIPTION_EX4 {
+            ServiceScalingPolicies: std::ptr::null_mut(), // TODO: support scaling policies
+            ScalingPolicyCount: 0,
+            Reserved: std::ptr::null_mut(),
+        });
+        let ex3 = Box::new(FABRIC_STATELESS_SERVICE_DESCRIPTION_EX3 {
+            ServiceDnsName: self.service_dns_name.as_pcwstr(),
+            ServicePackageActivationMode: self.service_package_activation_mode.clone().into(),
+            Reserved: ex4.as_ref() as *const _ as *mut c_void,
+        });
+        let ex2 = Box::new(FABRIC_STATELESS_SERVICE_DESCRIPTION_EX2 {
+            IsDefaultMoveCostSpecified: self.default_move_cost.is_some(),
+            DefaultMoveCost: self
+                .default_move_cost
+                .clone()
+                .unwrap_or(MoveCost::Zero)
+                .into(),
+            Reserved: ex3.as_ref() as *const _ as *mut c_void,
+        });
+        let ex1 = Box::new(FABRIC_STATELESS_SERVICE_DESCRIPTION_EX1 {
+            PolicyList: std::ptr::null_mut(), // TODO:
+            Reserved: ex2.as_ref() as *const _ as *mut c_void,
+        });
+        let internal = Box::new(FABRIC_STATELESS_SERVICE_DESCRIPTION {
+            ApplicationName: FABRIC_URI(self.application_name.as_ptr() as *mut u16),
+            ServiceName: FABRIC_URI(self.service_name.as_ptr() as *mut u16),
+            ServiceTypeName: self.service_type_name.as_pcwstr(),
+            InitializationDataSize: self.initialization_data.len() as u32,
+            InitializationData: self.initialization_data.as_ptr() as *mut u8,
+            PartitionScheme: self.partition_scheme_description.as_raw().0,
+            PartitionSchemeDescription: self.partition_scheme_description.as_raw().1,
+            InstanceCount: self.instance_count,
+            PlacementConstraints: self.placement_contraints.as_pcwstr(), // TODO:
+            CorrelationCount: 0,
+            Correlations: std::ptr::null_mut(), // TODO: FABRIC_SERVICE_CORRELATION_DESCRIPTION
+            Metrics: std::ptr::null_mut(),      // TODO:
+            MetricCount: 0,
+            Reserved: ex1.as_ref() as *const _ as *mut c_void,
+        });
+        StatelessServiceDescriptionRaw {
+            internal,
+            _internal_ex1: ex1,
+            _internal_ex2: ex2,
+            _internal_ex3: ex3,
+            _internal_ex4: ex4,
+        }
+    }
+}
+
+pub(crate) enum ServiceDescriptionRaw {
+    Stateful(StatefulServiceDescriptionRaw),
+    Stateless(StatelessServiceDescriptionRaw),
+}
+
+impl ServiceDescriptionRaw {
+    pub fn as_raw(&self) -> FABRIC_SERVICE_DESCRIPTION {
+        match self {
+            ServiceDescriptionRaw::Stateful(ref desc) => FABRIC_SERVICE_DESCRIPTION {
+                Kind: FABRIC_SERVICE_DESCRIPTION_KIND_STATEFUL,
+                Value: desc.as_raw() as *const _ as *mut c_void,
+            },
+            ServiceDescriptionRaw::Stateless(ref desc) => FABRIC_SERVICE_DESCRIPTION {
+                Kind: FABRIC_SERVICE_DESCRIPTION_KIND_STATELESS,
+                Value: desc.as_raw() as *const _ as *mut c_void,
+            },
+        }
+    }
+}
+
+impl ServiceDescription {
+    pub(crate) fn build_raw(&self) -> ServiceDescriptionRaw {
+        match self {
+            ServiceDescription::Stateful(ref desc) => {
+                ServiceDescriptionRaw::Stateful(desc.build_raw())
+            }
+            ServiceDescription::Stateless(ref desc) => {
+                ServiceDescriptionRaw::Stateless(desc.build_raw())
+            }
+        }
+    }
+}

--- a/crates/libs/core/src/types/common/mod.rs
+++ b/crates/libs/core/src/types/common/mod.rs
@@ -17,8 +17,9 @@ use mssf_com::FabricTypes::{
     FABRIC_FAULT_TYPE, FABRIC_FAULT_TYPE_INVALID, FABRIC_FAULT_TYPE_PERMANENT,
     FABRIC_FAULT_TYPE_TRANSIENT, FABRIC_HEALTH_STATE, FABRIC_HEALTH_STATE_ERROR,
     FABRIC_HEALTH_STATE_INVALID, FABRIC_HEALTH_STATE_OK, FABRIC_HEALTH_STATE_UNKNOWN,
-    FABRIC_HEALTH_STATE_WARNING,
+    FABRIC_HEALTH_STATE_WARNING, FABRIC_URI,
 };
+use windows_core::WString;
 
 // FABRIC_HEALTH_STATE
 #[derive(Debug, PartialEq, Clone)]
@@ -81,5 +82,31 @@ impl From<FaultType> for FABRIC_FAULT_TYPE {
             FaultType::Permanent => FABRIC_FAULT_TYPE_PERMANENT,
             FaultType::Transient => FABRIC_FAULT_TYPE_TRANSIENT,
         }
+    }
+}
+
+/// FABRIC_URI interoperability type.
+#[derive(Debug, Clone, Default)]
+pub struct Uri(pub WString);
+impl Uri {
+    /// Needs to have the same lifetime as the original WString.
+    pub fn as_raw(&self) -> FABRIC_URI {
+        FABRIC_URI(self.0.as_ptr() as *mut u16)
+    }
+
+    pub fn new(s: WString) -> Self {
+        Self(s)
+    }
+}
+
+impl From<WString> for Uri {
+    fn from(value: WString) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for Uri {
+    fn from(value: &str) -> Self {
+        Self(WString::from(value))
     }
 }

--- a/crates/libs/core/src/types/common/partition.rs
+++ b/crates/libs/core/src/types/common/partition.rs
@@ -3,18 +3,26 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use std::ffi::c_void;
+
 use crate::{WString, GUID};
 use mssf_com::FabricTypes::{
     FABRIC_INT64_RANGE_PARTITION_INFORMATION, FABRIC_NAMED_PARTITION_INFORMATION,
-    FABRIC_SERVICE_PARTITION_ACCESS_STATUS, FABRIC_SERVICE_PARTITION_ACCESS_STATUS_GRANTED,
-    FABRIC_SERVICE_PARTITION_ACCESS_STATUS_INVALID,
+    FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION, FABRIC_PARTITION_SCHEME,
+    FABRIC_PARTITION_SCHEME_NAMED, FABRIC_PARTITION_SCHEME_SINGLETON,
+    FABRIC_PARTITION_SCHEME_UNIFORM_INT64_RANGE, FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE,
+    FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE_EXCLUSIVE_PROCESS,
+    FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE_SHARED_PROCESS, FABRIC_SERVICE_PARTITION_ACCESS_STATUS,
+    FABRIC_SERVICE_PARTITION_ACCESS_STATUS_GRANTED, FABRIC_SERVICE_PARTITION_ACCESS_STATUS_INVALID,
     FABRIC_SERVICE_PARTITION_ACCESS_STATUS_NOT_PRIMARY,
     FABRIC_SERVICE_PARTITION_ACCESS_STATUS_NO_WRITE_QUORUM,
     FABRIC_SERVICE_PARTITION_ACCESS_STATUS_RECONFIGURATION_PENDING,
     FABRIC_SERVICE_PARTITION_INFORMATION, FABRIC_SERVICE_PARTITION_KIND_INT64_RANGE,
     FABRIC_SERVICE_PARTITION_KIND_INVALID, FABRIC_SERVICE_PARTITION_KIND_NAMED,
     FABRIC_SERVICE_PARTITION_KIND_SINGLETON, FABRIC_SINGLETON_PARTITION_INFORMATION,
+    FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION,
 };
+use windows_core::PCWSTR;
 
 use crate::strings::WStringWrap;
 
@@ -159,6 +167,105 @@ impl From<ServicePartitionAccessStatus> for FABRIC_SERVICE_PARTITION_ACCESS_STAT
             ServicePartitionAccessStatus::NoWriteQuorum => {
                 FABRIC_SERVICE_PARTITION_ACCESS_STATUS_NO_WRITE_QUORUM
             }
+        }
+    }
+}
+
+// Partition Schemes
+// FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION
+pub struct UniformIn64PartitionSchemeDescription {
+    internal: Box<FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION>,
+}
+
+impl UniformIn64PartitionSchemeDescription {
+    pub fn new(partition_count: i32, low_key: i64, high_key: i64) -> Self {
+        UniformIn64PartitionSchemeDescription {
+            internal: Box::new(FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION {
+                PartitionCount: partition_count,
+                LowKey: low_key,
+                HighKey: high_key,
+                Reserved: std::ptr::null_mut(),
+            }),
+        }
+    }
+    /// No lifetime requirement.
+    fn as_raw(&self) -> &FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION {
+        self.internal.as_ref()
+    }
+}
+
+// FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION
+pub struct NamedPartitionSchemeDescription {
+    _names: Vec<WString>,
+    _raw_names: Vec<PCWSTR>,
+    internal: Box<FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION>,
+}
+
+impl NamedPartitionSchemeDescription {
+    /// Must have lifetime as self. Can be moved.
+    pub fn as_raw(&self) -> &FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION {
+        self.internal.as_ref()
+    }
+}
+
+impl NamedPartitionSchemeDescription {
+    pub fn new(names: Vec<WString>) -> Self {
+        let raw_names: Vec<PCWSTR> = names.iter().map(|name| name.as_pcwstr()).collect();
+        let internal = Box::new(FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION {
+            PartitionCount: raw_names.len() as i32,
+            Names: raw_names.as_ptr() as *mut _,
+            Reserved: std::ptr::null_mut(),
+        });
+        NamedPartitionSchemeDescription {
+            _names: names,
+            _raw_names: raw_names,
+            internal,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ServicePackageActivationMode {
+    // Invalid = 0,
+    SharedProcess,
+    ExclusiveProcess,
+}
+
+impl From<ServicePackageActivationMode> for FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE {
+    fn from(mode: ServicePackageActivationMode) -> Self {
+        match mode {
+            ServicePackageActivationMode::SharedProcess => {
+                FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE_SHARED_PROCESS
+            }
+            ServicePackageActivationMode::ExclusiveProcess => {
+                FABRIC_SERVICE_PACKAGE_ACTIVATION_MODE_EXCLUSIVE_PROCESS
+            }
+        }
+    }
+}
+
+pub enum PartitionSchemeDescription {
+    // Invalid,
+    Singleton, // This should be nullptr when passed to com.
+    Int64Range(UniformIn64PartitionSchemeDescription), // FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION
+    Named(NamedPartitionSchemeDescription),            // FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION
+}
+
+impl PartitionSchemeDescription {
+    /// Needs to have lifetime as self. Can be moved.
+    pub(crate) fn as_raw(&self) -> (FABRIC_PARTITION_SCHEME, *mut c_void) {
+        match self {
+            PartitionSchemeDescription::Singleton => {
+                (FABRIC_PARTITION_SCHEME_SINGLETON, std::ptr::null_mut())
+            }
+            PartitionSchemeDescription::Int64Range(ref scheme) => (
+                FABRIC_PARTITION_SCHEME_UNIFORM_INT64_RANGE,
+                scheme.as_raw() as *const _ as *mut _,
+            ),
+            PartitionSchemeDescription::Named(ref scheme) => (
+                FABRIC_PARTITION_SCHEME_NAMED,
+                scheme.as_raw() as *const _ as *mut _,
+            ),
         }
     }
 }

--- a/crates/samples/echomain-stateful2/src/echo.rs
+++ b/crates/samples/echomain-stateful2/src/echo.rs
@@ -10,8 +10,6 @@ use std::io::Error;
 use mssf_core::runtime::stateful_proxy::StatefulServicePartition;
 use mssf_core::types::LoadMetric;
 use mssf_core::WString;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -22,49 +20,6 @@ pub fn get_addr(port: u32, hostname: WString) -> String {
     addr.push(':');
     addr.push_str(&port.to_string());
     addr
-}
-
-async fn echo_loop(listener: TcpListener, token: CancellationToken) -> Result<(), Error> {
-    loop {
-        // Asynchronously wait for an inbound socket.
-        let (mut socket, _) = select! {
-            _ = token.cancelled() => {
-                // The token was cancelled
-                info!("echo_loop cancelled.");
-                break Ok(());
-            }
-            socket = listener.accept() =>{ socket? }
-        };
-
-        // And this is where much of the magic of this server happens. We
-        // crucially want all clients to make progress concurrently, rather than
-        // blocking one on completion of another. To achieve this we use the
-        // `tokio::spawn` function to execute the work in the background.
-        //
-        // Essentially here we're executing a new task to run concurrently,
-        // which will allow all of our clients to be processed concurrently.
-
-        tokio::spawn(async move {
-            let mut buf = vec![0; 1024];
-
-            // In a loop, read data from the socket and write the data back.
-            loop {
-                let n = socket
-                    .read(&mut buf)
-                    .await
-                    .expect("failed to read data from socket");
-
-                if n == 0 {
-                    return;
-                }
-
-                socket
-                    .write_all(&buf[0..n])
-                    .await
-                    .expect("failed to write data to socket");
-            }
-        });
-    }
 }
 
 /// Report load for the app via SF partition api periodically
@@ -103,24 +58,9 @@ pub async fn start_echo(
     partition: StatefulServicePartition,
 ) -> Result<(), Error> {
     let addr = get_addr(port, hostname);
-
-    let listener = TcpListener::bind(&addr).await?;
-    let token2 = token.clone();
     info!("start_echo: Listening on: {}", addr);
     // launch report load loop and listner separately
-    let h = tokio::spawn(async move { echo_loop(listener, token2).await });
     let h2 = tokio::spawn(async move { report_load_loop(partition, token).await });
-
-    match h.await {
-        Ok(e) => {
-            if let Err(e2) = e {
-                error!("echo_loop task failed {e2}");
-            }
-        }
-        Err(e) => {
-            error!("echo_loop task join failed {e}");
-        }
-    }
 
     if let Err(e) = h2.await {
         error!("report_load_loop task failed {e}");

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -285,7 +285,7 @@ async fn test_partition_info() {
     assert_ne!(single.id, GUID::zeroed());
 
     // test get replica info
-    let (p, s1, _s2) = tc.get_replicas(single.id).await.unwrap();
+    let (p, _, _) = tc.get_replicas(single.id).await.unwrap();
     assert_eq!(p.replica_status, QueryServiceReplicaStatus::Ready);
     assert_ne!(p.node_name, WString::new());
 
@@ -401,7 +401,8 @@ async fn test_partition_info() {
         .collect::<Vec<_>>();
     println!("Secondary metric loads: {:?}", secondary_loads);
 
-    // test get deployed service info
+    // test get deployed service info after failover
+    let (p, s1, _) = tc.get_replicas(single.id).await.unwrap();
     let deployed_replica_detail = tc
         .get_deployed_replica_detail(&p.node_name, single.id, p.replica_id)
         .await
@@ -515,6 +516,6 @@ async fn test_service_curd_range() {
     let partition_scheme = mssf_core::types::PartitionSchemeDescription::Int64Range(
         mssf_core::types::UniformIn64PartitionSchemeDescription::new(1, 10, 100),
     );
-    let service_name = Uri::from("fabric:/StatefulEchoApp/CurdTestServiceNamed");
+    let service_name = Uri::from("fabric:/StatefulEchoApp/CurdTestServiceRange");
     test_service_create_delete(&fc, &partition_scheme, &service_name).await;
 }


### PR DESCRIPTION
Support #152 
UpdateService will be implemented in a separate PR.
Added test for a sample app, create and delete services for various partition schemes.
Deleted the code in sample app to start listener, since it creates port conflict.