### PR TITLE
Add CodePackageActivationContext::get_config_package_names and CodePackageActivationContext::get_data_package_names

### DIFF
--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -82,6 +82,16 @@ impl CodePackageActivationContext {
         Ok(ConfigurationPackage::from(c))
     }
 
+    pub fn get_config_package_names(&self) -> Vec<WString> {
+        // cpp code never returns failure.
+        let com = unsafe {
+            self.com_impl
+                .GetConfigurationPackageNames()
+                .expect("cannot get config package names")
+        };
+        crate::strings::WStringList::from(&com).into_vec()
+    }
+
     pub fn get_code_package_info(&self) -> CodePackageInfo {
         CodePackageInfo {
             context_id: WStringWrap::from(unsafe { self.com_impl.get_ContextId() }).into(),
@@ -193,6 +203,16 @@ impl CodePackageActivationContext {
         }
         .unwrap();
         Ok(())
+    }
+
+    pub fn get_data_package_names(&self) -> Vec<WString> {
+        // cpp code never returns failure.
+        let com = unsafe {
+            self.com_impl
+                .GetDataPackageNames()
+                .expect("cannot get data package names")
+        };
+        crate::strings::WStringList::from(&com).into_vec()
     }
 }
 

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -67,6 +67,18 @@ fn main() -> mssf_core::Result<()> {
         assert_eq!(name.to_string_lossy(), "Code");
     }
 
+    // inspect and check the config package
+    let config_package_names = actctx.get_config_package_names();
+    assert_eq!(config_package_names.len(), 1);
+    for name in config_package_names {
+        info!("config package {name}");
+        assert_eq!(name.to_string_lossy(), "Config");
+    }
+
+    // inspect and check the data package(s). Currently zero, which is completely valid
+    let data_package_names = actctx.get_data_package_names();
+    assert_eq!(data_package_names.len(), 0);
+
     // get listening port
     let endpoint = actctx
         .get_endpoint_resource(&WString::from("ServiceEndpoint1"))


### PR DESCRIPTION
I have a version of get_config_package_names in my repo; but it makes more sense to have the library provide it, exaclty like get_code_package_names. So add it.

I don't have immediate need for data package names, but I already happened to see it in source while checking the implementation of GetConfigPackageNames, and confirmed that it's not actually able to fail today either, and I may want it eventually (though there's more work to be done to expose Data Packages more fully if I ever do want it).