### PR TITLE
CancelToken trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,6 @@ dependencies = [
  "mssf-com",
  "mssf-pal",
  "tokio",
- "tokio-util",
  "tracing",
  "trait-variant",
  "windows",

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -12,9 +12,7 @@ readme = "README.md"
 include = ["**/*.rs", "Cargo.toml"]
 
 [features]
-default = ["config_source", "tokio_async", "tracing"]
-# Requires CancellationToken
-tokio_async = ["dep:tokio-util"]
+default = ["config_source", "tracing"]
 # Config crate required to implement its interface. 
 config_source = ["dep:config"]
 tracing = ["dep:tracing"]
@@ -22,7 +20,6 @@ tracing = ["dep:tracing"]
 [dependencies]
 futures-channel = { workspace = true, default-features = false, features = ["std"] }
 tracing = { workspace = true, optional = true }
-tokio-util = { workspace = true , optional = true , default-features = false, features = [] }
 trait-variant.workspace = true
 bitflags.workspace = true
 config = { workspace = true, optional = true }

--- a/crates/libs/core/src/client/property_client.rs
+++ b/crates/libs/core/src/client/property_client.rs
@@ -3,23 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-#![cfg_attr(
-    not(feature = "tokio_async"),
-    allow(unused_imports, reason = "code configured out")
-)]
-
 use std::time::Duration;
 
-#[cfg(feature = "tokio_async")]
 use crate::{
     WString,
-    sync::CancellationToken,
-    sync::FabricReceiver,
-    sync::fabric_begin_end_proxy,
-    types::{NameEnumerationResult, Uri},
-    types::{PropertyMetadataResult, PropertyValueResult},
+    runtime::executor::CancelToken,
+    sync::{FabricReceiver, fabric_begin_end_proxy},
+    types::{NameEnumerationResult, PropertyMetadataResult, PropertyValueResult, Uri},
 };
