### PR TITLE
Prepare 0.0.23 release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,9 +9,11 @@
 	"service": "repo",
 	"customizations": {
     "vscode": {
-      "extensions": [
-				"ms-vscode.cmake-tools",
-				"rust-lang.rust-analyzer"]
+      	"extensions": [
+			"ms-vscode.cmake-tools",
+			"rust-lang.rust-analyzer",
+			"tamasfe.even-better-toml"
+		]
     }
   }
 }

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -41,5 +41,7 @@ jobs:
     - name: Install rust nightly
       uses: dtolnay/rust-toolchain@nightly
 
+    # TODO: move back to stable once package-workspace is stabilized
+    # https://doc.rust-lang.org/cargo/reference/unstable.html#package-workspace
     - name: check crate packaging
-      run: cargo package -p mssf-pal -p mssf-com -p mssf-core --allow-dirty 
+      run: cargo +nightly -Z package-workspace package -p mssf-pal -p mssf-com -p mssf-core --allow-dirty 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,14 +229,14 @@ dependencies = [
 
 [[package]]
 name = "mssf-com"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "mssf-pal",
 ]
 
 [[package]]
 name = "mssf-core"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bitflags",
  "config",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-pal"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "windows-core",
 ]

--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-com"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 license = "MIT"
 description = "Rust for Azure Service Fabric. The COM base layer."
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies.mssf-pal]
 path = "../pal"
-version = "0.0.22"
+version = "0.0.23"
 
 [features]
 default = []

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 license = "MIT"
 description = "Rust for Azure Service Fabric. Rust safe APIs."
@@ -51,11 +51,11 @@ features = [
 [dependencies.windows-core]
 package = "mssf-pal"
 path = "../pal"
-version = "0.0.22"
+version = "0.0.23"
 
 [dependencies.mssf-com]
 path = "../com"
-version = "0.0.22"
+version = "0.0.23"
 default-features = false
 features = [
     "ServiceFabric_FabricClient",

--- a/crates/libs/pal/Cargo.toml
+++ b/crates/libs/pal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-pal"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 license = "MIT"
 description = "mssf-pal enables service fabric rust to run on linux"


### PR DESCRIPTION
Revert to use nightly for packaging test since the package-workspace feature is still unstable.