### PR TITLE
FabricClient: Finalize create service api

### DIFF
--- a/crates/libs/core/src/types/client/service.rs
+++ b/crates/libs/core/src/types/client/service.rs
@@ -287,7 +287,6 @@ pub(crate) struct StatelessServiceDescriptionRaw<'a> {
     _internal_ex2: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX2>,
     _internal_ex3: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX3>,
     _internal_ex4: Box<FABRIC_STATELESS_SERVICE_DESCRIPTION_EX4>,
-    // String buffers memory owner
     phantom: PhantomData<&'a StatelessServiceDescription>,
 }
 impl StatelessServiceDescriptionRaw<'_> {
@@ -412,7 +411,6 @@ pub(crate) struct NamedRepartitionDescriptionRaw<'a> {
     _names_to_add: Vec<PCWSTR>,
     _names_to_remove: Vec<PCWSTR>,
     internal: Box<FABRIC_NAMED_REPARTITION_DESCRIPTION>,
-    // owner of string buffers
     phantom: PhantomData<&'a NamedRepartitionDescription>,
 }
 

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -453,17 +453,18 @@ impl TestCreateUpdateClient {
         partition_scheme: &mssf_core::types::PartitionSchemeDescription,
     ) {
         // TODO: get service first
-        let desc = ServiceDescription::Stateful(StatefulServiceDescription {
-            application_name: Uri::from("fabric:/StatefulEchoApp"),
-            service_name: service_name.clone(),
-            service_type_name: WString::from("StatefulEchoAppService"),
-            partition_scheme: partition_scheme.clone(),
-            target_replica_set_size: 1,
-            min_replica_set_size: 1,
-            initialization_data: Vec::new(),
-            has_persistent_state: true,
-            ..Default::default()
-        });
+        let desc = ServiceDescription::Stateful(
+            StatefulServiceDescription::new(
+                Uri::from("fabric:/StatefulEchoApp"),
+                service_name.clone(),
+                WString::from("StatefulEchoAppService"),
+                partition_scheme.clone(),
+            )
+            .with_has_persistent_state(true)
+            .with_service_activation_mode(
+                mssf_core::types::ServicePackageActivationMode::SharedProcess,
+            ),
+        );
         println!("creating service {:?}", service_name);
         self.fc
             .get_service_manager()
@@ -497,9 +498,9 @@ impl TestCreateUpdateClient {
                 Ok(info) => {
                     return info.get_endpoint_list().iter().collect::<Vec<_>>();
                 }
-                Err(_) => {
+                Err(e) => {
                     if count > 30 {
-                        panic!("service not ready");
+                        panic!("service not ready, {e}");
                     }
                 }
             }


### PR DESCRIPTION
Added builder pattern for create service api, removed pub struct fields.
Moved to use PhantomData when possible.
