### PR TITLE
Use boxed cancellation token

### DIFF
--- a/crates/libs/core/src/client/property_client.rs
+++ b/crates/libs/core/src/client/property_client.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::{
     WString,
-    runtime::executor::CancelToken,
+    runtime::executor::BoxedCancelToken,
     sync::{FabricReceiver, fabric_begin_end_proxy},
     types::{NameEnumerationResult, PropertyMetadataResult, PropertyValueResult, Uri},
 };
@@ -43,7 +43,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -60,7 +60,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -77,7 +77,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<u8>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -96,7 +96,7 @@ impl PropertyManagementClient {
         prev: Option<&IFabricNameEnumerationResult>,
         recursive: bool,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricNameEnumerationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -121,7 +121,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &[u8],
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -146,7 +146,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: i64,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -171,7 +171,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: f64,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -196,7 +196,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -221,7 +221,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &windows_core::GUID,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -245,7 +245,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -268,7 +268,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricPropertyMetadataResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -291,7 +291,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricPropertyValueResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -317,7 +317,7 @@ impl PropertyManagementClient {
         name: &Uri,
         batch: &[FABRIC_PROPERTY_BATCH_OPERATION],
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<(u32, IFabricPropertyBatchResult)>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -343,7 +343,7 @@ impl PropertyManagementClient {
         include_values: bool,
         prev: Option<&IFabricPropertyEnumerationResult>,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricPropertyEnumerationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -369,7 +369,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_operation: &FABRIC_PUT_CUSTOM_PROPERTY_OPERATION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -400,7 +400,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.create_name_internal(
             name,
@@ -418,7 +418,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.delete_name_internal(
             name,
@@ -434,7 +434,7 @@ impl PropertyManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<bool> {
         self.name_exists_internal(
             name,
@@ -456,7 +456,7 @@ impl PropertyManagementClient {
         prev: Option<&NameEnumerationResult>,
         recursive: bool,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<NameEnumerationResult> {
         self.enumerate_sub_names_internal(
             name,
@@ -477,7 +477,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &[u8],
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.put_property_binary_internal(
             name,
@@ -497,7 +497,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: f64,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.put_property_double_internal(
             name,
@@ -517,7 +517,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: i64,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.put_property_int64_internal(
             name,
@@ -537,7 +537,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &WString,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.put_property_wstring_internal(
             name,
@@ -557,7 +557,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         data: &windows_core::GUID,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.put_property_guid_internal(
             name,
@@ -576,7 +576,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.delete_property_internal(
             name,
@@ -594,7 +594,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<PropertyMetadataResult> {
         self.get_property_metadata_internal(
             name,
@@ -613,7 +613,7 @@ impl PropertyManagementClient {
         name: &Uri,
         property_name: &WString,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<PropertyValueResult> {
         self.get_property_internal(
             name,

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -19,7 +19,7 @@ use mssf_com::{
 };
 
 use crate::{
-    runtime::executor::CancelToken,
+    runtime::executor::BoxedCancelToken,
     sync::{FabricReceiver, fabric_begin_end_proxy},
 };
 use crate::{
@@ -46,7 +46,7 @@ impl QueryClient {
         &self,
         query_description: &FABRIC_NODE_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricGetNodeListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -64,7 +64,7 @@ impl QueryClient {
         &self,
         desc: &FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricGetPartitionListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -81,7 +81,7 @@ impl QueryClient {
         &self,
         desc: &FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricGetReplicaListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -98,7 +98,7 @@ impl QueryClient {
         &self,
         desc: &FABRIC_PARTITION_LOAD_INFORMATION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricGetPartitionLoadInformationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -115,7 +115,7 @@ impl QueryClient {
         &self,
         desc: &FABRIC_DEPLOYED_SERVICE_REPLICA_DETAIL_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricGetDeployedServiceReplicaDetailResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -147,7 +147,7 @@ impl QueryClient {
         &self,
         desc: &NodeQueryDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<NodeList> {
         // Note that the SF raw structs are scoped to avoid having them across await points.
         // This makes api Send. All FabricClient api should follow this pattern.
@@ -185,7 +185,7 @@ impl QueryClient {
         &self,
         desc: &ServicePartitionQueryDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<ServicePartitionList> {
         let com = {
             let raw: FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION = desc.into();
@@ -200,7 +200,7 @@ impl QueryClient {
         &self,
         desc: &ServiceReplicaQueryDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<ServiceReplicaList> {
         let com = {
             let raw: FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION = desc.into();
@@ -215,7 +215,7 @@ impl QueryClient {
         &self,
         desc: &PartitionLoadInformationQueryDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<PartitionLoadInformation> {
         let com = {
             let raw: FABRIC_PARTITION_LOAD_INFORMATION_QUERY_DESCRIPTION = desc.into();
@@ -230,7 +230,7 @@ impl QueryClient {
         &self,
         desc: &DeployedServiceReplicaDetailQueryDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<DeployedServiceReplicaDetailQueryResult> {
         let com = {
             let raw: FABRIC_DEPLOYED_SERVICE_REPLICA_DETAIL_QUERY_DESCRIPTION = desc.into();

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -5,7 +5,7 @@
 
 use std::{ffi::c_void, time::Duration};
 
-use crate::{PCWSTR, WString, types::Uri};
+use crate::{PCWSTR, WString, runtime::executor::BoxedCancelToken, types::Uri};
 use mssf_com::{
     FabricClient::{IFabricResolvedServicePartitionResult, IFabricServiceManagementClient6},
     FabricTypes::{
@@ -23,10 +23,7 @@ use mssf_com::{
     },
 };
 
-use crate::{
-    runtime::executor::CancelToken,
-    sync::{FabricReceiver, fabric_begin_end_proxy},
-};
+use crate::sync::{FabricReceiver, fabric_begin_end_proxy};
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
@@ -57,7 +54,7 @@ impl ServiceManagementClient {
         partition_key: Option<*const ::core::ffi::c_void>,
         previous_result: Option<&IFabricResolvedServicePartitionResult>, // This is different from generated code
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<IFabricResolvedServicePartitionResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -81,7 +78,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_RESTART_REPLICA_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -98,7 +95,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_REMOVE_REPLICA_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -115,7 +112,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<i64>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -132,7 +129,7 @@ impl ServiceManagementClient {
         &self,
         filterid: i64,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -153,7 +150,7 @@ impl ServiceManagementClient {
         &self,
         desc: &FABRIC_SERVICE_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -171,7 +168,7 @@ impl ServiceManagementClient {
         name: FABRIC_URI,
         desc: &FABRIC_SERVICE_UPDATE_DESCRIPTION,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -188,7 +185,7 @@ impl ServiceManagementClient {
         &self,
         name: FABRIC_URI,
         timeout_milliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> FabricReceiver<crate::WinResult<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
@@ -224,7 +221,7 @@ impl ServiceManagementClient {
         key_type: &PartitionKeyType,
         prev: Option<&ResolvedServicePartition>,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<ResolvedServicePartition> {
         let com = {
             let uri = FABRIC_URI(name.as_ptr() as *mut u16);
@@ -255,7 +252,7 @@ impl ServiceManagementClient {
         &self,
         desc: &RestartReplicaDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         {
             let raw: FABRIC_RESTART_REPLICA_DESCRIPTION = desc.into();
@@ -274,7 +271,7 @@ impl ServiceManagementClient {
         &self,
         desc: &RemoveReplicaDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         {
             let raw: FABRIC_REMOVE_REPLICA_DESCRIPTION = desc.into();
@@ -302,7 +299,7 @@ impl ServiceManagementClient {
         &self,
         desc: &ServiceNotificationFilterDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<FilterIdHandle> {
         let id = {
             let raw: FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION = desc.into();
@@ -323,7 +320,7 @@ impl ServiceManagementClient {
         &self,
         filter_id_handle: FilterIdHandle,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.unregister_service_notification_filter_internal(
             filter_id_handle.id,
@@ -338,7 +335,7 @@ impl ServiceManagementClient {
         &self,
         desc: &crate::types::ServiceDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         {
             let desc_raw = desc.build_raw();
@@ -354,7 +351,7 @@ impl ServiceManagementClient {
         name: &Uri,
         desc: &crate::types::ServiceUpdateDescription,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         {
             let desc_raw = desc.build_raw();
@@ -374,7 +371,7 @@ impl ServiceManagementClient {
         &self,
         name: &Uri,
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         self.delete_service_internal(
             name.as_raw(),

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -7,11 +7,7 @@
 
 use std::time::Duration;
 
-use crate::{
-    WString,
-    client::FabricClient,
-    sync::{NONE_CANCEL_TOKEN, SimpleCancelToken},
-};
+use crate::{WString, client::FabricClient, sync::SimpleCancelToken};
 use mssf_com::FabricTypes::FABRIC_E_SERVICE_DOES_NOT_EXIST;
 
 use crate::{
@@ -41,7 +37,7 @@ async fn test_fabric_client() {
         let qc_cp = qc.clone();
         let list = tokio::spawn(async move {
             // make sure api is Send.
-            qc_cp.get_node_list(&desc, timeout, NONE_CANCEL_TOKEN).await
+            qc_cp.get_node_list(&desc, timeout, None).await
         })
         .await
         .unwrap()
@@ -63,10 +59,7 @@ async fn test_fabric_client() {
             },
             ..Default::default()
         };
-        let list = qc
-            .get_node_list(&desc, timeout, NONE_CANCEL_TOKEN)
-            .await
-            .unwrap();
+        let list = qc.get_node_list(&desc, timeout, None).await.unwrap();
         let v = list.iter().collect::<Vec<_>>();
         for n in v {
             println!("More Node: {n:?}")
@@ -78,7 +71,7 @@ async fn test_fabric_client() {
         let desc = NodeQueryDescription {
             ..Default::default()
         };
-        let token = SimpleCancelToken::new();
+        let token = SimpleCancelToken::new_boxed();
         let list = qc.get_node_list(&desc, timeout, Some(token.clone()));
         token.cancel();
         let err = list.await.expect_err("request should be cancelled");
@@ -94,7 +87,7 @@ async fn test_fabric_client() {
                 &PartitionKeyType::None,
                 None,
                 timeout,
-                NONE_CANCEL_TOKEN,
+                None,
             )
             .await;
         match res {

--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -42,4 +42,16 @@ pub trait CancelToken: Send + Sync + 'static {
 
     /// Cancel the token.
     fn cancel(&self);
+
+    /// Clone the cancel token.
+    /// Because the dyn requirement, CancelToken cannot be cloned directly.
+    fn clone_box(&self) -> Box<dyn CancelToken>;
+}
+
+pub type BoxedCancelToken = Box<dyn CancelToken>;
+
+impl Clone for BoxedCancelToken {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
 }

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -5,15 +5,16 @@
 
 use std::time::Duration;
 
+use crate::runtime::executor::BoxedCancelToken;
 use crate::{Interface, WString};
 use mssf_com::FabricRuntime::{IFabricNodeContextResult, IFabricNodeContextResult2};
 
-use crate::{runtime::executor::CancelToken, sync::fabric_begin_end_proxy};
+use crate::sync::fabric_begin_end_proxy;
 use crate::{strings::WStringWrap, types::NodeId};
 
 pub fn get_com_node_context(
     timeout_milliseconds: u32,
-    cancellation_token: Option<impl CancelToken>,
+    cancellation_token: Option<BoxedCancelToken>,
 ) -> crate::sync::FabricReceiver<crate::WinResult<IFabricNodeContextResult>> {
     fabric_begin_end_proxy(
         move |callback| {
@@ -38,7 +39,7 @@ impl NodeContext {
     // Get the node context from SF runtime
     pub async fn get(
         timeout: Duration,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<Self> {
         let com = get_com_node_context(timeout.as_millis().try_into().unwrap(), cancellation_token)
             .await??;

--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -5,7 +5,7 @@
 
 // stateful contains rs definition of stateful traits that user needs to implement
 
-use crate::runtime::executor::CancelToken;
+use crate::runtime::executor::BoxedCancelToken;
 use crate::types::ReplicaRole;
 
 use crate::types::{Epoch, OpenMode, ReplicaInformation, ReplicaSetConfig, ReplicaSetQuorumMode};
@@ -43,7 +43,7 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<impl PrimaryReplicator>;
 
     /// Changes the role of the service replica to one of the ReplicaRole.
@@ -56,11 +56,11 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<crate::WString>;
 
     /// Closes the service replica gracefully when it is being shut down.
-    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()>;
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()>;
 
     /// Ungracefully terminates the service replica.
     /// Remarks: Network issues resulting in Service Fabric process shutdown
@@ -76,8 +76,8 @@ pub trait LocalReplicator: Send + Sync + 'static {
     /// in ReplicaInformation.
     /// Remarks:
     /// Replicator does not have an assigned role yet and should setup listening endpoint.
-    async fn open(&self, cancellation_token: impl CancelToken) -> crate::Result<crate::WString>;
-    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()>;
+    async fn open(&self, cancellation_token: BoxedCancelToken) -> crate::Result<crate::WString>;
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()>;
 
     /// Change the replicator role.
     ///
@@ -87,7 +87,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 
     /// (TODO: This doc is from IStateProvider but not Replicator.)
@@ -101,7 +101,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
     async fn update_epoch(
         &self,
         epoch: &Epoch,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 
     /// Get the current LSN, end of log, called on secondaries.
@@ -142,7 +142,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     // SF calls this to indicate that possible data loss has occurred (write quorum loss),
     // returns is isStateChanged. If true, SF will re-create other secondaries.
     // The default SF impl might be a pass through to the state provider.
-    async fn on_data_loss(&self, cancellation_token: impl CancelToken) -> crate::Result<u8>;
+    async fn on_data_loss(&self, cancellation_token: BoxedCancelToken) -> crate::Result<u8>;
 
     // Remarks on replicator configuration:
     // At any time the replicator can have one or two configurations. There is always a current
@@ -211,7 +211,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 
     /// Transferring state up to the current quorum LSN to a new or existing replica
@@ -233,7 +233,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 
     /// Notifies primary that an idle replica built by build_replica() api call

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -8,7 +8,7 @@
 
 use std::ffi::c_void;
 
-use crate::{Interface, WString, runtime::executor::CancelToken};
+use crate::{Interface, WString, runtime::executor::BoxedCancelToken};
 use mssf_com::FabricRuntime::{
     IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
     IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
@@ -46,7 +46,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<impl PrimaryReplicator> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -83,7 +83,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<WString> {
         // replica address
         let com1 = &self.com_impl;
@@ -101,7 +101,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()> {
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -135,7 +135,7 @@ impl Replicator for ReplicatorProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn open(&self, cancellation_token: impl CancelToken) -> crate::Result<WString> {
+    async fn open(&self, cancellation_token: BoxedCancelToken) -> crate::Result<WString> {
         // replicator address
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -151,7 +151,7 @@ impl Replicator for ReplicatorProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()> {
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -169,7 +169,7 @@ impl Replicator for ReplicatorProxy {
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -187,7 +187,7 @@ impl Replicator for ReplicatorProxy {
     async fn update_epoch(
         &self,
         epoch: &Epoch,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -238,17 +238,17 @@ impl PrimaryReplicatorProxy {
 }
 
 impl Replicator for PrimaryReplicatorProxy {
-    async fn open(&self, cancellation_token: impl CancelToken) -> crate::Result<WString> {
+    async fn open(&self, cancellation_token: BoxedCancelToken) -> crate::Result<WString> {
         self.parent.open(cancellation_token).await
     }
-    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()> {
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()> {
         self.parent.close(cancellation_token).await
     }
     async fn change_role(
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()> {
         self.parent
             .change_role(epoch, role, cancellation_token)
@@ -257,7 +257,7 @@ impl Replicator for PrimaryReplicatorProxy {
     async fn update_epoch(
         &self,
         epoch: &Epoch,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()> {
         self.parent.update_epoch(epoch, cancellation_token).await
     }
@@ -277,7 +277,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
         feature = "tracing",
         tracing::instrument(skip_all, level = "debug", ret, err)
     )]
-    async fn on_data_loss(&self, cancellation_token: impl CancelToken) -> crate::Result<u8> {
+    async fn on_data_loss(&self, cancellation_token: BoxedCancelToken) -> crate::Result<u8> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
         let rx = fabric_begin_end_proxy(
@@ -311,7 +311,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();
@@ -343,7 +343,7 @@ impl PrimaryReplicator for PrimaryReplicatorProxy {
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();

--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -7,7 +7,7 @@
 
 use crate::WString;
 use crate::runtime::StatelessServicePartition;
-use crate::runtime::executor::CancelToken;
+use crate::runtime::executor::BoxedCancelToken;
 
 /// Stateless service factories are registered with the FabricRuntime by service hosts via
 /// Runtime::register_stateless_service_factory().
@@ -36,11 +36,11 @@ pub trait LocalStatelessServiceInstance: Send + Sync + 'static {
     async fn open(
         &self,
         partition: &StatelessServicePartition,
-        cancellation_token: impl CancelToken,
+        cancellation_token: BoxedCancelToken,
     ) -> crate::Result<WString>;
 
     /// Closes this service instance gracefully when the service instance is being shut down.
-    async fn close(&self, cancellation_token: impl CancelToken) -> crate::Result<()>;
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()>;
 
     /// Terminates this instance ungracefully with this synchronous method call.
     /// Remarks:

--- a/crates/libs/core/src/runtime/store_proxy.rs
+++ b/crates/libs/core/src/runtime/store_proxy.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::{PCWSTR, runtime::executor::CancelToken};
+use crate::{PCWSTR, runtime::executor::BoxedCancelToken};
 use mssf_com::{
     FabricRuntime::{
         IFabricKeyValueStoreItemResult, IFabricKeyValueStoreReplica2, IFabricTransaction,
@@ -112,7 +112,7 @@ impl TransactionProxy {
     pub async fn commit(
         &self,
         timeoutmilliseconds: u32,
-        cancellation_token: Option<impl CancelToken>,
+        cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<i64> {
         let com1 = &self.com_impl;
         let com2 = self.com_impl.clone();

--- a/crates/libs/core/src/sync/mod.rs
+++ b/crates/libs/core/src/sync/mod.rs
@@ -15,7 +15,7 @@ use windows_core::implement;
 
 mod token;
 pub mod wait;
-pub use token::{NONE_CANCEL_TOKEN, SimpleCancelToken};
+pub use token::SimpleCancelToken;
 
 // This is intentional private. User should directly use bridge mod.
 mod bridge_context;

--- a/crates/libs/core/src/sync/proxy.rs
+++ b/crates/libs/core/src/sync/proxy.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::{runtime::executor::CancelToken, sync::NONE_CANCEL_TOKEN};
+use crate::runtime::executor::BoxedCancelToken;
 use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
 
 use super::{FabricReceiver, oneshot_channel};
@@ -39,7 +39,7 @@ use super::{FabricReceiver, oneshot_channel};
 pub fn fabric_begin_end_proxy<BEGIN, END, T>(
     begin: BEGIN,
     end: END,
-    token: Option<impl CancelToken>,
+    token: Option<BoxedCancelToken>,
 ) -> FabricReceiver<crate::WinResult<T>>
 where
     BEGIN: FnOnce(
@@ -62,7 +62,7 @@ where
             rx
         }
         Err(e) => {
-            let (tx2, rx2) = oneshot_channel(NONE_CANCEL_TOKEN);
+            let (tx2, rx2) = oneshot_channel(None);
             tx2.send(Err(e));
             rx2
         }

--- a/crates/libs/util/src/resolve.rs
+++ b/crates/libs/util/src/resolve.rs
@@ -5,16 +5,13 @@
 
 use std::{pin::Pin, time::Duration};
 
-use mssf_core::runtime::executor::{CancelToken, Timer};
+use mssf_core::runtime::executor::{BoxedCancelToken, Timer};
 use mssf_core::{ErrorCode, WString};
-use tokio_util::sync::CancellationToken;
 
 use mssf_core::client::{
     FabricClient,
     svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition, ServiceManagementClient},
 };
-
-use crate::tokio::TokioCancelToken;
 
 /// The same as dotnet sdk:
 /// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/develop/src/Microsoft.ServiceFabric.Services/Client/ServicePartitionResolver.cs
@@ -115,10 +112,8 @@ impl ServicePartitionResolver {
         key_type: &PartitionKeyType,
         prev: Option<&ResolvedServicePartition>,
         timeout: Option<Duration>, // Total timeout for the operation
-        token: Option<CancellationToken>,
+        token: Option<BoxedCancelToken>,
     ) -> mssf_core::Result<ResolvedServicePartition> {
-        let token = token.map(TokioCancelToken::from);
-
         let timeout = timeout.unwrap_or(self.default_timeout);
         let timer = TimeCounter::new(timeout);
         let mut cancel: Pin<Box<dyn std::future::Future<Output = ()> + Send>> =

--- a/crates/libs/util/src/tokio/tests.rs
+++ b/crates/libs/util/src/tokio/tests.rs
@@ -14,8 +14,8 @@ mod proxy_test {
 
     use mssf_core::{
         ErrorCode,
-        runtime::executor::CancelToken,
-        sync::{BridgeContext, NONE_CANCEL_TOKEN, fabric_begin_end_proxy},
+        runtime::executor::BoxedCancelToken,
+        sync::{BridgeContext, fabric_begin_end_proxy},
     };
 
     use crate::tokio::{TokioCancelToken, TokioExecutor};
@@ -34,14 +34,14 @@ mod proxy_test {
             &self,
             delay: Duration,
             ignore_cancel: bool, // ignores the token
-            token: Option<impl CancelToken>,
+            token: Option<BoxedCancelToken>,
         ) -> mssf_core::WinResult<String>;
 
         async fn set_data_delay(
             &self,
             input: String,
             delay: Duration,
-            token: Option<impl CancelToken>,
+            token: Option<BoxedCancelToken>,
         ) -> mssf_core::WinResult<()>;
     }
 
@@ -57,7 +57,7 @@ mod proxy_test {
             &self,
             delay: Duration,
             ignore_cancel: bool,
-            token: Option<impl CancelToken>,
+            token: Option<BoxedCancelToken>,
         ) -> mssf_core::WinResult<String> {
             if self.panic.load(std::sync::atomic::Ordering::Relaxed) {
                 panic!("test panic is set")
@@ -91,7 +91,7 @@ mod proxy_test {
             &self,
             input: String,
             delay: Duration,
-            token: Option<impl CancelToken>,
+            token: Option<BoxedCancelToken>,
         ) -> mssf_core::WinResult<()> {
             if self.panic.load(std::sync::atomic::Ordering::Relaxed) {
                 panic!("test panic is set")
@@ -237,7 +237,7 @@ mod proxy_test {
             &self,
             delay: Duration,
             ignore_cancel: bool,
-            token: Option<impl CancelToken>,
+            token: Option<BoxedCancelToken>,
         ) -> mssf_core::WinResult<String> {
             let com1 = &self.com;
             let com2 = self.com.clone();
@@ -255,7 +255,7 @@ mod proxy_test {
             &self,
             input: String,
             delay: Duration,
-            token: Option<impl CancelToken>,
+            token: Option<BoxedCancelToken>,
         ) -> mssf_core::WinResult<()> {
             let com1 = &self.com;
             let com2 = self.com.clone();
@@ -291,7 +291,7 @@ mod proxy_test {
     async fn test_cancel_interface(obj: &impl IMyObj, init_data: &str) {
         // get with no cancel
         {
-            let token = TokioCancelToken::new();
+            let token = TokioCancelToken::new_boxed();
             let out = obj
                 .get_data_delay(Duration::ZERO, false, Some(token))
                 .await
@@ -300,7 +300,7 @@ mod proxy_test {
         }
         // get with cancel
         {
-            let token = TokioCancelToken::new();
+            let token = TokioCancelToken::new_boxed();
             let fu = obj.get_data_delay(Duration::from_secs(5), false, Some(token.clone()));
             token.cancel();
             let err = fu.await.unwrap_err();
@@ -311,7 +311,7 @@ mod proxy_test {
         // This shows that the sender and receiver does not short circuit the future when token is cancelled,
         // the future result is always the result from the (SF) background task.
         {
-            let token = TokioCancelToken::new();
+            let token = TokioCancelToken::new_boxed();
             let fu = obj.get_data_delay(Duration::from_millis(3), true, Some(token.clone()));
             token.cancel();
             let out = fu.await.unwrap();
@@ -319,7 +319,7 @@ mod proxy_test {
         }
         // set with cancel
         {
-            let token = TokioCancelToken::new();
+            let token = TokioCancelToken::new_boxed();
             let fu = obj.set_data_delay(
                 "random_data".to_string(),
                 Duration::from_millis(15),
@@ -334,7 +334,7 @@ mod proxy_test {
             // sleep past the delay time to observe the final state
             tokio::time::sleep(Duration::from_millis(20)).await;
             let out = obj
-                .get_data_delay(Duration::ZERO, false, NONE_CANCEL_TOKEN)
+                .get_data_delay(Duration::ZERO, false, None)
                 .await
                 .unwrap();
             assert_eq!(out, init_data);
@@ -342,18 +342,14 @@ mod proxy_test {
         let expected_data2 = "mydata2";
         // set without cancel
         {
-            obj.set_data_delay(
-                expected_data2.to_string(),
-                Duration::from_millis(1),
-                NONE_CANCEL_TOKEN,
-            )
-            .await
-            .expect("fail to set data");
+            obj.set_data_delay(expected_data2.to_string(), Duration::from_millis(1), None)
+                .await
+                .expect("fail to set data");
         }
         // read the set.
         {
             let out = obj
-                .get_data_delay(Duration::ZERO, false, NONE_CANCEL_TOKEN)
+                .get_data_delay(Duration::ZERO, false, None)
                 .await
                 .unwrap();
             assert_eq!(out, expected_data2);
@@ -362,7 +358,7 @@ mod proxy_test {
         // So that the next test can reuse the obj.
         {
             {
-                obj.set_data_delay(init_data.to_string(), Duration::ZERO, NONE_CANCEL_TOKEN)
+                obj.set_data_delay(init_data.to_string(), Duration::ZERO, None)
                     .await
                     .expect("fail to set data");
             }
@@ -421,7 +417,7 @@ mod proxy_test {
                     res.unwrap();
                     break;
                 }
-                data = IMyObj::get_data_delay(obj,Duration::ZERO, false, NONE_CANCEL_TOKEN) =>{
+                data = IMyObj::get_data_delay(obj,Duration::ZERO, false, None) =>{
                     assert_eq!(data.unwrap(), expected_data);
                     count += 1;
                     if rx.try_recv().is_ok(){
@@ -441,7 +437,7 @@ mod proxy_test {
         let inner = MyObj::new(expected_data1.to_string());
         let proxy = MyObjProxy::new(h.clone(), inner);
         {
-            let out = IMyObj::get_data_delay(&proxy, Duration::ZERO, false, NONE_CANCEL_TOKEN)
+            let out = IMyObj::get_data_delay(&proxy, Duration::ZERO, false, None)
                 .await
                 .expect("fail to get data");
             assert_eq!(out, expected_data1);
@@ -454,7 +450,7 @@ mod proxy_test {
             .panic
             .store(true, std::sync::atomic::Ordering::Relaxed);
         {
-            let out = IMyObj::get_data_delay(&proxy, Duration::ZERO, false, NONE_CANCEL_TOKEN)
+            let out = IMyObj::get_data_delay(&proxy, Duration::ZERO, false, None)
                 .await
                 .expect_err("should error out");
             assert_eq!(out, ErrorCode::E_UNEXPECTED.into());

--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use mssf_core::runtime::executor::CancelToken;
+use mssf_core::runtime::executor::BoxedCancelToken;
 use mssf_core::{Error, WString};
 use mssf_core::{
     runtime::{
@@ -66,7 +66,7 @@ impl AppFabricReplicator {
 
 // This is basic implementation of Replicator
 impl Replicator for AppFabricReplicator {
-    async fn open(&self, _: impl CancelToken) -> mssf_core::Result<WString> {
+    async fn open(&self, _: BoxedCancelToken) -> mssf_core::Result<WString> {
         info!(
             "AppFabricReplicator2::Replicator::Open: {:?}",
             self.ctx.get_trace_read_write_status()
@@ -76,7 +76,7 @@ impl Replicator for AppFabricReplicator {
         Ok(str_res)
     }
 
-    async fn close(&self, _: impl CancelToken) -> mssf_core::Result<()> {
+    async fn close(&self, _: BoxedCancelToken) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::Replicator::close {:?}",
             self.ctx.get_trace_read_write_status()
@@ -88,7 +88,7 @@ impl Replicator for AppFabricReplicator {
         &self,
         epoch: &Epoch,
         role: &ReplicaRole,
-        _: impl CancelToken,
+        _: BoxedCancelToken,
     ) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::Replicator::change_role epoch:{epoch:?}, role:{role:?}, {:?}",
@@ -97,7 +97,7 @@ impl Replicator for AppFabricReplicator {
         Ok(())
     }
 
-    async fn update_epoch(&self, epoch: &Epoch, _: impl CancelToken) -> mssf_core::Result<()> {
+    async fn update_epoch(&self, epoch: &Epoch, _: BoxedCancelToken) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::Replicator::update_epoch: {epoch:?}, {:?}",
             self.ctx.get_trace_read_write_status()
@@ -131,7 +131,7 @@ impl Replicator for AppFabricReplicator {
 
 // This is basic implementation of PrimaryReplicator
 impl PrimaryReplicator for AppFabricReplicator {
-    async fn on_data_loss(&self, _: impl CancelToken) -> mssf_core::Result<u8> {
+    async fn on_data_loss(&self, _: BoxedCancelToken) -> mssf_core::Result<u8> {
         info!(
             "AppFabricReplicator2::PrimaryReplicator::on_data_loss {:?}",
             self.ctx.get_trace_read_write_status()
@@ -154,7 +154,7 @@ impl PrimaryReplicator for AppFabricReplicator {
     async fn wait_for_catch_up_quorum(
         &self,
         catchupmode: ReplicaSetQuorumMode,
-        _: impl CancelToken,
+        _: BoxedCancelToken,
     ) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::PrimaryReplicator::wait_for_catch_up_quorum mode:{catchupmode:?} {:?}",
@@ -197,7 +197,7 @@ impl PrimaryReplicator for AppFabricReplicator {
     async fn build_replica(
         &self,
         replica: &ReplicaInformation,
-        _: impl CancelToken,
+        _: BoxedCancelToken,
     ) -> mssf_core::Result<()> {
         info!(
             "AppFabricReplicator2::PrimaryReplicator::build_replica: info: {replica:?} {:?}",
@@ -306,7 +306,7 @@ impl StatefulServiceReplica for Replica {
         &self,
         openmode: OpenMode,
         partition: &StatefulServicePartition,
-        _: impl CancelToken,
+        _: BoxedCancelToken,
     ) -> mssf_core::Result<impl PrimaryReplicator> {
         self.ctx.init(partition.clone());
         info!(
@@ -323,7 +323,7 @@ impl StatefulServiceReplica for Replica {
     async fn change_role(
         &self,
         newrole: ReplicaRole,
-        _: impl CancelToken,
+        _: BoxedCancelToken,
     ) -> mssf_core::Result<WString> {
         info!(
             "Replica::change_role {newrole:?}, {:?}",
@@ -337,7 +337,7 @@ impl StatefulServiceReplica for Replica {
         let str_res = WString::from(addr);
         Ok(str_res)
     }
-    async fn close(&self, _: impl CancelToken) -> mssf_core::Result<()> {
+    async fn close(&self, _: BoxedCancelToken) -> mssf_core::Result<()> {
         info!(
             "Replica::close: {:?}",
             self.ctx.get_trace_read_write_status()

--- a/crates/samples/echomain-stateful2/src/test.rs
+++ b/crates/samples/echomain-stateful2/src/test.rs
@@ -14,7 +14,6 @@ use mssf_core::{
             ServiceEndpointRole, ServicePartitionKind,
         },
     },
-    sync::NONE_CANCEL_TOKEN,
     types::{
         DeployedServiceReplicaDetailQueryDescription, DeployedServiceReplicaDetailQueryResult,
         DeployedServiceReplicaDetailQueryResultValue, NamedPartitionSchemeDescription,
@@ -60,7 +59,7 @@ impl TestClient {
             partition_id_filter: None,
         };
         let list = qc
-            .get_partition_list(&desc, self.timeout, NONE_CANCEL_TOKEN)
+            .get_partition_list(&desc, self.timeout, None)
             .await
             .unwrap();
         // there is only one partition
@@ -84,7 +83,7 @@ impl TestClient {
         let qc = self.fc.get_query_manager();
         let desc = PartitionLoadInformationQueryDescription { partition_id };
         let partition_load_info = qc
-            .get_partition_load_information(&desc, self.timeout, NONE_CANCEL_TOKEN)
+            .get_partition_load_information(&desc, self.timeout, None)
             .await?;
 
         Ok(partition_load_info)
@@ -106,7 +105,7 @@ impl TestClient {
             replica_id_or_instance_id_filter: None,
         };
         let replicas = qc
-            .get_replica_list(&desc, self.timeout, NONE_CANCEL_TOKEN)
+            .get_replica_list(&desc, self.timeout, None)
             .await?
             .iter()
             .collect::<Vec<_>>();
@@ -149,7 +148,7 @@ impl TestClient {
             replica_id,
         };
 
-        qc.get_deployed_replica_detail(&desc, self.timeout, NONE_CANCEL_TOKEN)
+        qc.get_deployed_replica_detail(&desc, self.timeout, None)
             .await
     }
 
@@ -213,7 +212,7 @@ impl TestClient {
             &PartitionKeyType::None,
             prev,
             self.timeout,
-            NONE_CANCEL_TOKEN,
+            None,
         )
         .await
     }
@@ -231,7 +230,7 @@ impl TestClient {
             replica_or_instance_id: p.replica_id,
         };
         let mgmt = self.fc.get_service_manager();
-        mgmt.restart_replica(&desc, self.timeout, NONE_CANCEL_TOKEN)
+        mgmt.restart_replica(&desc, self.timeout, None)
             .await
             .unwrap();
 
@@ -301,7 +300,7 @@ async fn test_partition_info() {
             flags: ServiceNotificationFilterFlags::NamePrefix,
         };
         // register takes more than 1 sec.
-        mgmt.register_service_notification_filter(&desc, Duration::from_secs(10), NONE_CANCEL_TOKEN)
+        mgmt.register_service_notification_filter(&desc, Duration::from_secs(10), None)
             .await
             .unwrap()
     };
@@ -343,7 +342,7 @@ async fn test_partition_info() {
         }
     }
     // unregisters the notification
-    mgmt.unregister_service_notification_filter(filter_handle, timeout, NONE_CANCEL_TOKEN)
+    mgmt.unregister_service_notification_filter(filter_handle, timeout, None)
         .await
         .unwrap();
 
@@ -473,7 +472,7 @@ impl TestCreateUpdateClient {
         println!("creating service {service_name:?}");
         let sm = self.fc.get_service_manager().clone();
         let timeout = self.timeout;
-        tokio::spawn(async move { sm.create_service(&desc, timeout, NONE_CANCEL_TOKEN).await })
+        tokio::spawn(async move { sm.create_service(&desc, timeout, None).await })
             .await
             .expect("task panicked")
             .expect("create failed");
@@ -484,13 +483,10 @@ impl TestCreateUpdateClient {
         let sm = self.fc.get_service_manager().clone();
         let timeout = self.timeout;
         let service_name = service_name.clone();
-        tokio::spawn(async move {
-            sm.delete_service(&service_name, timeout, NONE_CANCEL_TOKEN)
-                .await
-        })
-        .await
-        .expect("task panicked")
-        .expect("delete failed");
+        tokio::spawn(async move { sm.delete_service(&service_name, timeout, None).await })
+            .await
+            .expect("task panicked")
+            .expect("delete failed");
     }
 
     async fn resolve_service(
@@ -503,13 +499,7 @@ impl TestCreateUpdateClient {
         let mut count = 0;
         loop {
             let res = smgr
-                .resolve_service_partition(
-                    &service_name.0,
-                    &key_type,
-                    None,
-                    self.timeout,
-                    NONE_CANCEL_TOKEN,
-                )
+                .resolve_service_partition(&service_name.0, &key_type, None, self.timeout, None)
                 .await;
             match res {
                 Ok(info) => {
@@ -546,13 +536,10 @@ impl TestCreateUpdateClient {
         let sm = self.fc.get_service_manager().clone();
         let timeout = self.timeout;
         let service_name = service_name.clone();
-        tokio::spawn(async move {
-            sm.update_service(&service_name, &desc, timeout, NONE_CANCEL_TOKEN)
-                .await
-        })
-        .await
-        .expect("task panicked")
-        .expect("delete failed");
+        tokio::spawn(async move { sm.update_service(&service_name, &desc, timeout, None).await })
+            .await
+            .expect("task panicked")
+            .expect("delete failed");
     }
 }
 

--- a/crates/samples/echomain-stateful2/src/test2.rs
+++ b/crates/samples/echomain-stateful2/src/test2.rs
@@ -10,7 +10,6 @@ use mssf_core::{
         FabricClient,
         svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition, ServiceEndpointRole},
     },
-    sync::NONE_CANCEL_TOKEN,
     types::{ReplicaRole, ServicePartitionInformation, ServicePartitionQueryResult, Uri},
 };
 use mssf_util::resolve::ServicePartitionResolver;
@@ -25,10 +24,7 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         partition_id_filter: None,
     };
 
-    let ptt = q
-        .get_partition_list(&desc, sm.timeout, NONE_CANCEL_TOKEN)
-        .await
-        .unwrap();
+    let ptt = q.get_partition_list(&desc, sm.timeout, None).await.unwrap();
     let partitions = ptt
         .iter()
         .filter_map(|p| match p {
@@ -46,7 +42,7 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         replica_id_or_instance_id_filter: None,
     };
     let replicas = q
-        .get_replica_list(&desc, sm.timeout, NONE_CANCEL_TOKEN)
+        .get_replica_list(&desc, sm.timeout, None)
         .await
         .unwrap()
         .iter()
@@ -69,7 +65,7 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         replica_or_instance_id: primary_replica.replica_id,
     };
     fc.get_service_manager()
-        .restart_replica(&desc, sm.timeout, NONE_CANCEL_TOKEN)
+        .restart_replica(&desc, sm.timeout, None)
         .await
         .unwrap();
 }
@@ -177,7 +173,7 @@ async fn test_resolve_notification() {
             flags: mssf_core::types::ServiceNotificationFilterFlags::NamePrefix,
         };
         fc.get_service_manager()
-            .register_service_notification_filter(&desc, sm.timeout, NONE_CANCEL_TOKEN)
+            .register_service_notification_filter(&desc, sm.timeout, None)
             .await
             .unwrap()
     };
@@ -215,7 +211,7 @@ async fn test_resolve_notification() {
 
     // Unregister the notification filter.
     fc.get_service_manager()
-        .unregister_service_notification_filter(filter_id, sm.timeout, NONE_CANCEL_TOKEN)
+        .unregister_service_notification_filter(filter_id, sm.timeout, None)
         .await
         .unwrap();
     sm.delete_service(&uri).await;


### PR DESCRIPTION
Using trait Option<impl CancelToken> for user facing api makes it very hard to use:
* None cannot be directly used but None::<specific token type> must be used.
* The impl cannot be cloned due to vtable constraints.
* It is difficult in the user code to pass the token around and every function needs to turn generic.

As a result I am change the parameter to Option<BoxedCancelToke> which is Box<dyn CancelToken> that use code will anyway make the boxing. And boxed version is made clonable.