### PR TITLE
FabricClient: Add cluster health api

### DIFF
--- a/crates/libs/core/src/iter.rs
+++ b/crates/libs/core/src/iter.rs
@@ -69,6 +69,22 @@ where
     }
 }
 
+/// Convert a raw pointer and length into a Vec of safe type.
+pub(crate) fn vec_from_raw_com<T, V>(len: usize, raw: *const T) -> Vec<V>
+where
+    V: for<'a> std::convert::From<&'a T>,
+{
+    if len == 0 || raw.is_null() {
+        return vec![];
+    }
+    unsafe {
+        std::slice::from_raw_parts(raw, len)
+            .iter()
+            .map(|x| x.into())
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod test {
 

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod debug;
 mod error;
 pub use error::{Error, ErrorCode, Result};
 mod iter;
+pub mod mem;
 pub mod runtime;
 pub mod strings;
 pub mod sync;

--- a/crates/libs/core/src/mem.rs
+++ b/crates/libs/core/src/mem.rs
@@ -1,0 +1,68 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+/// A pool to hold boxes to extend their lifetime.
+/// This is typically useful to build raw COM structures that require
+/// raw pointers in struct fields.
+#[derive(Debug, Default)]
+pub struct BoxPool {
+    inner: Vec<Box<dyn 'static + std::any::Any>>,
+}
+
+impl BoxPool {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    /// Push a box into the pool, and return a raw pointer to the boxed value.
+    /// The pointer is valid as long as the pool is alive.
+    pub fn push<T: 'static>(&mut self, b: Box<T>) -> *const T {
+        let raw = b.as_ref() as *const T;
+        self.inner.push(b);
+        raw
+    }
+
+    /// Push a Vec<T> into the pool, and return its length and a raw pointer to its data.
+    /// The pointer is valid as long as the pool is alive.
+    pub fn push_vec<T: 'static>(&mut self, v: Vec<T>) -> (usize, *const T) {
+        let len = v.len();
+        let raw = v.as_ptr();
+        // Convert Vec<T> to Box<dyn Any>.
+        let boxed_v = Box::new(v);
+        self.inner.push(boxed_v);
+        (len, raw)
+    }
+}
+
+/// Trait to get a raw pointer from a type, using a BoxPool to hold the box.
+/// This is useful to implement conversions to raw COM types that require
+/// raw pointers in struct fields.
+pub trait GetRawWithBoxPool<T> {
+    fn get_raw_with_pool(&self, pool: &mut BoxPool) -> T;
+}
+
+/// Trait to get a raw pointer from a type.
+/// Type should implement this trait if it can return a raw pointer without BoxPool.
+pub trait GetRaw<T> {
+    fn get_raw(&self) -> T;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_box_pool() {
+        let mut pool = BoxPool::new();
+        let b = Box::new(42);
+        let raw = pool.push(b);
+        assert_eq!(unsafe { *raw }, 42);
+
+        let v = vec![1, 2, 3];
+        let (len, raw_v) = pool.push_vec(v);
+        assert_eq!(len, 3);
+        assert_eq!(unsafe { *raw_v }, 1);
+    }
+}

--- a/crates/libs/core/src/types/client/health.rs
+++ b/crates/libs/core/src/types/client/health.rs
@@ -3,14 +3,21 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use mssf_com::FabricClient::IFabricNodeHealthResult;
-use mssf_com::FabricTypes::{FABRIC_HEALTH_EVENT, FABRIC_HEALTH_EVENT_LIST};
+use mssf_com::FabricClient::{IFabricClusterHealthResult, IFabricNodeHealthResult};
+use mssf_com::FabricTypes::{
+    FABRIC_APPLICATION_HEALTH_POLICY, FABRIC_APPLICATION_HEALTH_POLICY_MAP,
+    FABRIC_APPLICATION_HEALTH_POLICY_MAP_ITEM, FABRIC_APPLICATION_HEALTH_STATES_FILTER,
+    FABRIC_CLUSTER_HEALTH, FABRIC_CLUSTER_HEALTH_POLICY, FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION,
+    FABRIC_HEALTH_EVENT, FABRIC_HEALTH_EVENTS_FILTER, FABRIC_NODE_HEALTH_STATES_FILTER,
+    FABRIC_SERVICE_TYPE_HEALTH_POLICY, FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP,
+    FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP_ITEM,
+};
 use windows_core::Win32::Foundation::FILETIME;
 
-use crate::iter::{FabricIter, FabricListAccessor};
+use crate::mem::{BoxPool, GetRaw, GetRawWithBoxPool};
 use crate::{GUID, WString};
 
-use crate::types::{HealthInformation, HealthState};
+use crate::types::{HealthInformation, HealthState, Uri};
 
 /// FABRIC_HEALTH_REPORT
 #[derive(Debug, Clone)]
@@ -126,6 +133,15 @@ pub struct HealthEventsFilter {
     pub health_state_filter: HealthStateFilterFlags, // FABRIC_HEALTH_STATE_FILTER
 }
 
+impl GetRaw<FABRIC_HEALTH_EVENTS_FILTER> for HealthEventsFilter {
+    fn get_raw(&self) -> FABRIC_HEALTH_EVENTS_FILTER {
+        FABRIC_HEALTH_EVENTS_FILTER {
+            HealthStateFilter: self.health_state_filter.bits() as u32,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
 bitflags::bitflags! {
     /// bitflag of FABRIC_HEALTH_STATE_FILTER
     #[derive(Debug, Clone)]
@@ -148,6 +164,7 @@ pub struct NodeHealthQueryDescription {
 }
 
 /// IFabricNodeHealthResult and FABRIC_NODE_HEALTH
+#[derive(Debug, Clone)]
 pub struct NodeHealthResult {
     pub node_name: WString,
     pub aggregated_health_state: HealthState,
@@ -157,15 +174,19 @@ pub struct NodeHealthResult {
 impl NodeHealthResult {
     pub fn from_com(com: &IFabricNodeHealthResult) -> Self {
         let raw = unsafe { com.get_NodeHealth().as_ref().unwrap() };
+        let health_event_list = unsafe { raw.HealthEvents.as_ref() }.map_or(vec![], |list| {
+            crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+        });
         Self {
             node_name: WString::from(raw.NodeName),
             aggregated_health_state: (&raw.AggregatedHealthState).into(),
-            health_events: HealthEventList { com: com.clone() }.iter().collect(),
+            health_events: health_event_list,
         }
     }
 }
 
 /// FABRIC_HEALTH_EVENT
+#[derive(Debug, Clone)]
 pub struct HealthEvent {
     pub health_information: HealthInformation,
     pub source_utc_timestamp: FILETIME,
@@ -184,29 +205,248 @@ impl From<&FABRIC_HEALTH_EVENT> for HealthEvent {
     }
 }
 
-// FABRIC_HEALTH_EVENT_LIST
-pub struct HealthEventList {
-    com: IFabricNodeHealthResult,
+// FABRIC_NODE_HEALTH_STATES_FILTER
+#[derive(Debug, Clone)]
+pub struct NodeHealthStatesFilter {
+    pub health_state_filter: HealthStateFilterFlags, // FABRIC_HEALTH_STATE_FILTER
 }
 
-type HealthEventListIter<'a> = FabricIter<'a, FABRIC_HEALTH_EVENT, HealthEvent, HealthEventList>;
-
-impl HealthEventList {
-    fn get_raw_list(&self) -> Option<&FABRIC_HEALTH_EVENT_LIST> {
-        unsafe { self.com.get_NodeHealth().as_ref()?.HealthEvents.as_ref() }
-    }
-    pub fn iter(&self) -> HealthEventListIter<'_> {
-        FabricIter::new(self, self)
+impl GetRaw<FABRIC_NODE_HEALTH_STATES_FILTER> for NodeHealthStatesFilter {
+    fn get_raw(&self) -> FABRIC_NODE_HEALTH_STATES_FILTER {
+        FABRIC_NODE_HEALTH_STATES_FILTER {
+            HealthStateFilter: self.health_state_filter.bits() as u32,
+            Reserved: std::ptr::null_mut(),
+        }
     }
 }
-impl FabricListAccessor<FABRIC_HEALTH_EVENT> for HealthEventList {
-    fn get_count(&self) -> u32 {
-        let raw = self.get_raw_list();
-        raw.map(|r| r.Count).unwrap_or(0)
-    }
 
-    fn get_first_item(&self) -> *const FABRIC_HEALTH_EVENT {
-        let raw = self.get_raw_list();
-        raw.map(|r| r.Items).unwrap_or(std::ptr::null())
+// FABRIC_NODE_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct NodeHealthState {
+    pub node_name: WString,
+    pub aggregated_health_state: HealthState,
+}
+
+impl From<&mssf_com::FabricTypes::FABRIC_NODE_HEALTH_STATE> for NodeHealthState {
+    fn from(value: &mssf_com::FabricTypes::FABRIC_NODE_HEALTH_STATE) -> Self {
+        Self {
+            node_name: WString::from(value.NodeName),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+        }
+    }
+}
+
+// FABRIC_APPLICATION_HEALTH_STATES_FILTER
+#[derive(Debug, Clone)]
+pub struct ApplicationHealthStatesFilter {
+    pub health_state_filter: HealthStateFilterFlags, // FABRIC_HEALTH_STATE_FILTER
+}
+
+impl GetRaw<FABRIC_APPLICATION_HEALTH_STATES_FILTER> for ApplicationHealthStatesFilter {
+    fn get_raw(&self) -> FABRIC_APPLICATION_HEALTH_STATES_FILTER {
+        FABRIC_APPLICATION_HEALTH_STATES_FILTER {
+            HealthStateFilter: self.health_state_filter.bits() as u32,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+// FABRIC_APPLICATION_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct ApplicationHealthState {
+    pub application_name: Uri,
+    pub aggregated_health_state: HealthState,
+}
+
+impl From<&mssf_com::FabricTypes::FABRIC_APPLICATION_HEALTH_STATE> for ApplicationHealthState {
+    fn from(value: &mssf_com::FabricTypes::FABRIC_APPLICATION_HEALTH_STATE) -> Self {
+        Self {
+            application_name: Uri::from(value.ApplicationName),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+        }
+    }
+}
+
+// FABRIC_SERVICE_TYPE_HEALTH_POLICY
+#[derive(Debug, Clone, Default)]
+pub struct ServiceTypeHealthPolicy {
+    pub max_percent_unhealthy_services: u8,
+    pub max_percent_unhealthy_partitions_per_service: u8,
+    pub max_percent_unhealthy_replicas_per_partition: u8,
+}
+impl GetRaw<FABRIC_SERVICE_TYPE_HEALTH_POLICY> for ServiceTypeHealthPolicy {
+    fn get_raw(&self) -> FABRIC_SERVICE_TYPE_HEALTH_POLICY {
+        FABRIC_SERVICE_TYPE_HEALTH_POLICY {
+            MaxPercentUnhealthyServices: self.max_percent_unhealthy_services,
+            MaxPercentUnhealthyPartitionsPerService: self
+                .max_percent_unhealthy_partitions_per_service,
+            MaxPercentUnhealthyReplicasPerPartition: self
+                .max_percent_unhealthy_replicas_per_partition,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+// FABRIC_APPLICATION_HEALTH_POLICY
+#[derive(Debug, Clone, Default)]
+pub struct ApplicationHealthPolicy {
+    pub consider_warning_as_error: bool,
+    pub max_percent_unhealthy_partitions: u8,
+    pub default_service_type_health_policy: Option<ServiceTypeHealthPolicy>,
+    pub service_type_health_policy_map:
+        Option<std::collections::HashMap<WString, ServiceTypeHealthPolicy>>,
+}
+
+impl GetRawWithBoxPool<FABRIC_APPLICATION_HEALTH_POLICY> for ApplicationHealthPolicy {
+    fn get_raw_with_pool(&self, pool: &mut BoxPool) -> FABRIC_APPLICATION_HEALTH_POLICY {
+        let default_service_type_health_policy = self
+            .default_service_type_health_policy
+            .as_ref()
+            .map(|policy| pool.push(Box::new(policy.get_raw())));
+        // build the policy map FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP
+        let service_type_health_policy_map =
+            self.service_type_health_policy_map
+                .as_ref()
+                .map(|policies| {
+                    let mut items = Vec::new();
+                    for (name, policy) in policies {
+                        let raw_svc_tp_policy = pool.push(Box::new(policy.get_raw()));
+                        items.push(FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP_ITEM {
+                            ServiceTypeName: name.as_pcwstr(),
+                            ServiceTypeHealthPolicy: raw_svc_tp_policy,
+                        });
+                    }
+                    let (count, items) = pool.push_vec(items);
+                    // save the items on heap_holder to extend the lifetime
+                    pool.push(Box::new(FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP {
+                        Count: count as u32,
+                        Items: items as *mut _,
+                    }))
+                });
+        FABRIC_APPLICATION_HEALTH_POLICY {
+            ConsiderWarningAsError: self.consider_warning_as_error,
+            DefaultServiceTypeHealthPolicy: default_service_type_health_policy
+                .unwrap_or(std::ptr::null()),
+            ServiceTypeHealthPolicyMap: service_type_health_policy_map.unwrap_or(std::ptr::null()),
+            MaxPercentUnhealthyDeployedApplications: self.max_percent_unhealthy_partitions,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+// FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION
+#[derive(Debug, Clone, Default)]
+pub struct ClusterHealthQueryDescription {
+    pub health_policy: Option<ClusterHealthPolicy>,
+    pub application_health_policy_map:
+        Option<std::collections::HashMap<Uri, ApplicationHealthPolicy>>,
+    pub events_filter: Option<HealthEventsFilter>,
+    pub nodes_filter: Option<NodeHealthStatesFilter>,
+    pub applications_filter: Option<ApplicationHealthStatesFilter>,
+}
+
+impl GetRawWithBoxPool<FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION> for ClusterHealthQueryDescription {
+    fn get_raw_with_pool(&self, pool: &mut BoxPool) -> FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION {
+        let health_policy = self.health_policy.as_ref().map(|policy| {
+            let raw = Box::new(FABRIC_CLUSTER_HEALTH_POLICY {
+                ConsiderWarningAsError: policy.consider_warning_as_error,
+                MaxPercentUnhealthyNodes: policy.max_percent_unhealthy_nodes,
+                MaxPercentUnhealthyApplications: policy.max_percent_unhealthy_applications,
+                Reserved: std::ptr::null_mut(),
+            });
+            pool.push(raw)
+        });
+        let application_health_policy_map =
+            self.application_health_policy_map.as_ref().map(|policies| {
+                let mut items = Vec::new();
+                for (name, policy) in policies {
+                    let raw_policy = Box::new(policy.get_raw_with_pool(pool));
+                    let raw_policy = pool.push(raw_policy);
+                    items.push(FABRIC_APPLICATION_HEALTH_POLICY_MAP_ITEM {
+                        ApplicationName: name.as_raw(),
+                        HealthPolicy: raw_policy,
+                    });
+                }
+                let (count, items) = pool.push_vec(items);
+                // save the items on heap_holder to extend the lifetime
+                pool.push(Box::new(FABRIC_APPLICATION_HEALTH_POLICY_MAP {
+                    Count: count as u32,
+                    Items: items as *mut _,
+                }))
+            });
+        FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION {
+            HealthPolicy: health_policy.unwrap_or(std::ptr::null()),
+            ApplicationHealthPolicyMap: application_health_policy_map.unwrap_or(std::ptr::null()),
+            EventsFilter: self
+                .events_filter
+                .as_ref()
+                .map(|f| pool.push(Box::new(f.get_raw())))
+                .unwrap_or(std::ptr::null()),
+            NodesFilter: self
+                .nodes_filter
+                .as_ref()
+                .map(|f| pool.push(Box::new(f.get_raw())))
+                .unwrap_or(std::ptr::null()),
+            ApplicationsFilter: self
+                .applications_filter
+                .as_ref()
+                .map(|f| pool.push(Box::new(f.get_raw())))
+                .unwrap_or(std::ptr::null()),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// FABRIC_CLUSTER_HEALTH
+#[derive(Debug, Clone)]
+pub struct ClusterHealth {
+    pub aggregated_health_state: HealthState,
+    pub node_health_states: Vec<NodeHealthState>,
+    pub application_health_states: Vec<ApplicationHealthState>,
+    pub health_events: Vec<HealthEvent>,
+    // TODO: health evaluations
+    // TODO: health statistics
+}
+
+impl From<&FABRIC_CLUSTER_HEALTH> for ClusterHealth {
+    fn from(value: &FABRIC_CLUSTER_HEALTH) -> Self {
+        let ex1 = unsafe {
+            (value.Reserved as *const mssf_com::FabricTypes::FABRIC_CLUSTER_HEALTH_EX1)
+                .as_ref()
+                .unwrap()
+        };
+        let ex2 = unsafe {
+            (ex1.Reserved as *const mssf_com::FabricTypes::FABRIC_CLUSTER_HEALTH_EX2)
+                .as_ref()
+                .unwrap()
+        };
+        let _ex3 = unsafe {
+            (ex2.Reserved as *const mssf_com::FabricTypes::FABRIC_CLUSTER_HEALTH_EX3)
+                .as_ref()
+                .unwrap()
+        };
+        let node_health_list = unsafe { ex1.NodeHealthStates.as_ref() }.map_or(vec![], |list| {
+            crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+        });
+        let application_health_list = unsafe { ex1.ApplicationHealthStates.as_ref() }
+            .map_or(vec![], |list| {
+                crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+            });
+        let health_event_list = unsafe { ex1.HealthEvents.as_ref() }.map_or(vec![], |list| {
+            crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+        });
+        Self {
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+            node_health_states: node_health_list,
+            application_health_states: application_health_list,
+            health_events: health_event_list,
+        }
+    }
+}
+
+impl From<&IFabricClusterHealthResult> for ClusterHealth {
+    fn from(value: &IFabricClusterHealthResult) -> Self {
+        let raw = unsafe { value.get_ClusterHealth().as_ref().unwrap() };
+        raw.into()
     }
 }

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -105,7 +105,7 @@ impl NodeList {
 
 type NodeListIter<'a> = FabricIter<'a, FABRIC_NODE_QUERY_RESULT_ITEM, Node, NodeList>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     pub name: WString,
     pub ip_address_or_fqdn: WString,

--- a/crates/libs/core/src/types/common/mod.rs
+++ b/crates/libs/core/src/types/common/mod.rs
@@ -110,3 +110,9 @@ impl From<&str> for Uri {
         Self(WString::from(value))
     }
 }
+
+impl From<FABRIC_URI> for Uri {
+    fn from(value: FABRIC_URI) -> Self {
+        Self::from(WString::from(windows_core::PCWSTR(value.0)))
+    }
+}

--- a/crates/libs/util/src/monitoring/entities.rs
+++ b/crates/libs/util/src/monitoring/entities.rs
@@ -3,16 +3,22 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use mssf_core::types::HealthState;
+use mssf_core::types::{ClusterHealth, Node, NodeHealthResult};
 
 /// Health entities produced by HealthDataProducer.
 #[derive(Debug, Clone)]
 pub enum HealthEntity {
     Node(NodeHealthEntity),
+    Cluster(ClusterHealthEntity),
 }
 
 #[derive(Debug, Clone)]
 pub struct NodeHealthEntity {
-    pub node_name: String,
-    pub aggregated_health_state: HealthState,
+    pub node: Node,
+    pub health: NodeHealthResult,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClusterHealthEntity {
+    pub health: ClusterHealth,
 }


### PR DESCRIPTION
Also add cluster health in monitoring api.

Added new mechanism to construct COM structs using BoxPool:  COM api call ususally involves using COM structs that are short lived, and such structs have complex pointer associations. Previously different tricks were used to construct these structs and it is hard to maintain. With the introduction of BoxPool, COM structs can be easily allocated with raw pointers.
BoxPool needs to be kept in scope until the COM api call returns. This works because COM api always copies the struct into internal cpp structs before returning.
COM api used to return a iterator for com lists and it is quite complex to write. We plan to just return Vec<_> instead of iterator so that we don't need to manage lifetimes and boilerplate code. User usually convert the iterator to Vec immediately, so there is no point to support the iterator.