### PR TITLE
util: extract retry logic from resolver api

### DIFF
--- a/crates/libs/util/src/lib.rs
+++ b/crates/libs/util/src/lib.rs
@@ -8,9 +8,12 @@
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-// Requires tokio_util
+// Requires tokio select
 #[cfg(feature = "tokio")]
 pub mod resolve;
+
+#[cfg(feature = "tokio")]
+pub mod retry;
 
 #[cfg(feature = "tokio")]
 pub mod monitoring;

--- a/crates/libs/util/src/resolve.rs
+++ b/crates/libs/util/src/resolve.rs
@@ -3,16 +3,17 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use std::{pin::Pin, time::Duration};
-
-use mssf_core::ErrorCode;
-use mssf_core::runtime::executor::{BoxedCancelToken, Timer};
-use mssf_core::types::Uri;
-
-use mssf_core::client::{
-    FabricClient,
-    svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition, ServiceManagementClient},
+use crate::retry::OperationRetryer;
+use mssf_core::{
+    ErrorCode,
+    client::{
+        FabricClient,
+        svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition, ServiceManagementClient},
+    },
+    runtime::executor::BoxedCancelToken,
+    types::Uri,
 };
+use std::time::Duration;
 
 /// The same as dotnet sdk:
 /// https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/develop/src/Microsoft.ServiceFabric.Services/Client/ServicePartitionResolver.cs
