### PR TITLE
0.1.0 Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,14 +229,14 @@ dependencies = [
 
 [[package]]
 name = "mssf-com"
-version = "0.0.23"
+version = "0.1.0"
 dependencies = [
  "mssf-pal",
 ]
 
 [[package]]
 name = "mssf-core"
-version = "0.0.23"
+version = "0.1.0"
 dependencies = [
  "bitflags",
  "config",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-pal"
-version = "0.0.23"
+version = "0.1.0"
 dependencies = [
  "windows-core",
 ]

--- a/crates/libs/com/Cargo.toml
+++ b/crates/libs/com/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-com"
-version = "0.0.23"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Rust for Azure Service Fabric. The COM base layer."
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies.mssf-pal]
 path = "../pal"
-version = "0.0.23"
+version = "0.1.0"
 
 [features]
 default = []

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.0.23"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Rust for Azure Service Fabric. Rust safe APIs."
@@ -51,11 +51,11 @@ features = [
 [dependencies.windows-core]
 package = "mssf-pal"
 path = "../pal"
-version = "0.0.23"
+version = "0.1.0"
 
 [dependencies.mssf-com]
 path = "../com"
-version = "0.0.23"
+version = "0.1.0"
 default-features = false
 features = [
     "ServiceFabric_FabricClient",

--- a/crates/libs/pal/Cargo.toml
+++ b/crates/libs/pal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-pal"
-version = "0.0.23"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "mssf-pal enables service fabric rust to run on linux"


### PR DESCRIPTION
Changed mssf crate versions to 0.1.0.
The crates are stable enough that we now should utilize patch version for small fixes.
From now on the patch version of the mssf crates may differ, and each crate may have different release cadence. For example, the mssf-pal crate has not been changed for a long time, so we can skip publishing the same code with new versions over and over again.