-#[cfg(feature = "tokio_async")]
 use mssf_com::{
     FabricClient::{
         IFabricNameEnumerationResult, IFabricPropertyBatchResult, IFabricPropertyEnumerationResult,
@@ -47,13 +38,12 @@ impl From<PropertyManagementClient> for IFabricPropertyManagementClient2 {
     }
 }
 
-#[cfg(feature = "tokio_async")]
 impl PropertyManagementClient {
     fn create_name_internal(
         &self,
         name: &Uri,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -70,7 +60,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -87,7 +77,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<u8>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -106,7 +96,7 @@ impl PropertyManagementClient {
         prev: Option<&IFabricNameEnumerationResult>,
         recursive: bool,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricNameEnumerationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -131,7 +121,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &[u8],
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -156,7 +146,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: i64,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -181,7 +171,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: f64,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -206,7 +196,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -231,7 +221,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &windows_core::GUID,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -255,7 +245,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -278,7 +268,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricPropertyMetadataResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -301,7 +291,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricPropertyValueResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -327,7 +317,7 @@ impl PropertyManagementClient {
         name: &Uri,
         batch: &[FABRIC_PROPERTY_BATCH_OPERATION],
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<(u32, IFabricPropertyBatchResult)>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -353,7 +343,7 @@ impl PropertyManagementClient {
         include_values: bool,
         prev: Option<&IFabricPropertyEnumerationResult>,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricPropertyEnumerationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -379,7 +369,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_operation: &FABRIC_PUT_CUSTOM_PROPERTY_OPERATION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -398,7 +388,6 @@ impl PropertyManagementClient {
     }
 }
 
-#[cfg(feature = "tokio_async")]
 impl PropertyManagementClient {
     /// Creates a SF name in Naming Service.
     /// Provisioned app and service will automatically create names:
@@ -411,7 +400,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.create_name_internal(
             name,
@@ -429,7 +418,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.delete_name_internal(
             name,
@@ -445,7 +434,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<bool> {
         self.name_exists_internal(
             name,
@@ -467,7 +456,7 @@ impl PropertyManagementClient {
         prev: Option<&NameEnumerationResult>,
         recursive: bool,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<NameEnumerationResult> {
         self.enumerate_sub_names_internal(
             name,
@@ -488,7 +477,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &[u8],
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.put_property_binary_internal(
             name,
@@ -508,7 +497,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: f64,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.put_property_double_internal(
             name,
@@ -528,7 +517,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: i64,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.put_property_int64_internal(
             name,
@@ -548,7 +537,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &WString,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.put_property_wstring_internal(
             name,
@@ -568,7 +557,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &windows_core::GUID,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.put_property_guid_internal(
             name,
@@ -587,7 +576,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.delete_property_internal(
             name,
@@ -605,7 +594,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<PropertyMetadataResult> {
         self.get_property_metadata_internal(
             name,
@@ -624,7 +613,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout: Duration,
-        cancellation_token: Option<crate::sync::CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<PropertyValueResult> {
         self.get_property_internal(
             name,

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -2,10 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-#![cfg_attr(
-    not(feature = "tokio_async"),
-    allow(unused_imports, reason = "code configured out")
-)]
+
 use std::{ffi::c_void, time::Duration};
 
 use crate::{PCWSTR, WString, types::Uri};
@@ -26,8 +23,10 @@ use mssf_com::{
     },
 };
 
-#[cfg(feature = "tokio_async")]
-use crate::sync::{CancellationToken, FabricReceiver, fabric_begin_end_proxy};
+use crate::{
+    runtime::executor::CancelToken,
+    sync::{FabricReceiver, fabric_begin_end_proxy},
+};
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
@@ -49,7 +48,7 @@ impl ServiceManagementClient {
     }
 }
 // internal implementation block
-#[cfg(feature = "tokio_async")]
+
 impl ServiceManagementClient {
     fn resolve_service_partition_internal(
         &self,
@@ -58,7 +57,7 @@ impl ServiceManagementClient {
         partition_key: Option<*const ::core::ffi::c_void>,
         previous_result: Option<&IFabricResolvedServicePartitionResult>, // This is different from generated code
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricResolvedServicePartitionResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -82,7 +81,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_RESTART_REPLICA_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -99,7 +98,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_REMOVE_REPLICA_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -116,7 +115,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<i64>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -133,7 +132,7 @@ impl ServiceManagementClient {
         &self,
         filterid: i64,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -154,7 +153,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_SERVICE_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -172,7 +171,7 @@ impl ServiceManagementClient {
         name: FABRIC_URI,
         desc: &FABRIC_SERVICE_UPDATE_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -189,7 +188,7 @@ impl ServiceManagementClient {
         &self,
         name: FABRIC_URI,
         timeout_milliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -216,7 +215,7 @@ impl From<ServiceManagementClient> for IFabricServiceManagementClient6 {
 }
 
 // public implementation block - tokio required
-#[cfg(feature = "tokio_async")]
+
 impl ServiceManagementClient {
     // Resolve service partition
     pub async fn resolve_service_partition(
@@ -225,7 +224,7 @@ impl ServiceManagementClient {
         key_type: &PartitionKeyType,
         prev: Option<&ResolvedServicePartition>,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<ResolvedServicePartition> {
         let com = {
             let uri = FABRIC_URI(name.as_ptr() as *mut u16);
@@ -256,7 +255,7 @@ impl ServiceManagementClient {
         &self,
         desc: &RestartReplicaDescription,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         {
             let raw: FABRIC_RESTART_REPLICA_DESCRIPTION = desc.into();
@@ -275,7 +274,7 @@ impl ServiceManagementClient {
         &self,
         desc: &RemoveReplicaDescription,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         {
             let raw: FABRIC_REMOVE_REPLICA_DESCRIPTION = desc.into();
@@ -303,7 +302,7 @@ impl ServiceManagementClient {
         &self,
         desc: &ServiceNotificationFilterDescription,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<FilterIdHandle> {
         let id = {
             let raw: FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION = desc.into();
@@ -324,7 +323,7 @@ impl ServiceManagementClient {
         &self,
         filter_id_handle: FilterIdHandle,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.unregister_service_notification_filter_internal(
             filter_id_handle.id,
@@ -339,7 +338,7 @@ impl ServiceManagementClient {
         &self,
         desc: &crate::types::ServiceDescription,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         {
             let desc_raw = desc.build_raw();
@@ -355,7 +354,7 @@ impl ServiceManagementClient {
         name: &Uri,
         desc: &crate::types::ServiceUpdateDescription,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         {
             let desc_raw = desc.build_raw();
@@ -375,7 +374,7 @@ impl ServiceManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<()> {
         self.delete_service_internal(
             name.as_raw(),
@@ -388,7 +387,7 @@ impl ServiceManagementClient {
 }
 
 // Handle to the registered service notification filter
-#[cfg(feature = "tokio_async")]
+
 #[derive(Debug, PartialEq)]
 pub struct FilterIdHandle {
     pub(crate) id: i64,
@@ -434,7 +433,6 @@ impl From<&PartitionKeyType> for FABRIC_PARTITION_KEY_TYPE {
     }
 }
 
-#[cfg(feature = "tokio_async")]
 impl PartitionKeyType {
     // get raw ptr to pass in com api
     fn get_raw_opt(&self) -> Option<*const c_void> {

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -4,37 +4,35 @@
 // ------------------------------------------------------------
 
 use crate::Interface;
-#[cfg(feature = "tokio_async")]
+
 use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
 use mssf_com::FabricRuntime::IFabricRuntime;
 
-#[cfg(feature = "tokio_async")]
 pub use self::runtime_wrapper::Runtime;
 
 pub mod config;
 pub mod error;
-#[cfg(feature = "tokio_async")]
+
 pub mod executor;
 pub mod node_context;
 
 pub mod package_change;
 
-#[cfg(feature = "tokio_async")]
 pub mod runtime_wrapper;
-#[cfg(feature = "tokio_async")]
+
 pub mod stateful;
-#[cfg(feature = "tokio_async")]
+
 pub mod stateful_bridge;
-#[cfg(feature = "tokio_async")]
+
 pub mod stateful_proxy;
-#[cfg(feature = "tokio_async")]
+
 pub mod stateless;
-#[cfg(feature = "tokio_async")]
+
 pub mod stateless_bridge;
 mod stateless_proxy;
 pub use stateless_proxy::StatelessServicePartition;
 pub mod store;
-#[cfg(feature = "tokio_async")]
+
 pub mod store_proxy;
 
 mod activation_context;

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -2,21 +2,18 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-#[cfg(feature = "tokio_async")]
+
 use std::time::Duration;
 
 use crate::{Interface, WString};
 use mssf_com::FabricRuntime::{IFabricNodeContextResult, IFabricNodeContextResult2};
 
+use crate::{runtime::executor::CancelToken, sync::fabric_begin_end_proxy};
 use crate::{strings::WStringWrap, types::NodeId};
 
-#[cfg(feature = "tokio_async")]
-use crate::sync::{CancellationToken, fabric_begin_end_proxy};
-
-#[cfg(feature = "tokio_async")]
 pub fn get_com_node_context(
     timeout_milliseconds: u32,
-    cancellation_token: Option<CancellationToken>,
+    cancellation_token: Option<impl CancelToken>,
 ) -> crate::sync::FabricReceiver<crate::WinResult<IFabricNodeContextResult>> {
     fabric_begin_end_proxy(
         move |callback| {
@@ -37,12 +34,11 @@ pub struct NodeContext {
     pub node_id: NodeId,
 }
 
-#[cfg(feature = "tokio_async")]
 impl NodeContext {
     // Get the node context from SF runtime
     pub async fn get(
         timeout: Duration,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<Self> {
         let com = get_com_node_context(timeout.as_millis().try_into().unwrap(), cancellation_token)
             .await??;

--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -5,7 +5,7 @@
 
 // stateful contains rs definition of stateful traits that user needs to implement
 
-use crate::sync::CancellationToken;
+use crate::runtime::executor::CancelToken;
 use crate::types::ReplicaRole;
 
 use crate::types::{Epoch, OpenMode, ReplicaInformation, ReplicaSetConfig, ReplicaSetQuorumMode};
@@ -43,7 +43,7 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<impl PrimaryReplicator>;
 
     /// Changes the role of the service replica to one of the ReplicaRole.
@@ -56,11 +56,11 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<crate::WString>;
 
     /// Closes the service replica gracefully when it is being shut down.
-    async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
+    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()>;
 
     /// Ungracefully terminates the service replica.
     /// Remarks: Network issues resulting in Service Fabric process shutdown
@@ -76,8 +76,8 @@ pub trait LocalReplicator: Send + Sync + 'static {
     /// in ReplicaInformation.
     /// Remarks:
     /// Replicator does not have an assigned role yet and should setup listening endpoint.
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<crate::WString>;
-    async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
+    async fn open(&self, cancellation_token: impl CancelToken) -> crate::Result<crate::WString>;
+    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()>;
 
     /// Change the replicator role.
     ///
@@ -87,7 +87,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()>;
 
     /// (TODO: This doc is from IStateProvider but not Replicator.)
@@ -101,7 +101,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
     async fn update_epoch(
         &self,
         epoch: &Epoch,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()>;
 
     /// Get the current LSN, end of log, called on secondaries.
@@ -142,7 +142,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     // SF calls this to indicate that possible data loss has occurred (write quorum loss),
     // returns is isStateChanged. If true, SF will re-create other secondaries.
     // The default SF impl might be a pass through to the state provider.
-    async fn on_data_loss(&self, cancellation_token: CancellationToken) -> crate::Result<u8>;
+    async fn on_data_loss(&self, cancellation_token: impl CancelToken) -> crate::Result<u8>;
 
     // Remarks on replicator configuration:
     // At any time the replicator can have one or two configurations. There is always a current
@@ -211,7 +211,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()>;
 
     /// Transferring state up to the current quorum LSN to a new or existing replica
@@ -233,7 +233,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()>;
 
     /// Notifies primary that an idle replica built by build_replica() api call

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -8,7 +8,7 @@
 
 use std::ffi::c_void;
 
-use crate::{Interface, WString};
+use crate::{Interface, WString, runtime::executor::CancelToken};
 use mssf_com::FabricRuntime::{
     IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
     IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
@@ -17,7 +17,7 @@ use mssf_com::FabricRuntime::{
 use crate::{
     error::ErrorCode,
     strings::WStringWrap,
-    sync::{CancellationToken, fabric_begin_end_proxy},
+    sync::fabric_begin_end_proxy,
     types::{
         FaultType, HealthInformation, LoadMetric, LoadMetricListRef, MoveCost, ReplicaRole,
         ServicePartitionAccessStatus, ServicePartitionInformation,
@@ -46,7 +46,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<impl PrimaryReplicator> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -83,7 +83,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<WString> {
         // replica address
         let com1 = &self.com_impl;
@@ -101,7 +101,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
+    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -135,7 +135,7 @@ impl Replicator for ReplicatorProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<WString> {
+    async fn open(&self, cancellation_token: impl CancelToken) -> crate::Result<WString> {
         // replicator address
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -151,7 +151,7 @@ impl Replicator for ReplicatorProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
+    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -169,7 +169,7 @@ impl Replicator for ReplicatorProxy {
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -187,7 +187,7 @@ impl Replicator for ReplicatorProxy {
     async fn update_epoch(
         &self,
         epoch: &Epoch,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -238,17 +238,17 @@ impl PrimaryReplicatorProxy {
 }
 
 impl Replicator for PrimaryReplicatorProxy {
-    async fn open(&self, cancellation_token: CancellationToken) -> crate::Result<WString> {
+    async fn open(&self, cancellation_token: impl CancelToken) -> crate::Result<WString> {
         self.parent.open(cancellation_token).await
     }
-    async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()> {
+    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()> {
         self.parent.close(cancellation_token).await
     }
     async fn change_role(
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()> {
         self.parent
             .change_role(epoch, role, cancellation_token)
@@ -257,7 +257,7 @@ impl Replicator for PrimaryReplicatorProxy {
     async fn update_epoch(
         &self,
         epoch: &Epoch,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()> {
         self.parent.update_epoch(epoch, cancellation_token).await
     }
@@ -277,7 +277,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn on_data_loss(&self, cancellation_token: CancellationToken) -> crate::Result<u8> {
+    async fn on_data_loss(&self, cancellation_token: impl CancelToken) -> crate::Result<u8> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -311,7 +311,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -343,7 +343,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();

--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -7,7 +7,7 @@
 
 use crate::WString;
 use crate::runtime::StatelessServicePartition;
-use crate::sync::CancellationToken;
+use crate::runtime::executor::CancelToken;
 
 /// Stateless service factories are registered with the FabricRuntime by service hosts via
 /// Runtime::register_stateless_service_factory().
@@ -36,11 +36,11 @@ pub trait LocalStatelessServiceInstance: Send + Sync + 'static {
     async fn open(
         &self,
         partition: &StatelessServicePartition,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> crate::Result<WString>;
 
     /// Closes this service instance gracefully when the service instance is being shut down.
-    async fn close(&self, cancellation_token: CancellationToken) -> crate::Result<()>;
+    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()>;
 
     /// Terminates this instance ungracefully with this synchronous method call.
     /// Remarks:

--- a/crates/libs/core/src/runtime/store_proxy.rs
+++ b/crates/libs/core/src/runtime/store_proxy.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::PCWSTR;
+use crate::{PCWSTR, runtime::executor::CancelToken};
 use mssf_com::{
     FabricRuntime::{
         IFabricKeyValueStoreItemResult, IFabricKeyValueStoreReplica2, IFabricTransaction,
@@ -11,7 +11,7 @@ use mssf_com::{
     FabricTypes::{FABRIC_KEY_VALUE_STORE_ITEM, FABRIC_KEY_VALUE_STORE_ITEM_METADATA},
 };
 
-use crate::sync::{CancellationToken, fabric_begin_end_proxy};
+use crate::sync::fabric_begin_end_proxy;
 
 use crate::types::TransactionIsolationLevel;
 
@@ -112,7 +112,7 @@ impl TransactionProxy {
     pub async fn commit(
         &self,
         timeoutmilliseconds: u32,
-        cancellation_token: Option<CancellationToken>,
+        cancellation_token: Option<impl CancelToken>,
     ) -> crate::Result<i64> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();

--- a/crates/libs/core/src/sync/bridge_context.rs
+++ b/crates/libs/core/src/sync/bridge_context.rs
@@ -5,13 +5,11 @@
 
 use std::{cell::Cell, future::Future};
 
-use crate::{error::ErrorCode, runtime::executor::Executor};
+use crate::{error::ErrorCode, runtime::executor::Executor, sync::SimpleCancelToken};
 use mssf_com::FabricCommon::{
     IFabricAsyncOperationCallback, IFabricAsyncOperationContext, IFabricAsyncOperationContext_Impl,
 };
 use windows_core::{AsImpl, implement};
-
-use crate::sync::CancellationToken;
 
 /// Async operation context for bridging rust code into SF COM api that supports cancellation.
 #[implement(IFabricAsyncOperationContext)]
@@ -32,14 +30,14 @@ where
     /// This is always false.
     is_completed_synchronously: bool,
     callback: IFabricAsyncOperationCallback,
-    token: CancellationToken,
+    token: SimpleCancelToken,
 }
 
 impl<T> BridgeContext<T>
 where
     T: Send,
 {
-    fn new(callback: IFabricAsyncOperationCallback, token: CancellationToken) -> Self {
+    fn new(callback: IFabricAsyncOperationCallback, token: SimpleCancelToken) -> Self {
         Self {
             content: Cell::new(None),
             is_completed: std::sync::atomic::AtomicBool::new(false),
@@ -54,8 +52,8 @@ where
     /// where Cancel() api cancels the operation.
     pub fn make(
         callback: windows_core::Ref<IFabricAsyncOperationCallback>,
-    ) -> (Self, CancellationToken) {
-        let token = CancellationToken::new();
+    ) -> (Self, SimpleCancelToken) {
+        let token = SimpleCancelToken::new();
         let ctx = Self::new(callback.unwrap().clone(), token.clone());
         (ctx, token)
     }

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -13,25 +13,19 @@ use mssf_com::FabricCommon::{
 };
 use windows_core::implement;
 
+mod token;
 pub mod wait;
+pub use token::{NONE_CANCEL_TOKEN, SimpleCancelToken};
 
 // This is intentional private. User should directly use bridge mod.
-#[cfg(feature = "tokio_async")]
 mod bridge_context;
-#[cfg(feature = "tokio_async")]
 pub use bridge_context::BridgeContext;
 
-#[cfg(feature = "tokio_async")]
 mod channel;
-#[cfg(feature = "tokio_async")]
 pub use channel::{FabricReceiver, FabricSender, oneshot_channel};
 
-#[cfg(feature = "tokio_async")]
 mod proxy;
-#[cfg(feature = "tokio_async")]
 pub use proxy::fabric_begin_end_proxy;
-#[cfg(feature = "tokio_async")]
-pub use tokio_util::sync::CancellationToken;
 
 // fabric code begins here
 

--- a/crates/libs/core/src/sync/proxy.rs
+++ b/crates/libs/core/src/sync/proxy.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::sync::CancellationToken;
+use crate::{runtime::executor::CancelToken, sync::NONE_CANCEL_TOKEN};
 use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
 
 use super::{FabricReceiver, oneshot_channel};
@@ -39,7 +39,7 @@ use super::{FabricReceiver, oneshot_channel};
 pub fn fabric_begin_end_proxy<BEGIN, END, T>(
     begin: BEGIN,
     end: END,
-    token: Option<CancellationToken>,
+    token: Option<impl CancelToken>,
 ) -> FabricReceiver<crate::WinResult<T>>
 where
     BEGIN: FnOnce(
@@ -62,7 +62,7 @@ where
             rx
         }
         Err(e) => {
-            let (tx2, rx2) = oneshot_channel(None);
+            let (tx2, rx2) = oneshot_channel(NONE_CANCEL_TOKEN);
             tx2.send(Err(e));
             rx2
         }

--- a/crates/libs/core/src/sync/token.rs
+++ b/crates/libs/core/src/sync/token.rs
@@ -1,0 +1,151 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use crate::runtime::executor::{CancelToken, EventFuture};
+
+/// A simple cancel token implementation
+#[derive(Clone, Debug)]
+pub struct SimpleCancelToken {
+    inner: Arc<TokenInner>,
+}
+
+#[derive(Debug)]
+struct TokenInner {
+    cancelled: AtomicBool,
+    wakers: Mutex<Vec<Waker>>,
+}
+
+impl SimpleCancelToken {
+    pub fn new() -> Self {
+        SimpleCancelToken {
+            inner: Arc::new(TokenInner {
+                cancelled: AtomicBool::new(false),
+                wakers: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    pub fn cancel(&self) {
+        // Set the cancelled flag
+        self.inner.cancelled.store(true, Ordering::Release);
+
+        // Wake all waiting tasks
+        let mut wakers = self.inner.wakers.lock().unwrap();
+        for waker in wakers.drain(..) {
+            waker.wake();
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Returns a future that completes when cancellation is triggered
+    pub fn cancelled(&self) -> CancelledFuture {
+        CancelledFuture {
+            token: self.clone(),
+        }
+    }
+}
+
+/// This future is cancel safe.
+pub struct CancelledFuture {
+    token: SimpleCancelToken,
+}
+
+impl Future for CancelledFuture {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.token.is_cancelled() {
+            return Poll::Ready(());
+        }
+
+        // Register this task's waker to be notified when cancelled
+        let mut wakers = self.token.inner.wakers.lock().unwrap();
+
+        // Double-check after acquiring the lock
+        if self.token.is_cancelled() {
+            return Poll::Ready(());
+        }
+
+        // Store the waker to be called when cancel() is invoked
+        wakers.push(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl Default for SimpleCancelToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Integrate with mssf trait system.
+impl CancelToken for SimpleCancelToken {
+    fn cancel(&self) {
+        self.cancel();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.is_cancelled()
+    }
+
+    fn wait(&self) -> Pin<Box<dyn EventFuture>> {
+        Box::pin(self.cancelled())
+    }
+}
+
+pub const NONE_CANCEL_TOKEN: Option<SimpleCancelToken> = None;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cancel_token() {
+        let token = SimpleCancelToken::new();
+        assert!(!token.is_cancelled());
+        token.cancel();
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_token_async() {
+        let token = SimpleCancelToken::new();
+        let h = tokio::spawn({
+            let token = token.clone();
+            async move {
+                token.wait().await;
+            }
+        });
+        token.cancel();
+        assert!(token.is_cancelled());
+        h.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cancel_token_multi() {
+        let token = SimpleCancelToken::new();
+        let mut join_set = tokio::task::JoinSet::new();
+
+        for _ in 0..10 {
+            let token = token.clone();
+            join_set.spawn(async move {
+                token.wait().await;
+            });
+            tokio::task::yield_now().await;
+        }
+        token.cancel();
+        assert!(token.is_cancelled());
+        join_set.join_all().await;
+    }
+}

--- a/crates/libs/core/src/types/client/property.rs
+++ b/crates/libs/core/src/types/client/property.rs
@@ -2,11 +2,6 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-#![cfg_attr(
-    not(feature = "tokio_async"),
-    allow(unused_imports, reason = "code configured out"),
-    allow(dead_code, reason = "code configured out")
-)]
 
 use mssf_com::{
     FabricClient::IFabricNameEnumerationResult,

--- a/crates/libs/core/src/types/client/service.rs
+++ b/crates/libs/core/src/types/client/service.rs
@@ -3,11 +3,6 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-#![cfg_attr(
-    not(feature = "tokio_async"),
-    allow(dead_code, reason = "code configured out")
-)]
-
 use std::{ffi::c_void, marker::PhantomData};
 
 use mssf_com::FabricTypes::{

--- a/crates/libs/core/src/types/common/partition.rs
+++ b/crates/libs/core/src/types/common/partition.rs
@@ -3,11 +3,6 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-#![cfg_attr(
-    not(feature = "tokio_async"),
-    allow(dead_code, reason = "code configured out")
-)]
-
 use std::ffi::c_void;
 
 use crate::{GUID, WString};

--- a/crates/libs/util/Cargo.toml
+++ b/crates/libs/util/Cargo.toml
@@ -19,7 +19,7 @@ tracing = ["dep:tracing"]
 tokio = { workspace = true, features = ["rt", "signal"], optional = true, default-features = false }
 tokio-util = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-mssf-core = { workspace = true, default-features = false, features = ["tokio_async"] }
+mssf-core = { workspace = true, default-features = false }
 
 [dev-dependencies]
 mssf-com.workspace = true

--- a/crates/libs/util/src/resolve.rs
+++ b/crates/libs/util/src/resolve.rs
@@ -5,7 +5,7 @@
 
 use std::{pin::Pin, time::Duration};
 
-use mssf_core::runtime::executor::Timer;
+use mssf_core::runtime::executor::{CancelToken, Timer};
 use mssf_core::{ErrorCode, WString};
 use tokio_util::sync::CancellationToken;
 
@@ -13,6 +13,8 @@ use mssf_core::client::{
     FabricClient,
     svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition, ServiceManagementClient},
 };
+
+use crate::tokio::TokioCancelToken;
 
 /// The same as dotnet sdk:
 /// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/develop/src/Microsoft.ServiceFabric.Services/Client/ServicePartitionResolver.cs
@@ -115,11 +117,13 @@ impl ServicePartitionResolver {
         timeout: Option<Duration>, // Total timeout for the operation
         token: Option<CancellationToken>,
     ) -> mssf_core::Result<ResolvedServicePartition> {
+        let token = token.map(TokioCancelToken::from);
+
         let timeout = timeout.unwrap_or(self.default_timeout);
         let timer = TimeCounter::new(timeout);
         let mut cancel: Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
             if let Some(t) = &token {
-                Box::pin(t.cancelled())
+                t.wait()
             } else {
                 Box::pin(std::future::pending())
             };

--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use mssf_core::runtime::executor::CancelToken;
 use mssf_core::{Error, WString};
 use mssf_core::{
     runtime::{
@@ -65,7 +66,7 @@ impl AppFabricReplicator {
 
 // This is basic implementation of Replicator
 impl Replicator for AppFabricReplicator {
-    async fn open(&self, _: CancellationToken) -> mssf_core::Result<WString> {
+    async fn open(&self, _: impl CancelToken) -> mssf_core::Result<WString> {
         info!(
             "AppFabricReplicator2::Replicator::Open: {:?}",
             self.ctx.get_trace_read_write_status()
@@ -75,7 +76,7 @@ impl Replicator for AppFabricReplicator {
         Ok(str_res)
     }
 
-    async fn close(&self, _: CancellationToken) -> mssf_core::Result<()> {
+    async fn close(&self, _: impl CancelToken) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::Replicator::close {:?}",
             self.ctx.get_trace_read_write_status()
@@ -87,7 +88,7 @@ impl Replicator for AppFabricReplicator {
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        _: CancellationToken,
+        _: impl CancelToken,
     ) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::Replicator::change_role epoch:{epoch:?}, role:{role:?}, {:?}",
@@ -96,7 +97,7 @@ impl Replicator for AppFabricReplicator {
         Ok(())
     }
 
-    async fn update_epoch(&self, epoch: &Epoch, _: CancellationToken) -> mssf_core::Result<()> {
+    async fn update_epoch(&self, epoch: &Epoch, _: impl CancelToken) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::Replicator::update_epoch: {epoch:?}, {:?}",
             self.ctx.get_trace_read_write_status()
@@ -130,7 +131,7 @@ impl Replicator for AppFabricReplicator {
 
 // This is basic implementation of PrimaryReplicator
 impl PrimaryReplicator for AppFabricReplicator {
-    async fn on_data_loss(&self, _: CancellationToken) -> mssf_core::Result<u8> {
+    async fn on_data_loss(&self, _: impl CancelToken) -> mssf_core::Result<u8> {
         info!(
             "AppFabricReplicator2::PrimaryReplicator::on_data_loss {:?}",
             self.ctx.get_trace_read_write_status()
@@ -153,7 +154,7 @@ impl PrimaryReplicator for AppFabricReplicator {
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
-        _: CancellationToken,
+        _: impl CancelToken,
     ) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::PrimaryReplicator::wait_for_catch_up_quorum mode:{catchupmode:?} {:?}",
@@ -196,7 +197,7 @@ impl PrimaryReplicator for AppFabricReplicator {
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
-        _: CancellationToken,
+        _: impl CancelToken,
     ) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::PrimaryReplicator::build_replica: info: {replica:?} {:?}",
@@ -305,7 +306,7 @@ impl StatefulServiceReplica for Replica {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        _: CancellationToken,
+        _: impl CancelToken,
     ) -> mssf_core::Result<impl PrimaryReplicator> {
         self.ctx.init(partition.clone());
         info!(
@@ -322,7 +323,7 @@ impl StatefulServiceReplica for Replica {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        _: CancellationToken,
+        _: impl CancelToken,
     ) -> mssf_core::Result<WString> {
         info!(
             "Replica::change_role {newrole:?}, {:?}",
@@ -336,7 +337,7 @@ impl StatefulServiceReplica for Replica {
         let str_res = WString::from(addr);
         Ok(str_res)
     }
-    async fn close(&self, _: CancellationToken) -> mssf_core::Result<()> {
+    async fn close(&self, _: impl CancelToken) -> mssf_core::Result<()> {
         info!(
             "Replica::close: {:?}",
             self.ctx.get_trace_read_write_status()

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -14,6 +14,7 @@ use mssf_core::{
             ServiceEndpointRole, ServicePartitionKind,
         },
     },
+    sync::NONE_CANCEL_TOKEN,
     types::{
         DeployedServiceReplicaDetailQueryDescription, DeployedServiceReplicaDetailQueryResult,
         DeployedServiceReplicaDetailQueryResultValue, NamedPartitionSchemeDescription,
@@ -59,7 +60,7 @@ impl TestClient {
             partition_id_filter: None,
         };
         let list = qc
-            .get_partition_list(&desc, self.timeout, None)
+            .get_partition_list(&desc, self.timeout, NONE_CANCEL_TOKEN)
             .await
             .unwrap();
         // there is only one partition
@@ -83,7 +84,7 @@ impl TestClient {
         let qc = self.fc.get_query_manager();
         let desc = PartitionLoadInformationQueryDescription { partition_id };
         let partition_load_info = qc
-            .get_partition_load_information(&desc, self.timeout, None)
+            .get_partition_load_information(&desc, self.timeout, NONE_CANCEL_TOKEN)
             .await?;
 
         Ok(partition_load_info)
@@ -105,7 +106,7 @@ impl TestClient {
             replica_id_or_instance_id_filter: None,
         };
         let replicas = qc
-            .get_replica_list(&desc, self.timeout, None)
+            .get_replica_list(&desc, self.timeout, NONE_CANCEL_TOKEN)
             .await?
             .iter()
             .collect::<Vec<_>>();
@@ -148,7 +149,7 @@ impl TestClient {
             replica_id,
         };
 
-        qc.get_deployed_replica_detail(&desc, self.timeout, None)
+        qc.get_deployed_replica_detail(&desc, self.timeout, NONE_CANCEL_TOKEN)
             .await
     }
 
@@ -212,7 +213,7 @@ impl TestClient {
             &PartitionKeyType::None,
             prev,
             self.timeout,
-            None,
+            NONE_CANCEL_TOKEN,
         )
         .await
     }
@@ -230,7 +231,7 @@ impl TestClient {
             replica_or_instance_id: p.replica_id,
         };
         let mgmt = self.fc.get_service_manager();
-        mgmt.restart_replica(&desc, self.timeout, None)
+        mgmt.restart_replica(&desc, self.timeout, NONE_CANCEL_TOKEN)
             .await
             .unwrap();
 
@@ -300,7 +301,7 @@ async fn test_partition_info() {
             flags: ServiceNotificationFilterFlags::NamePrefix,
         };
         // register takes more than 1 sec.
-        mgmt.register_service_notification_filter(&desc, Duration::from_secs(10), None)
+        mgmt.register_service_notification_filter(&desc, Duration::from_secs(10), NONE_CANCEL_TOKEN)
             .await
             .unwrap()
     };
@@ -342,7 +343,7 @@ async fn test_partition_info() {
         }
     }
     // unregisters the notification
-    mgmt.unregister_service_notification_filter(filter_handle, timeout, None)
+    mgmt.unregister_service_notification_filter(filter_handle, timeout, NONE_CANCEL_TOKEN)
         .await
         .unwrap();
 
@@ -472,7 +473,7 @@ impl TestCreateUpdateClient {
         println!("creating service {service_name:?}");
         let sm = self.fc.get_service_manager().clone();
         let timeout = self.timeout;
-        tokio::spawn(async move { sm.create_service(&desc, timeout, None).await })
+        tokio::spawn(async move { sm.create_service(&desc, timeout, NONE_CANCEL_TOKEN).await })
             .await
             .expect("task panicked")
             .expect("create failed");
@@ -483,10 +484,13 @@ impl TestCreateUpdateClient {
         let sm = self.fc.get_service_manager().clone();
         let timeout = self.timeout;
         let service_name = service_name.clone();
-        tokio::spawn(async move { sm.delete_service(&service_name, timeout, None).await })
-            .await
-            .expect("task panicked")
-            .expect("delete failed");
+        tokio::spawn(async move {
+            sm.delete_service(&service_name, timeout, NONE_CANCEL_TOKEN)
+                .await
+        })
+        .await
+        .expect("task panicked")
+        .expect("delete failed");
     }
 
     async fn resolve_service(
@@ -499,7 +503,13 @@ impl TestCreateUpdateClient {
         let mut count = 0;
         loop {
             let res = smgr
-                .resolve_service_partition(&service_name.0, &key_type, None, self.timeout, None)
+                .resolve_service_partition(
+                    &service_name.0,
+                    &key_type,
+                    None,
+                    self.timeout,
+                    NONE_CANCEL_TOKEN,
+                )
                 .await;
             match res {
                 Ok(info) => {
@@ -536,10 +546,13 @@ impl TestCreateUpdateClient {
         let sm = self.fc.get_service_manager().clone();
         let timeout = self.timeout;
         let service_name = service_name.clone();
-        tokio::spawn(async move { sm.update_service(&service_name, &desc, timeout, None).await })
-            .await
-            .expect("task panicked")
-            .expect("delete failed");
+        tokio::spawn(async move {
+            sm.update_service(&service_name, &desc, timeout, NONE_CANCEL_TOKEN)
+                .await
+        })
+        .await
+        .expect("task panicked")
+        .expect("delete failed");
     }
 }
 

--- a/crates/samples/echomain-stateful2/src/test2.rs
+++ b/crates/samples/echomain-stateful2/src/test2.rs
@@ -10,6 +10,7 @@ use mssf_core::{
         FabricClient,
         svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition, ServiceEndpointRole},
     },
+    sync::NONE_CANCEL_TOKEN,
     types::{ReplicaRole, ServicePartitionInformation, ServicePartitionQueryResult, Uri},
 };
 use mssf_util::resolve::ServicePartitionResolver;
@@ -24,7 +25,10 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         partition_id_filter: None,
     };
 
-    let ptt = q.get_partition_list(&desc, sm.timeout, None).await.unwrap();
+    let ptt = q
+        .get_partition_list(&desc, sm.timeout, NONE_CANCEL_TOKEN)
+        .await
+        .unwrap();
     let partitions = ptt
         .iter()
         .filter_map(|p| match p {
@@ -42,7 +46,7 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         replica_id_or_instance_id_filter: None,
     };
     let replicas = q
-        .get_replica_list(&desc, sm.timeout, None)
+        .get_replica_list(&desc, sm.timeout, NONE_CANCEL_TOKEN)
         .await
         .unwrap()
         .iter()
@@ -65,7 +69,7 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         replica_or_instance_id: primary_replica.replica_id,
     };
     fc.get_service_manager()
-        .restart_replica(&desc, sm.timeout, None)
+        .restart_replica(&desc, sm.timeout, NONE_CANCEL_TOKEN)
         .await
         .unwrap();
 }
@@ -173,7 +177,7 @@ async fn test_resolve_notification() {
             flags: mssf_core::types::ServiceNotificationFilterFlags::NamePrefix,
         };
         fc.get_service_manager()
-            .register_service_notification_filter(&desc, sm.timeout, None)
+            .register_service_notification_filter(&desc, sm.timeout, NONE_CANCEL_TOKEN)
             .await
             .unwrap()
     };
@@ -211,7 +215,7 @@ async fn test_resolve_notification() {
 
     // Unregister the notification filter.
     fc.get_service_manager()
-        .unregister_service_notification_filter(filter_id, sm.timeout, None)
+        .unregister_service_notification_filter(filter_id, sm.timeout, NONE_CANCEL_TOKEN)
         .await
         .unwrap();
     sm.delete_service(&uri).await;

--- a/crates/samples/kvstore/src/kvstore.rs
+++ b/crates/samples/kvstore/src/kvstore.rs
@@ -9,12 +9,13 @@ use mssf_com::{
 use mssf_core::{
     Error, GUID, WString,
     runtime::{
+        executor::CancelToken,
         stateful::{PrimaryReplicator, StatefulServiceFactory, StatefulServiceReplica},
         stateful_proxy::{StatefulServicePartition, StatefulServiceReplicaProxy},
         store::{DummyStoreEventHandler, create_com_key_value_store_replica},
         store_proxy::KVStoreProxy,
     },
-    sync::CancellationToken,
+    sync::NONE_CANCEL_TOKEN,
     types::{LocalStoreKind, OpenMode, ReplicaRole, ReplicatorSettings},
 };
 use mssf_util::tokio::TokioExecutor;
@@ -164,7 +165,7 @@ impl Service {
             let key = WString::from("mykey");
             let value = String::from("myvalue");
             kv.add(&tx, key.as_wide(), value.as_bytes())?;
-            seq = tx.commit(1000, None).await?;
+            seq = tx.commit(1000, NONE_CANCEL_TOKEN).await?;
         }
 
         // remove kv
@@ -172,7 +173,7 @@ impl Service {
             let tx = kv.create_transaction()?;
             let key = WString::from("mykey");
             kv.remove(&tx, key.as_wide(), seq)?;
-            let _ = tx.commit(1000, None).await?;
+            let _ = tx.commit(1000, NONE_CANCEL_TOKEN).await?;
         }
         Ok(())
     }
@@ -183,7 +184,7 @@ impl StatefulServiceReplica for Replica {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> mssf_core::Result<impl PrimaryReplicator> {
         // should be primary replicator
         info!("Replica::open {:?}", openmode);
@@ -192,7 +193,7 @@ impl StatefulServiceReplica for Replica {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        cancellation_token: CancellationToken,
+        cancellation_token: impl CancelToken,
     ) -> mssf_core::Result<WString> {
         info!("Replica::change_role {:?}", newrole);
         let addr = self
@@ -204,7 +205,7 @@ impl StatefulServiceReplica for Replica {
         }
         Ok(addr)
     }
-    async fn close(&self, cancellation_token: CancellationToken) -> mssf_core::Result<()> {
+    async fn close(&self, cancellation_token: impl CancelToken) -> mssf_core::Result<()> {
         info!("Replica::close");
         self.svc.stop();
         self.kv.close(cancellation_token).await


### PR DESCRIPTION
Move from using tokio_util's CancellationToken to CancelToken trait.
Users can choose to use any custom implementations.
Provided SimpleCancelToken implementation which is lightweight compared to tokio's implementation.
In mssf-util crate, tokio_util's CancellationToken is supported as one of the options for user to use as a CancelToken.
All tokio dependencies are removed from mssf-core, we still use it as a dev-dependency. Removed the tokio_async feature, and async code are enabled by default (originally added by other users for not using tokio).