### PR TITLE
FabricClient: Fabric Property Client CRUD APIs

### DIFF
--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -28,12 +28,13 @@ mod notification;
 
 // Export public client modules
 pub mod health_client;
+mod property_client;
 pub mod query_client;
 pub mod svc_mgmt_client;
-
 // reexport
 pub use connection::GatewayInformationResult;
 pub use notification::ServiceNotification;
+pub use property_client::PropertyManagementClient;
 
 #[cfg(test)]
 mod tests;
@@ -314,22 +315,5 @@ impl FabricClient {
     /// Get the client for get/set Service Fabric health properties.
     pub fn get_health_manager(&self) -> &HealthClient {
         &self.health_client
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct PropertyManagementClient {
-    com: IFabricPropertyManagementClient2,
-}
-
-impl From<IFabricPropertyManagementClient2> for PropertyManagementClient {
-    fn from(com: IFabricPropertyManagementClient2) -> Self {
-        Self { com }
-    }
-}
-
-impl From<PropertyManagementClient> for IFabricPropertyManagementClient2 {
-    fn from(value: PropertyManagementClient) -> Self {
-        value.com
     }
 }

--- a/crates/libs/core/src/client/property_client.rs
+++ b/crates/libs/core/src/client/property_client.rs
@@ -1,0 +1,611 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+#![cfg_attr(
+    not(feature = "tokio_async"),
+    allow(unused_imports, reason = "code configured out")
+)]
+
+use std::time::Duration;
+
+#[cfg(feature = "tokio_async")]
+use crate::{
+    sync::fabric_begin_end_proxy,
+    sync::CancellationToken,
+    sync::FabricReceiver,
+    types::{NameEnumerationResult, Uri},
+    types::{PropertyMetadataResult, PropertyValueResult},
+    WString,
+};
+#[cfg(feature = "tokio_async")]
+use mssf_com::{
+    FabricClient::{
+        IFabricNameEnumerationResult, IFabricPropertyBatchResult, IFabricPropertyEnumerationResult,
+        IFabricPropertyMetadataResult, IFabricPropertyValueResult,
+    },
+    FabricTypes::{FABRIC_PROPERTY_BATCH_OPERATION, FABRIC_PUT_CUSTOM_PROPERTY_OPERATION},
+};
+
+use mssf_com::FabricClient::IFabricPropertyManagementClient2;
+
+#[derive(Debug, Clone)]
+pub struct PropertyManagementClient {
+    com: IFabricPropertyManagementClient2,
+}
+
+impl From<IFabricPropertyManagementClient2> for PropertyManagementClient {
+    fn from(com: IFabricPropertyManagementClient2) -> Self {
+        Self { com }
+    }
+}
+
+impl From<PropertyManagementClient> for IFabricPropertyManagementClient2 {
+    fn from(value: PropertyManagementClient) -> Self {
+        value.com
+    }
+}
+
+#[cfg(feature = "tokio_async")]
+impl PropertyManagementClient {
+    fn create_name_internal(
+        &self,
+        name: &Uri,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginCreateName(name.as_raw(), timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndCreateName(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn delete_name_internal(
+        &self,
+        name: &Uri,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginDeleteName(name.as_raw(), timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndDeleteName(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn name_exists_internal(
+        &self,
+        name: &Uri,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<bool>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginNameExists(name.as_raw(), timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndNameExists(ctx).map(|exists| exists != 0) },
+            cancellation_token,
+        )
+    }
+
+    fn enumerate_sub_names_internal(
+        &self,
+        name: &Uri,
+        prev: Option<&IFabricNameEnumerationResult>,
+        recursive: bool,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<IFabricNameEnumerationResult>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginEnumerateSubNames(
+                    name.as_raw(),
+                    prev,
+                    recursive,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndEnumerateSubNames(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn put_property_binary_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: &[u8],
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginPutPropertyBinary(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    data,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndPutPropertyBinary(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn put_property_int64_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: i64,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginPutPropertyInt64(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    data,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndPutPropertyInt64(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn put_property_double_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: f64,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginPutPropertyDouble(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    data,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndPutPropertyDouble(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn put_property_wstring_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: &WString,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginPutPropertyWString(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    data.as_pcwstr(),
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndPutPropertyWString(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn put_property_guid_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: &windows_core::GUID,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginPutPropertyGuid(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    data,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndPutPropertyGuid(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn delete_property_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginDeleteProperty(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndDeleteProperty(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn get_property_metadata_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<IFabricPropertyMetadataResult>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginGetPropertyMetadata(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndGetPropertyMetadata(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn get_property_internal(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<IFabricPropertyValueResult>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginGetProperty(
+                    name.as_raw(),
+                    property_name.as_pcwstr(),
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndGetProperty(ctx) },
+            cancellation_token,
+        )
+    }
+
+    // TODO: implement this
+    #[allow(dead_code)]
+    fn submit_property_batch_internal(
+        &self,
+        name: &Uri,
+        batch: &[FABRIC_PROPERTY_BATCH_OPERATION],
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<(u32, IFabricPropertyBatchResult)>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginSubmitPropertyBatch(name.as_raw(), batch, timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe {
+                let mut failed_operation_index_in_request = 0;
+                let result =
+                    com2.EndSubmitPropertyBatch(ctx, &mut failed_operation_index_in_request);
+                result.map(|res| (failed_operation_index_in_request, res))
+            },
+            cancellation_token,
+        )
+    }
+
+    // TODO: implement this
+    #[allow(dead_code)]
+    fn enumerate_properties_internal(
+        &self,
+        name: &Uri,
+        include_values: bool,
+        prev: Option<&IFabricPropertyEnumerationResult>,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<IFabricPropertyEnumerationResult>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginEnumerateProperties(
+                    name.as_raw(),
+                    include_values,
+                    prev,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndEnumerateProperties(ctx) },
+            cancellation_token,
+        )
+    }
+
+    // TODO:
+    #[allow(dead_code)]
+    fn put_custom_property_operation_internal(
+        &self,
+        name: &Uri,
+        property_operation: &FABRIC_PUT_CUSTOM_PROPERTY_OPERATION,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<CancellationToken>,
+    ) -> FabricReceiver<crate::WinResult<()>> {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginPutCustomPropertyOperation(
+                    name.as_raw(),
+                    property_operation,
+                    timeout_milliseconds,
+                    callback,
+                )
+            },
+            move |ctx| unsafe { com2.EndPutCustomPropertyOperation(ctx) },
+            cancellation_token,
+        )
+    }
+}
+
+#[cfg(feature = "tokio_async")]
+impl PropertyManagementClient {
+    pub async fn create_name(
+        &self,
+        name: &Uri,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.create_name_internal(
+            name,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+
+    pub async fn delete_name(
+        &self,
+        name: &Uri,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.delete_name_internal(
+            name,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+
+    pub async fn name_exists(
+        &self,
+        name: &Uri,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<bool> {
+        self.name_exists_internal(
+            name,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await?
+        .map_err(|e| e.into())
+    }
+
+    pub async fn enumerate_sub_names(
+        &self,
+        name: &Uri,
+        prev: Option<&NameEnumerationResult>,
+        recursive: bool,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<NameEnumerationResult> {
+        self.enumerate_sub_names_internal(
+            name,
+            prev.map(|x| x.as_com()),
+            recursive,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await?
+        .map_err(|e| e.into())
+        .map(NameEnumerationResult::from_com)
+    }
+
+    pub async fn put_property_binary(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: &[u8],
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.put_property_binary_internal(
+            name,
+            property_name,
+            data,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+
+    pub async fn put_property_double(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: f64,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.put_property_double_internal(
+            name,
+            property_name,
+            data,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+    pub async fn put_property_int64(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: i64,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.put_property_int64_internal(
+            name,
+            property_name,
+            data,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+    pub async fn put_property_wstring(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: &WString,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.put_property_wstring_internal(
+            name,
+            property_name,
+            data,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+
+    pub async fn put_property_guid(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        data: &windows_core::GUID,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.put_property_guid_internal(
+            name,
+            property_name,
+            data,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+
+    pub async fn delete_property(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<()> {
+        self.delete_property_internal(
+            name,
+            property_name,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await??;
+        Ok(())
+    }
+    pub async fn get_property_metadata(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<PropertyMetadataResult> {
+        self.get_property_metadata_internal(
+            name,
+            property_name,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await?
+        .map_err(|e| e.into())
+        .map(PropertyMetadataResult::from_com)
+    }
+
+    pub async fn get_property(
+        &self,
+        name: &Uri,
+        property_name: &WString,
+        timeout: Duration,
+        cancellation_token: Option<crate::sync::CancellationToken>,
+    ) -> crate::Result<PropertyValueResult> {
+        self.get_property_internal(
+            name,
+            property_name,
+            timeout.as_millis().try_into().unwrap(),
+            cancellation_token,
+        )
+        .await?
+        .map_err(|e| e.into())
+        .map(PropertyValueResult::from_com)
+    }
+}

--- a/crates/libs/core/src/client/property_client.rs
+++ b/crates/libs/core/src/client/property_client.rs
@@ -405,7 +405,7 @@ impl PropertyManagementClient {
     /// For example, fabric:/myapp/mysvc service will create 2 names in the same hierarchy:
     /// - fabric:/myapp
     /// - fabric:/myapp/mysvc
-    /// 
+    ///
     /// One can create names not related to any app or service as well.
     pub async fn create_name(
         &self,

--- a/crates/libs/core/src/strings.rs
+++ b/crates/libs/core/src/strings.rs
@@ -129,10 +129,10 @@ impl From<&IFabricStringListResult> for WStringList {
     }
 }
 
-struct FabricStringListAccessor<'a> {
-    itemcount: u32,
-    first_str: *mut PCWSTR,
-    phantom: PhantomData<&'a IFabricStringListResult>,
+pub(crate) struct FabricStringListAccessor<'a> {
+    pub(crate) itemcount: u32,
+    pub(crate) first_str: *mut PCWSTR,
+    pub(crate) phantom: PhantomData<&'a IFabricStringListResult>,
 }
 
 impl FabricListAccessor<PCWSTR> for FabricStringListAccessor<'_> {
@@ -145,7 +145,7 @@ impl FabricListAccessor<PCWSTR> for FabricStringListAccessor<'_> {
     }
 }
 
-type FabricStringListAccessorIter<'a> =
+pub(crate) type FabricStringListAccessorIter<'a> =
     FabricIter<'a, PCWSTR, WString, FabricStringListAccessor<'a>>;
 
 #[cfg(test)]

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -34,6 +34,11 @@ mod health;
 pub use health::*;
 mod settings;
 pub use settings::*;
+mod property;
+pub use property::{
+    EnumerationStatus, NameEnumerationResult, PropertyMetadataResult, PropertyTypeId,
+    PropertyValueResult,
+};
 
 mod service;
 pub use service::{

--- a/crates/libs/core/src/types/client/property.rs
+++ b/crates/libs/core/src/types/client/property.rs
@@ -1,0 +1,218 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+#![cfg_attr(
+    not(feature = "tokio_async"),
+    allow(unused_imports, reason = "code configured out"),
+    allow(dead_code, reason = "code configured out")
+)]
+
+use mssf_com::{
+    FabricClient::IFabricNameEnumerationResult,
+    FabricTypes::{
+        FABRIC_ENUMERATION_BEST_EFFORT_FINISHED, FABRIC_ENUMERATION_BEST_EFFORT_MASK,
+        FABRIC_ENUMERATION_BEST_EFFORT_MORE_DATA, FABRIC_ENUMERATION_CONSISTENT_FINISHED,
+        FABRIC_ENUMERATION_CONSISTENT_MASK, FABRIC_ENUMERATION_CONSISTENT_MORE_DATA,
+        FABRIC_ENUMERATION_FINISHED_MASK, FABRIC_ENUMERATION_INVALID,
+        FABRIC_ENUMERATION_MORE_DATA_MASK, FABRIC_ENUMERATION_STATUS,
+        FABRIC_NAMED_PROPERTY_METADATA,
+    },
+};
+use windows_core::WString;
+
+use crate::{strings::FabricStringListAccessorIter, types::Uri};
+
+pub struct NameEnumerationResult {
+    com: IFabricNameEnumerationResult,
+}
+
+impl NameEnumerationResult {
+    pub(crate) fn from_com(com: IFabricNameEnumerationResult) -> Self {
+        Self { com }
+    }
+
+    pub(crate) fn as_com(&self) -> &IFabricNameEnumerationResult {
+        &self.com
+    }
+
+    pub fn get_enumeration_status(&self) -> EnumerationStatus {
+        unsafe { self.com.get_EnumerationStatus().into() }
+    }
+
+    pub fn get_names(&self) -> crate::Result<Vec<Uri>> {
+        let mut count = 0;
+        let first_ptr = unsafe { self.com.GetNames(&mut count)? };
+        let l = crate::strings::FabricStringListAccessor {
+            itemcount: count,
+            first_str: first_ptr as *mut _,
+            phantom: std::marker::PhantomData,
+        };
+        let itr = FabricStringListAccessorIter::new(&l, &l);
+        let data = itr.map(Uri::new).collect::<Vec<_>>();
+        Ok(data)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EnumerationStatus {
+    BestEffortFinished,
+    BestEffortMask,
+    BestEffortMoreData,
+    ConsistentFinished,
+    ConsistentMask,
+    ConsistentMoreData,
+    FinishedMask,
+    Invalid,
+    MoreDataMask,
+}
+
+impl From<FABRIC_ENUMERATION_STATUS> for EnumerationStatus {
+    fn from(value: FABRIC_ENUMERATION_STATUS) -> Self {
+        match value {
+            FABRIC_ENUMERATION_BEST_EFFORT_FINISHED => Self::BestEffortFinished,
+            FABRIC_ENUMERATION_BEST_EFFORT_MASK => Self::BestEffortMask,
+            FABRIC_ENUMERATION_INVALID => Self::Invalid,
+            FABRIC_ENUMERATION_BEST_EFFORT_MORE_DATA => Self::BestEffortMoreData,
+            FABRIC_ENUMERATION_CONSISTENT_FINISHED => Self::ConsistentFinished,
+            FABRIC_ENUMERATION_CONSISTENT_MASK => Self::ConsistentMask,
+            FABRIC_ENUMERATION_CONSISTENT_MORE_DATA => Self::ConsistentMoreData,
+            FABRIC_ENUMERATION_FINISHED_MASK => Self::FinishedMask,
+            FABRIC_ENUMERATION_MORE_DATA_MASK => Self::MoreDataMask,
+            _ => Self::Invalid,
+        }
+    }
+}
+
+pub struct NamedPropertyMetadata {
+    pub property_name: WString,
+    pub property_type_id: PropertyTypeId,
+    pub value_size: i32,
+    pub sequence_number: i64,
+    pub last_modified_utc: windows_core::Win32::Foundation::FILETIME,
+    pub name: Uri,
+}
+
+impl NamedPropertyMetadata {
+    pub(crate) fn from_raw(ptr: &FABRIC_NAMED_PROPERTY_METADATA) -> Self {
+        Self {
+            property_name: ptr.PropertyName.into(),
+            property_type_id: ptr.TypeId.into(),
+            value_size: ptr.ValueSize,
+            sequence_number: ptr.SequenceNumber,
+            last_modified_utc: ptr.LastModifiedUtc,
+            name: Uri::new(windows_core::PCWSTR(ptr.Name.0).into()),
+        }
+    }
+}
+
+pub struct PropertyMetadataResult {
+    com: mssf_com::FabricClient::IFabricPropertyMetadataResult,
+}
+
+impl PropertyMetadataResult {
+    pub(crate) fn from_com(com: mssf_com::FabricClient::IFabricPropertyMetadataResult) -> Self {
+        Self { com }
+    }
+
+    pub fn get_metadata(&self) -> crate::Result<NamedPropertyMetadata> {
+        let ptr = unsafe { self.com.get_Metadata().as_ref() }.unwrap();
+
+        Ok(NamedPropertyMetadata::from_raw(ptr))
+    }
+}
+
+// See: https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Api/src/System/Fabric/CheckValuePropertyOperation.cs
+// TOOD: implement this
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PropertyTypeId {
+    Invalid = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_INVALID.0 as isize,
+    Binary = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_BINARY.0 as isize,
+    Int64 = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_INT64.0 as isize,
+    Double = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_DOUBLE.0 as isize,
+    WString = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_WSTRING.0 as isize,
+    Guid = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_GUID.0 as isize,
+}
+
+impl From<mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_ID> for PropertyTypeId {
+    fn from(value: mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_ID) -> Self {
+        match value {
+            mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_INVALID => PropertyTypeId::Invalid,
+            mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_BINARY => PropertyTypeId::Binary,
+            mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_INT64 => PropertyTypeId::Int64,
+            mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_DOUBLE => PropertyTypeId::Double,
+            mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_WSTRING => PropertyTypeId::WString,
+            mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_GUID => PropertyTypeId::Guid,
+            _ => PropertyTypeId::Invalid,
+        }
+    }
+}
+
+impl From<PropertyTypeId> for mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_ID {
+    fn from(kind: PropertyTypeId) -> Self {
+        mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_ID(kind as i32)
+    }
+}
+
+// // FABRIC_PROPERTY_BATCH_OPERATION
+// pub enum PropertyBatchOperation {
+//     Invalid,
+//     Put{name: WString, type_id: PropertyTypeId, value: WString},
+//     Get,
+//     CheckExists,
+//     CheckSequence,
+//     Delete,
+//     PutCustom,
+//     CheckValue,
+// }
+
+// FABRIC_CHECK_EXISTS_PROPERTY_OPERATION
+
+// IFabricPropertyValueResult
+pub struct PropertyValueResult {
+    com: mssf_com::FabricClient::IFabricPropertyValueResult,
+}
+
+fn raw_to_vec(ptr: *const u8, size: i32) -> Vec<u8> {
+    if size <= 0 {
+        return Vec::new();
+    }
+    unsafe { std::slice::from_raw_parts(ptr, size as usize).to_vec() }
+}
+
+impl PropertyValueResult {
+    pub(crate) fn from_com(com: mssf_com::FabricClient::IFabricPropertyValueResult) -> Self {
+        Self { com }
+    }
+
+    pub fn get_named_property(&self) -> (NamedPropertyMetadata, Vec<u8>) {
+        let ptr = unsafe { self.com.get_Property().as_ref() }.unwrap();
+        let meta = NamedPropertyMetadata::from_raw(unsafe { ptr.Metadata.as_ref().unwrap() });
+        let data = raw_to_vec(ptr.Value, meta.value_size);
+        (meta, data)
+    }
+
+    pub fn get_value_as_binary(&self) -> crate::Result<Vec<u8>> {
+        let mut bytecount = 0_u32;
+        let data = unsafe { self.com.GetValueAsBinary(&mut bytecount as *mut u32) }?;
+
+        Ok(raw_to_vec(data, bytecount as i32))
+    }
+
+    pub fn get_value_as_int64(&self) -> crate::Result<i64> {
+        let value = unsafe { self.com.GetValueAsInt64()? };
+        Ok(value)
+    }
+    pub fn get_value_as_double(&self) -> crate::Result<f64> {
+        let value = unsafe { self.com.GetValueAsDouble()? };
+        Ok(value)
+    }
+    pub fn get_value_as_wstring(&self) -> crate::Result<WString> {
+        let value = unsafe { self.com.GetValueAsWString() }?;
+        Ok(value.into())
+    }
+    pub fn get_value_as_guid(&self) -> crate::Result<windows_core::GUID> {
+        let value = unsafe { self.com.GetValueAsGuid() }?;
+        Ok(value)
+    }
+}

--- a/crates/libs/core/src/types/client/property.rs
+++ b/crates/libs/core/src/types/client/property.rs
@@ -40,6 +40,7 @@ impl NameEnumerationResult {
         unsafe { self.com.get_EnumerationStatus().into() }
     }
 
+    /// returns all SF names from the enumeration result.
     pub fn get_names(&self) -> crate::Result<Vec<Uri>> {
         let mut count = 0;
         let first_ptr = unsafe { self.com.GetNames(&mut count)? };
@@ -84,6 +85,7 @@ impl From<FABRIC_ENUMERATION_STATUS> for EnumerationStatus {
     }
 }
 
+/// Metadata for a named property.
 pub struct NamedPropertyMetadata {
     pub property_name: WString,
     pub property_type_id: PropertyTypeId,
@@ -123,7 +125,6 @@ impl PropertyMetadataResult {
 }
 
 // See: https://github.com/microsoft/service-fabric/blob/master/src/prod/src/managed/Api/src/System/Fabric/CheckValuePropertyOperation.cs
-// TOOD: implement this
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PropertyTypeId {
     Invalid = mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_INVALID.0 as isize,
@@ -154,6 +155,7 @@ impl From<PropertyTypeId> for mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_ID {
     }
 }
 
+// TODO: batch operations is net yet supported.
 // // FABRIC_PROPERTY_BATCH_OPERATION
 // pub enum PropertyBatchOperation {
 //     Invalid,
@@ -168,11 +170,12 @@ impl From<PropertyTypeId> for mssf_com::FabricTypes::FABRIC_PROPERTY_TYPE_ID {
 
 // FABRIC_CHECK_EXISTS_PROPERTY_OPERATION
 
-// IFabricPropertyValueResult
+/// Represents the result of a property value operation.
 pub struct PropertyValueResult {
     com: mssf_com::FabricClient::IFabricPropertyValueResult,
 }
 
+/// Converts a raw buffer into a `Vec<u8>` by making a copy.
 fn raw_to_vec(ptr: *const u8, size: i32) -> Vec<u8> {
     if size <= 0 {
         return Vec::new();
@@ -185,6 +188,7 @@ impl PropertyValueResult {
         Self { com }
     }
 
+    /// Get the property as raw bytes regardless of type.
     pub fn get_named_property(&self) -> (NamedPropertyMetadata, Vec<u8>) {
         let ptr = unsafe { self.com.get_Property().as_ref() }.unwrap();
         let meta = NamedPropertyMetadata::from_raw(unsafe { ptr.Metadata.as_ref().unwrap() });

--- a/crates/libs/core/src/types/common/mod.rs
+++ b/crates/libs/core/src/types/common/mod.rs
@@ -86,7 +86,7 @@ impl From<FaultType> for FABRIC_FAULT_TYPE {
 }
 
 /// FABRIC_URI interoperability type.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Uri(pub WString);
 impl Uri {
     /// Needs to have the same lifetime as the original WString.

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -11,14 +11,14 @@ use mssf_core::{
             PartitionKeyType, ResolvedServiceEndpoint, ResolvedServicePartitionInfo,
             ServiceEndpointRole, ServicePartitionKind,
         },
-        FabricClient, GatewayInformationResult, ServiceNotification,
+        FabricClient, GatewayInformationResult, PropertyManagementClient, ServiceNotification,
     },
     types::{
         QueryServiceReplicaStatus, RemoveReplicaDescription, ServiceNotificationFilterDescription,
         ServiceNotificationFilterFlags, ServicePartitionInformation,
         ServicePartitionQueryDescription, ServicePartitionQueryResult, ServicePartitionStatus,
         ServiceReplicaQueryDescription, ServiceReplicaQueryResult, SingletonPartitionInfomation,
-        StatelessServiceInstanceQueryResult, StatelessServicePartitionQueryResult,
+        StatelessServiceInstanceQueryResult, StatelessServicePartitionQueryResult, Uri,
     },
     ErrorCode, WString, GUID,
 };
@@ -252,4 +252,223 @@ async fn test_fabric_client() {
     mgmt.unregister_service_notification_filter(filter_handle, timeout, None)
         .await
         .unwrap();
+}
+
+async fn delete_property_if_exist(
+    pc: &PropertyManagementClient,
+    svc_uri: &Uri,
+    property_name: &WString,
+    timeout: Duration,
+) {
+    match pc
+        .get_property_metadata(svc_uri, property_name, timeout, None)
+        .await
+    {
+        Ok(_) => {
+            // Property already exists, remove it.
+            pc.delete_property(svc_uri, property_name, timeout, None)
+                .await
+                .unwrap();
+        }
+        Err(e) => {
+            if e.try_as_fabric_error_code().unwrap() == ErrorCode::FABRIC_E_PROPERTY_DOES_NOT_EXIST
+            {
+                // Property does not exist, continue.
+            } else {
+                panic!("unexpected error: {}", e);
+            }
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_property_client() {
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+
+    let pc = fc.get_property_manager();
+
+    let app_uri = Uri::from("fabric:/EchoApp");
+    let svc_uri = Uri::from("fabric:/EchoApp/EchoAppService");
+    let timeout = Duration::from_secs(1);
+    // If app is deployed, the name should be present.
+    {
+        let exist = pc.name_exists(&app_uri, timeout, None).await.unwrap();
+        assert!(exist);
+        let sub_names = pc
+            .enumerate_sub_names(&app_uri, None, false, timeout, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            sub_names.get_enumeration_status(),
+            mssf_core::types::EnumerationStatus::ConsistentFinished
+        );
+        let names = sub_names.get_names().unwrap();
+        assert!(names.contains(&svc_uri));
+    }
+    {
+        let exist = pc.name_exists(&svc_uri, timeout, None).await.unwrap();
+        assert!(exist);
+    }
+    // create new property test
+    // Clean up previous runs.
+    for property_name in [
+        WString::from("test_property_binary"),
+        WString::from("test_property_int64"),
+        WString::from("test_property_double"),
+        WString::from("test_property_wstring"),
+        WString::from("test_property_guid"),
+    ] {
+        delete_property_if_exist(pc, &svc_uri, &property_name, timeout).await;
+
+        // Create a binary property and read it back.
+        {
+            let property_name = WString::from("test_property_binary");
+            let value = WString::from("test_binary_value");
+            pc.put_property_binary(
+                &svc_uri,
+                &property_name,
+                value.to_string_lossy().as_bytes(),
+                timeout,
+                None,
+            )
+            .await
+            .unwrap();
+            let meta = pc
+                .get_property_metadata(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            assert_eq!(meta.get_metadata().unwrap().name, svc_uri);
+            let value_result = pc
+                .get_property(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            let (meta2, data) = value_result.get_named_property();
+            assert_eq!(meta2.name, svc_uri);
+            assert_eq!(meta2.value_size, data.len() as i32);
+            assert_eq!(data, value.to_string_lossy().as_bytes());
+
+            let data2 = value_result.get_value_as_binary().unwrap();
+            assert_eq!(data2, value.to_string_lossy().as_bytes());
+            assert_eq!(
+                value_result
+                    .get_value_as_double()
+                    .err()
+                    .unwrap()
+                    .try_as_fabric_error_code()
+                    .unwrap(),
+                ErrorCode::E_INVALIDARG
+            );
+        }
+
+        // Create an int64 property and read it back.
+        {
+            let property_name = WString::from("test_property_int64");
+            let value = 1234567890_i64;
+            pc.put_property_int64(&svc_uri, &property_name, value, timeout, None)
+                .await
+                .unwrap();
+            let meta = pc
+                .get_property_metadata(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            assert_eq!(meta.get_metadata().unwrap().name, svc_uri);
+            let value_result = pc
+                .get_property(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            let (meta2, data) = value_result.get_named_property();
+            assert_eq!(meta2.name, svc_uri);
+            assert_eq!(meta2.value_size, 8);
+            assert_eq!(data.len(), 8);
+            assert_eq!(value_result.get_value_as_int64().unwrap(), value);
+        }
+        // create a double property and read it back.
+        {
+            let property_name = WString::from("test_property_double");
+            let value = 1234.5678_f64;
+            pc.put_property_double(&svc_uri, &property_name, value, timeout, None)
+                .await
+                .unwrap();
+            let value_result = pc
+                .get_property(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            let (meta2, data) = value_result.get_named_property();
+            assert_eq!(meta2.name, svc_uri);
+            assert_eq!(meta2.value_size, 8);
+            assert_eq!(data.len(), 8);
+            assert_eq!(value_result.get_value_as_double().unwrap(), value);
+        }
+        // Create a wstring property and read it back.
+        {
+            let property_name = WString::from("test_property_wstring");
+            let value = WString::from("test_value_wstring");
+            pc.put_property_wstring(&svc_uri, &property_name, &value, timeout, None)
+                .await
+                .unwrap();
+            let value_result = pc
+                .get_property(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            let (meta2, data) = value_result.get_named_property();
+            assert_eq!(meta2.name, svc_uri);
+            assert_eq!(meta2.value_size, (value.len() + 1) as i32 * 2); // +1 for null terminator
+            assert_eq!(meta2.value_size, data.len() as i32);
+
+            let data2 = value_result.get_value_as_wstring().unwrap();
+            assert_eq!(data2, value);
+        }
+        // Create a guid property and read it back.
+        {
+            let property_name = WString::from("test_property_guid");
+            let value = GUID::from_values(
+                0x12345678,
+                0x1234,
+                0x5678,
+                [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef],
+            );
+            pc.put_property_guid(&svc_uri, &property_name, &value, timeout, None)
+                .await
+                .unwrap();
+            let value_result = pc
+                .get_property(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
+            let (meta2, data) = value_result.get_named_property();
+            assert_eq!(meta2.name, svc_uri);
+            assert_eq!(meta2.value_size, 16);
+            assert_eq!(data.len(), 16);
+            assert_eq!(value_result.get_value_as_guid().unwrap(), value);
+        }
+
+        // Create new names under that app
+        {
+            let svc_name2 = Uri::from("fabric:/EchoApp/EchoAppServiceNonExistent");
+            let property_name = WString::from("test_property_wstring");
+            let value = WString::from("test_value_wstring2");
+            let exist = pc.name_exists(&svc_name2, timeout, None).await.unwrap();
+            if exist {
+                delete_property_if_exist(pc, &svc_name2, &property_name, timeout).await;
+                // If the name exists, delete it.
+                pc.delete_name(&svc_name2, timeout, None).await.unwrap();
+            }
+            // Create a new name.
+            pc.create_name(&svc_name2, timeout, None).await.unwrap();
+            // Check if the name exists.
+            let exist = pc.name_exists(&svc_name2, timeout, None).await.unwrap();
+            assert!(exist);
+            // create a property under that name.
+            pc.put_property_wstring(&svc_name2, &property_name, &value, timeout, None)
+                .await
+                .unwrap();
+            let res = pc
+                .get_property(&svc_name2, &property_name, timeout, None)
+                .await
+                .unwrap();
+            assert_eq!(res.get_value_as_wstring().unwrap(), value);
+        }
+    }
 }

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -292,7 +292,7 @@ async fn test_property_client() {
 
     let app_uri = Uri::from("fabric:/EchoApp");
     let svc_uri = Uri::from("fabric:/EchoApp/EchoAppService");
-    let timeout = Duration::from_secs(1);
+    let timeout = Duration::from_secs(5);
     // If app is deployed, the name should be present.
     {
         let exist = pc.name_exists(&app_uri, timeout, None).await.unwrap();
@@ -384,6 +384,9 @@ async fn test_property_client() {
             assert_eq!(meta2.value_size, 8);
             assert_eq!(data.len(), 8);
             assert_eq!(value_result.get_value_as_int64().unwrap(), value);
+            pc.delete_property(&svc_uri, &property_name, timeout, None)
+                .await
+                .unwrap();
         }
         // create a double property and read it back.
         {
@@ -444,16 +447,20 @@ async fn test_property_client() {
             assert_eq!(value_result.get_value_as_guid().unwrap(), value);
         }
 
-        // Create new names under that app
+        // Create a non-existent name
         {
-            let svc_name2 = Uri::from("fabric:/EchoApp/EchoAppServiceNonExistent");
+            let app_name2 = Uri::from("fabric:/EchoAppNonExistent");
+            let svc_name2 = Uri::from("fabric:/EchoAppNonExistent/EchoAppServiceNonExistent");
             let property_name = WString::from("test_property_wstring");
             let value = WString::from("test_value_wstring2");
-            let exist = pc.name_exists(&svc_name2, timeout, None).await.unwrap();
-            if exist {
+            if pc.name_exists(&svc_name2, timeout, None).await.unwrap() {
                 delete_property_if_exist(pc, &svc_name2, &property_name, timeout).await;
                 // If the name exists, delete it.
                 pc.delete_name(&svc_name2, timeout, None).await.unwrap();
+            }
+            if pc.name_exists(&app_name2, timeout, None).await.unwrap() {
+                // If the name exists, delete it.
+                pc.delete_name(&app_name2, timeout, None).await.unwrap();
             }
             // Create a new name.
             pc.create_name(&svc_name2, timeout, None).await.unwrap();


### PR DESCRIPTION
Implement basic CRUD apis for Fabric Property Client.
Batch and other apis will be added in follow up PRs.
Added tests to create property for the echo app.
The corresponding csharp api is here: [PropertyManagementClient](https://learn.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.propertymanagementclient?view=azure-dotnet)