@@ -20,92 +21,22 @@ use mssf_core::client::{
 /// User needs to register notification manually on the FabricClient before creating this resolver.
 pub struct ServicePartitionResolver {
     sm: ServiceManagementClient,
-    timer: Box<dyn Timer>,
-    default_timeout: Duration,
-    max_retry_interval: Duration,
-}
-
-/// TimeCounter is used to track elapsed time and remaining time for operations.
-struct TimeCounter {
-    timeout: Duration,
-    start: std::time::Instant,
-}
-
-impl TimeCounter {
-    pub fn new(timeout: Duration) -> Self {
-        TimeCounter {
-            timeout,
-            start: std::time::Instant::now(),
-        }
-    }
-
-    pub fn elapsed(&self) -> Duration {
-        self.start.elapsed()
-    }
-
-    pub fn remaining(&self) -> mssf_core::Result<Duration> {
-        if self.elapsed() < self.timeout {
-            Ok(self.timeout - self.elapsed())
-        } else {
-            Err(ErrorCode::FABRIC_E_TIMEOUT.into())
-        }
-    }
-
-    /// returns a future that will sleep until the remaining time is up.
-    pub fn sleep_until_remaining(
-        &self,
-        timer: &dyn Timer,
-    ) -> mssf_core::Result<impl Future<Output = ()>> {
-        let remaining = self.remaining()?;
-        Ok(timer.sleep(remaining))
-    }
-}
-
-pub struct ServicePartitionResolverBuilder {
-    fc: FabricClient,
-    timer: Option<Box<dyn Timer>>,
-    default_timeout: Option<Duration>,
-    default_max_retry_interval: Option<Duration>,
-}
-
-impl ServicePartitionResolverBuilder {
-    pub fn new(fc: FabricClient) -> Self {
-        ServicePartitionResolverBuilder {
-            fc,
-            timer: None,
-            default_timeout: None,
-            default_max_retry_interval: None,
-        }
-    }
-
-    /// With a runtime timer to use for sleeping.
-    pub fn with_timer(mut self, timer: Box<dyn Timer>) -> Self {
-        self.timer = Some(timer);
-        self
-    }
-
-    pub fn build(self) -> ServicePartitionResolver {
-        ServicePartitionResolver {
-            sm: self.fc.get_service_manager().clone(),
-            timer: self.timer.unwrap_or(Box::new(crate::tokio::TokioTimer)),
-            default_timeout: self.default_timeout.unwrap_or(Duration::from_secs(30)),
-            max_retry_interval: self
-                .default_max_retry_interval
-                .unwrap_or(Duration::from_secs(5)),
-        }
-    }
+    retryer: OperationRetryer,
 }
 
 impl ServicePartitionResolver {
-    pub fn builder(fc: FabricClient) -> ServicePartitionResolverBuilder {
-        ServicePartitionResolverBuilder::new(fc)
+    pub fn new(fc: FabricClient, retryer: OperationRetryer) -> Self {
+        ServicePartitionResolver {
+            sm: fc.get_service_manager().clone(),
+            retryer,
+        }
     }
 
     /// Resolve the service partition by name and key type.
     /// It retries all transient errors and timeouts.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(uri = %name, timeout = ?timeout.unwrap_or(self.default_timeout)), err)
+        tracing::instrument(skip_all, fields(uri = %name, timeout = ?timeout), err)
     )]
     pub async fn resolve(
         &self,
@@ -115,67 +46,26 @@ impl ServicePartitionResolver {
         timeout: Option<Duration>, // Total timeout for the operation
         token: Option<BoxedCancelToken>,
     ) -> mssf_core::Result<ResolvedServicePartition> {
-        let timeout = timeout.unwrap_or(self.default_timeout);
-        let timer = TimeCounter::new(timeout);
-        let mut cancel: Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
-            if let Some(t) = &token {
-                t.wait()
-            } else {
-                Box::pin(std::future::pending())
-            };
-        loop {
-            let rsp_res = tokio::select! {
-                _ = timer.sleep_until_remaining(self.timer.as_ref())? => {
-                    // Timeout reached, return error.
-                    return Err(ErrorCode::FABRIC_E_TIMEOUT.into());
-                }
-                _ = &mut cancel => {
-                    // Cancellation requested, return error.
-                    return Err(ErrorCode::E_ABORT.into());
-                }
-                rsp_opt = self
-                    .sm
-                    .resolve_service_partition(name, key_type, prev, timer.remaining()?, token.clone()) => rsp_opt,
-            };
-            let rsp_opt = match rsp_res {
-                Ok(partition) => Some(partition),
-                Err(e) => match e.try_as_fabric_error_code() {
-                    Ok(ec) => {
-                        if ec == ErrorCode::FABRIC_E_TIMEOUT || ec.is_transient() {
-                            #[cfg(feature = "tracing")]
-                            tracing::debug!(
-                                "Service partition transient error {ec}. Remaining time {:?}. Retrying...",
-                                timer.remaining()?
-                            );
-                            // do nothing, retry.
-                            None
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                    _ => return Err(e),
-                },
-            };
+        // tracing span is auto propagated in async context
+        self.retryer
+            .run(
+                async |t, tk| {
+                    let rsp = self
+                        .sm
+                        .resolve_service_partition(name, key_type, prev, t, tk)
+                        .await?;
 
-            // Check rsp is valid and save in the cache.
-            // Sometimes endpoint is empty (may due to service removed), so we need to retry.
-            if let Some(rsp) = rsp_opt
-                && rsp.get_endpoint_list().iter().count() > 0
-            {
-                return Ok(rsp);
-            }
-            // sleep for a while before retrying.
-            tokio::select! {
-                _ = self.timer.sleep(self.max_retry_interval) => {},
-                _ = timer.sleep_until_remaining(self.timer.as_ref())? => {
-                    // Timeout reached, return error.
-                    return Err(ErrorCode::FABRIC_E_TIMEOUT.into());
-                }
-                _ = &mut cancel => {
-                    // Cancellation requested, return error.
-                    return Err(ErrorCode::E_ABORT.into());
-                }
-            }
-        }
+                    // Check rsp is valid and save in the cache.
+                    // Sometimes endpoint is empty (may due to service removed), so we need to retry.
+                    if rsp.get_endpoint_list().iter().count() > 0 {
+                        Ok(rsp)
+                    } else {
+                        Err(ErrorCode::FABRIC_E_SERVICE_OFFLINE.into())
+                    }
+                },
+                timeout,
+                token,
+            )
+            .await
     }
 }

--- a/crates/libs/util/src/retry.rs
+++ b/crates/libs/util/src/retry.rs
@@ -1,0 +1,171 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_core::{
+    ErrorCode,
+    runtime::executor::{BoxedCancelToken, Timer},
+};
+use std::{pin::Pin, time::Duration};
+
+/// TimeCounter is used to track elapsed time and remaining time for operations.
+struct TimeCounter {
+    timeout: Duration,
+    start: std::time::Instant,
+}
+
+impl TimeCounter {
+    pub fn new(timeout: Duration) -> Self {
+        TimeCounter {
+            timeout,
+            start: std::time::Instant::now(),
+        }
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.start.elapsed()
+    }
+
+    pub fn remaining(&self) -> mssf_core::Result<Duration> {
+        if self.elapsed() < self.timeout {
+            Ok(self.timeout - self.elapsed())
+        } else {
+            Err(ErrorCode::FABRIC_E_TIMEOUT.into())
+        }
+    }
+
+    /// returns a future that will sleep until the remaining time is up.
+    pub fn sleep_until_remaining(
+        &self,
+        timer: &dyn Timer,
+    ) -> mssf_core::Result<impl Future<Output = ()>> {
+        let remaining = self.remaining()?;
+        Ok(timer.sleep(remaining))
+    }
+}
+
+#[derive(Default)]
+pub struct OperationRetryerBuilder {
+    timer: Option<Box<dyn Timer>>,
+    default_timeout: Option<Duration>,
+    max_retry_interval: Option<Duration>,
+}
+
+impl OperationRetryerBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// With a runtime timer to use for sleeping.
+    pub fn with_timer(mut self, timer: Box<dyn Timer>) -> Self {
+        self.timer = Some(timer);
+        self
+    }
+
+    pub fn with_default_timeout(mut self, timeout: Duration) -> Self {
+        self.default_timeout = Some(timeout);
+        self
+    }
+
+    pub fn with_max_retry_interval(mut self, interval: Duration) -> Self {
+        self.max_retry_interval = Some(interval);
+        self
+    }
+
+    pub fn build(self) -> OperationRetryer {
+        OperationRetryer::new(
+            self.timer.unwrap_or(Box::new(crate::tokio::TokioTimer)),
+            self.default_timeout.unwrap_or(Duration::from_secs(30)),
+            self.max_retry_interval.unwrap_or(Duration::from_secs(5)),
+        )
+    }
+}
+
+/// A helper to retry an operation with transient error and timeout.
+pub struct OperationRetryer {
+    timer: Box<dyn Timer>,
+    default_timeout: Duration,
+    max_retry_interval: Duration,
+}
+
+impl OperationRetryer {
+    pub fn builder() -> OperationRetryerBuilder {
+        OperationRetryerBuilder::new()
+    }
+
+    fn new(timer: Box<dyn Timer>, default_timeout: Duration, max_retry_interval: Duration) -> Self {
+        OperationRetryer {
+            timer,
+            default_timeout,
+            max_retry_interval,
+        }
+    }
+
+    /// Run the operation with retry on transient errors and timeouts.
+    /// User can provide a total timeout and a cancel token.
+    pub async fn run<T, F, Fut>(
+        &self,
+        op: F,
+        timeout: Option<Duration>,
+        token: Option<BoxedCancelToken>,
+    ) -> mssf_core::Result<T>
+    where
+        F: Fn(Duration, Option<BoxedCancelToken>) -> Fut,
+        Fut: Future<Output = mssf_core::Result<T>> + Send,
+        T: Send,
+    {
+        let timeout = timeout.unwrap_or(self.default_timeout);
+        let timer = TimeCounter::new(timeout);
+        let mut cancel: Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
+            if let Some(t) = &token {
+                t.wait()
+            } else {
+                Box::pin(std::future::pending())
+            };
+        loop {
+            let res = tokio::select! {
+                _ = timer.sleep_until_remaining(self.timer.as_ref())? => {
+                    // Timeout reached, return error.
+                    return Err(ErrorCode::FABRIC_E_TIMEOUT.into());
+                }
+                _ = &mut cancel => {
+                    // Cancellation requested, return error.
+                    return Err(ErrorCode::E_ABORT.into());
+                }
+                // Run the operation with the remaining time and cancel token.
+                res = op(timer.remaining()?, token.clone()) => res,
+            };
+            match res {
+                Ok(r) => return Ok(r),
+                Err(e) => match e.try_as_fabric_error_code() {
+                    Ok(ec) => {
+                        if ec == ErrorCode::FABRIC_E_TIMEOUT || ec.is_transient() {
+                            #[cfg(feature = "tracing")]
+                            tracing::debug!(
+                                "Operation transient error {ec}. Remaining time {:?}. Retrying...",
+                                timer.remaining()?
+                            );
+                            // do nothing, retry.
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                    _ => return Err(e),
+                },
+            }
+            // sleep for a while before retrying.
+            tokio::select! {
+                _ = self.timer.sleep(self.max_retry_interval) => {},
+                _ = timer.sleep_until_remaining(self.timer.as_ref())? => {
+                    // Timeout reached, return error.
+                    return Err(ErrorCode::FABRIC_E_TIMEOUT.into());
+                }
+                _ = &mut cancel => {
+                    // Cancellation requested, return error.
+                    return Err(ErrorCode::E_ABORT.into());
+                }
+            }
+        }
+    }
+}

--- a/crates/samples/echomain-stateful2/src/test2.rs
+++ b/crates/samples/echomain-stateful2/src/test2.rs
@@ -173,7 +173,8 @@ async fn test_resolve_notification() {
     };
 
     // Resolve the service until all replicas are ready.
-    let srv = ServicePartitionResolver::builder(fc.clone()).build();
+    let retryer = mssf_util::retry::OperationRetryer::builder().build();
+    let srv = ServicePartitionResolver::new(fc.clone(), retryer);
     let mut prev = None;
     let rsp = loop {
         let rsp = srv


### PR DESCRIPTION
Resolver api had a robust retry mechanism for transient errors.
Refactor the retry logic into an api so that user can retry all SF calls reliably.