### PR TITLE
[FabricClient] CreateService an UpdateService api Send+Sync

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 as base
 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update -y && apt-get upgrade -y
 
 # install tools for sf
-RUN apt-get install apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils -y
+RUN apt-get install -y apt-transport-https curl lsb-release wget gnupg2 software-properties-common debconf-utils
 
 # install sf
 RUN wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb \
@@ -14,10 +14,10 @@ RUN echo "servicefabric servicefabric/accepted-eula-ga select true" | debconf-se
   && echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true" | debconf-set-selections
 
 RUN wget https://download.microsoft.com/download/3/1/F/31F3FEEB-F073-4E27-A98B-8E691FF74F40/ServiceFabric.U20.10.1.2319.1.deb
-RUN apt-get install ./ServiceFabric.U20.10.1.2319.1.deb -y
+RUN apt-get install -y ./ServiceFabric.U20.10.1.2319.1.deb 
 RUN rm ServiceFabric.U20.10.1.2319.1.deb
 
-RUN apt install  -y net-tools locales \
+RUN apt install -y net-tools locales \
  && locale-gen en_US.UTF-8 \
  && update-locale LANG=en_US.UTF-8
 

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -341,12 +341,11 @@ impl ServiceManagementClient {
         timeout: Duration,
         cancellation_token: Option<CancellationToken>,
     ) -> crate::Result<()> {
-        let desc_raw = desc.build_raw();
-        self.create_service_internal(
-            &desc_raw.as_ffi(),
-            timeout.as_millis() as u32,
-            cancellation_token,
-        )
+        {
+            let desc_raw = desc.build_raw();
+            let ffi_raw = desc_raw.as_ffi();
+            self.create_service_internal(&ffi_raw, timeout.as_millis() as u32, cancellation_token)
+        }
         .await?
         .map_err(crate::Error::from)
     }
@@ -358,13 +357,16 @@ impl ServiceManagementClient {
         timeout: Duration,
         cancellation_token: Option<CancellationToken>,
     ) -> crate::Result<()> {
-        let desc_raw = desc.build_raw();
-        self.update_service_internal(
-            name.as_raw(),
-            &desc_raw.as_ffi(),
-            timeout.as_millis() as u32,
-            cancellation_token,
-        )
+        {
+            let desc_raw = desc.build_raw();
+            let ffi_raw = desc_raw.as_ffi();
+            self.update_service_internal(
+                name.as_raw(),
+                &ffi_raw,
+                timeout.as_millis() as u32,
+                cancellation_token,
+            )
+        }
         .await?
         .map_err(crate::Error::from)
     }

--- a/crates/libs/core/src/types/common/partition.rs
+++ b/crates/libs/core/src/types/common/partition.rs
@@ -183,6 +183,10 @@ pub struct UniformIn64PartitionSchemeDescription {
     internal: Box<FABRIC_UNIFORM_INT64_RANGE_PARTITION_SCHEME_DESCRIPTION>,
 }
 
+/// SAFETY: This is thread safe because we do not use the raw pointer.
+unsafe impl Send for UniformIn64PartitionSchemeDescription {}
+unsafe impl Sync for UniformIn64PartitionSchemeDescription {}
+
 impl UniformIn64PartitionSchemeDescription {
     pub fn new(partition_count: i32, low_key: i64, high_key: i64) -> Self {
         UniformIn64PartitionSchemeDescription {
@@ -217,6 +221,10 @@ pub struct NamedPartitionSchemeDescription {
     _raw_names: Vec<PCWSTR>,
     internal: Box<FABRIC_NAMED_PARTITION_SCHEME_DESCRIPTION>,
 }
+
+/// SAFETY: This is thread safe because the raw pointers points to heap allocated memory.
+unsafe impl Send for NamedPartitionSchemeDescription {}
+unsafe impl Sync for NamedPartitionSchemeDescription {}
 
 impl NamedPartitionSchemeDescription {
     /// Must have lifetime as self. Can be moved.


### PR DESCRIPTION
CreateService and UpdateService api and the parameter arguments should be Send+Sync in order to be used in runtime tasks.
Changed existing tests to call these apis on a separate task to validate the compilation.