### PR TITLE
[util] Add empty replicator

### DIFF
--- a/crates/libs/util/src/data.rs
+++ b/crates/libs/util/src/data.rs
@@ -1,0 +1,172 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! mssf data utilities and extensions
+//!
+
+use mssf_core::{
+    WString,
+    runtime::{
+        executor::BoxedCancelToken,
+        stateful::{PrimaryReplicator, Replicator},
+        stateful_proxy::StatefulServicePartition,
+    },
+    types::{
+        Epoch, ReplicaInformation, ReplicaRole, ReplicaSetConfig, ReplicaSetQuorumMode,
+        ServicePartitionAccessStatus,
+    },
+};
+
+/// An empty replicator that does nothing. Useful for services without
+/// replication needs.
+/// Traces are added for all methods for easier debugging.
+#[derive(Clone)]
+pub struct EmptyReplicator {
+    name: WString,
+    partition: Option<StatefulServicePartition>,
+}
+
+impl EmptyReplicator {
+    /// Get read status for tracing.
+    fn read_status(&self) -> Option<ServicePartitionAccessStatus> {
+        self.partition
+            .as_ref()
+            .map(|p| p.get_read_status().ok())
+            .unwrap_or(None)
+    }
+
+    /// Get write status for tracing.
+    fn write_status(&self) -> Option<ServicePartitionAccessStatus> {
+        self.partition
+            .as_ref()
+            .map(|p| p.get_write_status().ok())
+            .unwrap_or(None)
+    }
+}
+
+/// Make it short for tracing purpose
+impl std::fmt::Debug for EmptyReplicator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EmptyReplicator-{}", self.name)
+    }
+}
+
+impl EmptyReplicator {
+    /// Create a new empty replicator with a name for tracing purpose.
+    pub fn new(name: WString, partition: Option<StatefulServicePartition>) -> EmptyReplicator {
+        EmptyReplicator { name, partition }
+    }
+}
+
+// This is basic implementation of Replicator
+impl Replicator for EmptyReplicator {
+    #[tracing::instrument(err, ret)]
+    async fn open(&self, _: BoxedCancelToken) -> mssf_core::Result<WString> {
+        // Empty replicator does not listen on any address
+        Ok(WString::from("NoProtocol://localhost:0"))
+    }
+
+    #[tracing::instrument(err, ret)]
+    async fn close(&self, _: BoxedCancelToken) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    #[tracing::instrument(fields(read_status = ?self.read_status(), write_status = ?self.write_status()), err, ret)]
+    async fn change_role(
+        &self,
+        epoch: &Epoch,
+        role: &ReplicaRole,
+        _: BoxedCancelToken,
+    ) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    #[tracing::instrument(fields(read_status = ?self.read_status(), write_status = ?self.write_status()), err, ret)]
+    async fn update_epoch(&self, epoch: &Epoch, _: BoxedCancelToken) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    #[tracing::instrument(err, ret)]
+    fn get_current_progress(&self) -> mssf_core::Result<i64> {
+        Ok(1)
+    }
+
+    #[tracing::instrument(err, ret)]
+    fn get_catch_up_capability(&self) -> mssf_core::Result<i64> {
+        Ok(1)
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn abort(&self) {
+        tracing::info!("abort");
+    }
+}
+
+// This is basic implementation of PrimaryReplicator
+impl PrimaryReplicator for EmptyReplicator {
+    async fn on_data_loss(&self, _: BoxedCancelToken) -> mssf_core::Result<u8> {
+        Ok(0)
+    }
+
+    #[tracing::instrument(err, ret)]
+    fn update_catch_up_replica_set_configuration(
+        &self,
+        currentconfiguration: &ReplicaSetConfig,
+        previousconfiguration: &ReplicaSetConfig,
+    ) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    #[tracing::instrument(fields(read_status = ?self.read_status(), write_status = ?self.write_status()), err, ret)]
+    async fn wait_for_catch_up_quorum(
+        &self,
+        catchupmode: ReplicaSetQuorumMode,
+        _: BoxedCancelToken,
+    ) -> mssf_core::Result<()> {
+        // Before demoting a primary to active secondary in graceful failover (MovePrimary api FabricClient trigger),
+        // (R:G, W:P) means read status granted, write status reconfiguration pending.
+        // NA means status NotPrimary.
+        // SF calls this in order:
+        // * update_catch_up_replica_set_configuration
+        // * wait_for_catch_up_quorum write mode, with (R:G, W:G).
+        //   app should catch up making necessary writes. (For example: complete transaction?)
+        //   This may take forever depends on the implementation, if write is faster than catch up.
+        //   App can ignore this call and let the next catch up call handle it all, if the app
+        //   does not need to do write while catching up.
+        // * update epoch,(R:G, W:P). SF revokes write status for the service.
+        // * update_catch_up_replica_set_configuration, with (R:G, W:P)
+        // * wait_for_catch_up_quorum, with (R:G, W:P).
+        //   app should catch up knowing that user/client is not able to write.
+        // * change_role from Primary to ActiveSecondary, with the same epoch from update epoch. (R:NA,W:NA)
+
+        // For newly created or promoted Primary, status starts with ChangeRole Primary (R:P, W:P)
+        // * update_catch_up_replica_set_configuration (R:P, W:P)
+        // * wait_for_catch_up_quorum (R:P, W:P)
+        // * update_current_replica_set_configuration (R:G, W:G)
+        Ok(())
+    }
+
+    #[tracing::instrument(err, ret)]
+    fn update_current_replica_set_configuration(
+        &self,
+        currentconfiguration: &ReplicaSetConfig,
+    ) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    #[tracing::instrument(err, ret)]
+    async fn build_replica(
+        &self,
+        replica: &ReplicaInformation,
+        _: BoxedCancelToken,
+    ) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    #[tracing::instrument(err, ret)]
+    fn remove_replica(&self, _replicaid: i64) -> mssf_core::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/libs/util/src/lib.rs
+++ b/crates/libs/util/src/lib.rs
@@ -14,3 +14,5 @@ pub mod resolve;
 
 #[cfg(feature = "tokio")]
 pub mod monitoring;
+
+pub mod data;

--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -7,13 +7,12 @@ use mssf_core::runtime::executor::BoxedCancelToken;
 use mssf_core::{Error, WString};
 use mssf_core::{
     runtime::{
-        stateful::{PrimaryReplicator, Replicator, StatefulServiceFactory, StatefulServiceReplica},
+        stateful::{PrimaryReplicator, StatefulServiceFactory, StatefulServiceReplica},
         stateful_proxy::StatefulServicePartition,
     },
-    types::{
-        Epoch, OpenMode, ReplicaInformation, ReplicaRole, ReplicaSetConfig, ReplicaSetQuorumMode,
-    },
+    types::{OpenMode, ReplicaRole},
 };
+use mssf_util::data::EmptyReplicator;
 use mssf_util::tokio::TokioExecutor;
 use std::{
     cell::Cell,
@@ -46,173 +45,6 @@ fn get_addr(port: u32, hostname: WString) -> String {
     addr.push(':');
     addr.push_str(&port.to_string());
     addr
-}
-
-pub struct AppFabricReplicator {
-    port_: u32,
-    hostname_: WString,
-    ctx: ReplicaCtx,
-}
-
-impl AppFabricReplicator {
-    pub fn new(port: u32, hostname: WString, ctx: ReplicaCtx) -> AppFabricReplicator {
-        AppFabricReplicator {
-            port_: port,
-            hostname_: hostname,
-            ctx,
-        }
-    }
-}
-
-// This is basic implementation of Replicator
-impl Replicator for AppFabricReplicator {
-    async fn open(&self, _: BoxedCancelToken) -> mssf_core::Result<WString> {
-        info!(
-            "AppFabricReplicator2::Replicator::Open: {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        let addr = get_addr(self.port_, self.hostname_.clone());
-        let str_res = WString::from(addr);
-        Ok(str_res)
-    }
-
-    async fn close(&self, _: BoxedCancelToken) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::Replicator::close {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
-
-    async fn change_role(
-        &self,
-        epoch: &Epoch,
-        role: &ReplicaRole,
-        _: BoxedCancelToken,
-    ) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::Replicator::change_role epoch:{epoch:?}, role:{role:?}, {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
-
-    async fn update_epoch(&self, epoch: &Epoch, _: BoxedCancelToken) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::Replicator::update_epoch: {epoch:?}, {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
-
-    fn get_current_progress(&self) -> mssf_core::Result<i64> {
-        info!(
-            "AppFabricReplicator2::Replicator::get_current_progress {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(0)
-    }
-
-    fn get_catch_up_capability(&self) -> mssf_core::Result<i64> {
-        info!(
-            "AppFabricReplicator2::Replicator::get_catch_up_capability {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(0)
-    }
-
-    fn abort(&self) {
-        info!(
-            "AppFabricReplicator2::Replicator::abort {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-    }
-}
-
-// This is basic implementation of PrimaryReplicator
-impl PrimaryReplicator for AppFabricReplicator {
-    async fn on_data_loss(&self, _: BoxedCancelToken) -> mssf_core::Result<u8> {
-        info!(
-            "AppFabricReplicator2::PrimaryReplicator::on_data_loss {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(0)
-    }
-
-    fn update_catch_up_replica_set_configuration(
-        &self,
-        currentconfiguration: &ReplicaSetConfig,
-        previousconfiguration: &ReplicaSetConfig,
-    ) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::PrimaryReplicator::update_catch_up_replica_set_configuration: curr: {currentconfiguration:?}, prev: {previousconfiguration:?},{:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
-
-    async fn wait_for_catch_up_quorum(
-        &self,
-        catchupmode: ReplicaSetQuorumMode,
-        _: BoxedCancelToken,
-    ) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::PrimaryReplicator::wait_for_catch_up_quorum mode:{catchupmode:?} {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        // Before demoting a primary to active secondary in graceful failover (MovePrimary api FabricClient trigger),
-        // (R:G, W:P) means read status granted, write status reconfiguration pending.
-        // NA means status NotPrimary.
-        // SF calls this in order:
-        // * update_catch_up_replica_set_configuration
-        // * wait_for_catch_up_quorum write mode, with (R:G, W:G).
-        //   app should catch up making necessary writes. (For example: complete transaction?)
-        //   This may take forever depends on the implementation, if write is faster than catch up.
-        //   App can ignore this call and let the next catch up call handle it all, if the app
-        //   does not need to do write while catching up.
-        // * update epoch,(R:G, W:P). SF revokes write status for the service.
-        // * update_catch_up_replica_set_configuration, with (R:G, W:P)
-        // * wait_for_catch_up_quorum, with (R:G, W:P).
-        //   app should catch up knowing that user/client is not able to write.
-        // * change_role from Primary to ActiveSecondary, with the same epoch from update epoch. (R:NA,W:NA)
-
-        // For newly created or promoted Primary, status starts with ChangeRole Primary (R:P, W:P)
-        // * update_catch_up_replica_set_configuration (R:P, W:P)
-        // * wait_for_catch_up_quorum (R:P, W:P)
-        // * update_current_replica_set_configuration (R:G, W:G)
-        Ok(())
-    }
-
-    fn update_current_replica_set_configuration(
-        &self,
-        currentconfiguration: &ReplicaSetConfig,
-    ) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::PrimaryReplicator::update_current_replica_set_configuration {currentconfiguration:?} {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
-
-    async fn build_replica(
-        &self,
-        replica: &ReplicaInformation,
-        _: BoxedCancelToken,
-    ) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::PrimaryReplicator::build_replica: info: {replica:?} {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
-
-    fn remove_replica(&self, _replicaid: i64) -> mssf_core::Result<()> {
-        info!(
-            "AppFabricReplicator2::PrimaryReplicator::remove_replica {:?}",
-            self.ctx.get_trace_read_write_status()
-        );
-        Ok(())
-    }
 }
 
 impl StatefulServiceFactory for Factory {
@@ -314,10 +146,10 @@ impl StatefulServiceReplica for Replica {
             self.ctx.get_trace_read_write_status()
         );
         self.svc.start_loop_in_background(partition);
-        Ok(AppFabricReplicator::new(
-            self.port_,
-            self.hostname_.clone(),
-            self.ctx.clone(),
+        // Use empty replicator
+        Ok(EmptyReplicator::new(
+            WString::from("Stateful2"),
+            Some(partition.clone()),
         ))
     }
     async fn change_role(


### PR DESCRIPTION
Provide an empty replicator implementation for stateful apps that does not need replication.
This replicator traces all SF callback actions and always returns success.