### PR TITLE
[FabricClient] QueryClient returns Vec directly

### DIFF
--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -42,12 +42,9 @@ async fn test_fabric_client() {
         .await
         .unwrap()
         .unwrap();
-        paging_status = list.get_paging_status();
-        let v = list.iter().collect::<Vec<_>>();
-        assert_ne!(v.len(), 0);
-        for n in v {
-            println!("Node: {n:?}")
-        }
+        println!("Nodes: {list:?}");
+        paging_status = list.paging_status;
+        assert_ne!(list.nodes.len(), 0);
     }
     // get more nodes using paging
     {
@@ -60,10 +57,7 @@ async fn test_fabric_client() {
             ..Default::default()
         };
         let list = qc.get_node_list(&desc, timeout, None).await.unwrap();
-        let v = list.iter().collect::<Vec<_>>();
-        for n in v {
-            println!("More Node: {n:?}")
-        }
+        println!("Nodes: {list:?}");
     }
 
     // get node but cancel

--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -8,14 +8,9 @@
 use std::time::SystemTime;
 
 use crate::WString;
-use mssf_com::{
-    FabricClient::IFabricGetPartitionLoadInformationResult, FabricTypes::FABRIC_LOAD_METRIC_REPORT,
-};
+use mssf_com::FabricTypes::FABRIC_LOAD_METRIC_REPORT;
 
-use crate::{
-    iter::{FabricIter, FabricListAccessor},
-    strings::WStringWrap,
-};
+use crate::strings::WStringWrap;
 
 /// Wrapper for FABRIC_LOAD_METRIC_REPORT
 #[derive(Debug, Clone)]
@@ -34,94 +29,3 @@ impl From<&FABRIC_LOAD_METRIC_REPORT> for LoadMetricReport {
         }
     }
 }
-
-/// Wrapper of the load metric report list from the primary replica of the partition
-pub struct PrimaryLoadMetricReportList {
-    com: IFabricGetPartitionLoadInformationResult,
-}
-
-impl FabricListAccessor<FABRIC_LOAD_METRIC_REPORT> for PrimaryLoadMetricReportList {
-    fn get_count(&self) -> u32 {
-        unsafe {
-            self.com
-                .get_PartitionLoadInformation()
-                .as_ref()
-                .unwrap()
-                .PrimaryLoadMetricReports
-                .as_ref()
-                .unwrap()
-                .Count
-        }
-    }
-
-    fn get_first_item(&self) -> *const FABRIC_LOAD_METRIC_REPORT {
-        unsafe {
-            self.com
-                .get_PartitionLoadInformation()
-                .as_ref()
-                .unwrap()
-                .PrimaryLoadMetricReports
-                .as_ref()
-                .unwrap()
-                .Items
-        }
-    }
-}
-
-impl PrimaryLoadMetricReportList {
-    pub fn new(com: IFabricGetPartitionLoadInformationResult) -> Self {
-        Self { com }
-    }
-
-    pub fn iter(&self) -> PrimaryLoadMetricReportListIter<'_> {
-        PrimaryLoadMetricReportListIter::new(self, self)
-    }
-}
-
-/// Wrapper of the load metric report list from the secondary replicas of the partition
-pub struct SecondaryLoadMetricReportList {
-    com: IFabricGetPartitionLoadInformationResult,
-}
-
-impl FabricListAccessor<FABRIC_LOAD_METRIC_REPORT> for SecondaryLoadMetricReportList {
-    fn get_count(&self) -> u32 {
-        unsafe {
-            self.com
-                .get_PartitionLoadInformation()
-                .as_ref()
-                .unwrap()
-                .SecondaryLoadMetricReports
-                .as_ref()
-                .unwrap()
-                .Count
-        }
-    }
-
-    fn get_first_item(&self) -> *const FABRIC_LOAD_METRIC_REPORT {
-        unsafe {
-            self.com
-                .get_PartitionLoadInformation()
-                .as_ref()
-                .unwrap()
-                .SecondaryLoadMetricReports
-                .as_ref()
-                .unwrap()
-                .Items
-        }
-    }
-}
-
-impl SecondaryLoadMetricReportList {
-    pub fn new(com: IFabricGetPartitionLoadInformationResult) -> Self {
-        Self { com }
-    }
-
-    pub fn iter(&self) -> SecondaryLoadMetricReportListIter<'_> {
-        SecondaryLoadMetricReportListIter::new(self, self)
-    }
-}
-
-type PrimaryLoadMetricReportListIter<'a> =
-    FabricIter<'a, FABRIC_LOAD_METRIC_REPORT, LoadMetricReport, PrimaryLoadMetricReportList>;
-type SecondaryLoadMetricReportListIter<'a> =
-    FabricIter<'a, FABRIC_LOAD_METRIC_REPORT, LoadMetricReport, SecondaryLoadMetricReportList>;

--- a/crates/libs/core/src/types/client/property.rs
+++ b/crates/libs/core/src/types/client/property.rs
@@ -16,7 +16,7 @@ use mssf_com::{
 };
 use windows_core::WString;
 
-use crate::{strings::FabricStringListAccessorIter, types::Uri};
+use crate::types::Uri;
 
 pub struct NameEnumerationResult {
     com: IFabricNameEnumerationResult,
@@ -39,13 +39,7 @@ impl NameEnumerationResult {
     pub fn get_names(&self) -> crate::Result<Vec<Uri>> {
         let mut count = 0;
         let first_ptr = unsafe { self.com.GetNames(&mut count)? };
-        let l = crate::strings::FabricStringListAccessor {
-            itemcount: count,
-            first_str: first_ptr as *mut _,
-            phantom: std::marker::PhantomData,
-        };
-        let itr = FabricStringListAccessorIter::new(&l, &l);
-        let data = itr.map(Uri::new).collect::<Vec<_>>();
+        let data = crate::iter::vec_from_raw_com(count as usize, first_ptr);
         Ok(data)
     }
 }

--- a/crates/libs/core/src/types/common/mod.rs
+++ b/crates/libs/core/src/types/common/mod.rs
@@ -115,6 +115,12 @@ impl From<&str> for Uri {
 
 impl From<FABRIC_URI> for Uri {
     fn from(value: FABRIC_URI) -> Self {
+        Self::from(&value)
+    }
+}
+
+impl From<&FABRIC_URI> for Uri {
+    fn from(value: &FABRIC_URI) -> Self {
         Self::from(WString::from(windows_core::PCWSTR(value.0)))
     }
 }

--- a/crates/libs/pal/src/strings.rs
+++ b/crates/libs/pal/src/strings.rs
@@ -206,6 +206,16 @@ impl From<PCWSTR> for WString {
     }
 }
 
+/// FFI conversion.
+impl From<Option<&WString>> for PCWSTR {
+    fn from(value: Option<&WString>) -> Self {
+        match value {
+            Some(s) => s.as_pcwstr(),
+            None => PCWSTR::null(),
+        }
+    }
+}
+
 impl core::fmt::Display for WString {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // convert u16 to char gracefully and write to formatter.

--- a/crates/libs/util/src/monitoring/producer.rs
+++ b/crates/libs/util/src/monitoring/producer.rs
@@ -358,8 +358,7 @@ impl HealthDataProducer {
             .inspect_err(|err| {
                 tracing::error!("Failed to get node list: {}", err);
             })?
-            .iter()
-            .collect::<Vec<_>>();
+            .nodes;
         Ok(nodes)
     }
 
@@ -421,8 +420,7 @@ impl HealthDataProducer {
             .inspect_err(|err| {
                 tracing::error!("Failed to get partition list: {}", err);
             })?
-            .iter()
-            .collect::<Vec<_>>();
+            .service_partitions;
         Ok(partitions)
     }
 
@@ -444,8 +442,7 @@ impl HealthDataProducer {
             .inspect_err(|err| {
                 tracing::error!("Failed to get replica list: {}", err);
             })?
-            .iter()
-            .collect::<Vec<_>>();
+            .service_replicas;
         Ok(replicas)
     }
 }

--- a/crates/samples/echomain-stateful2/src/test2.rs
+++ b/crates/samples/echomain-stateful2/src/test2.rs
@@ -26,7 +26,8 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
 
     let ptt = q.get_partition_list(&desc, sm.timeout, None).await.unwrap();
     let partitions = ptt
-        .iter()
+        .service_partitions
+        .into_iter()
         .filter_map(|p| match p {
             ServicePartitionQueryResultItem::Stateful(s) => Some(s),
             _ => None,
@@ -45,7 +46,8 @@ async fn restart_primary(uri: &Uri, fc: &FabricClient) {
         .get_replica_list(&desc, sm.timeout, None)
         .await
         .unwrap()
-        .iter()
+        .service_replicas
+        .into_iter()
         .filter_map(|r| match r {
             mssf_core::types::ServiceReplicaQueryResultItem::Stateful(s) => Some(s),
             _ => None,

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -60,7 +60,7 @@ impl EchoTestClient {
             .await
             .unwrap();
         // there is only one partition
-        let p = list.iter().next().unwrap();
+        let p = list.service_partitions.into_iter().next().unwrap();
         let stateless = match p {
             ServicePartitionQueryResultItem::Stateless(s) => s,
             _ => panic!("not stateless"),
@@ -83,7 +83,7 @@ impl EchoTestClient {
             replica_id_or_instance_id_filter: None,
         };
         let replicas = qc.get_replica_list(&desc, self.timeout, None).await?;
-        let replica_op = replicas.iter().next(); // only one replica
+        let replica_op = replicas.service_replicas.into_iter().next(); // only one replica
         match replica_op {
             Some(replica) => Ok(match replica {
                 ServiceReplicaQueryResultItem::Stateless(s) => s,


### PR DESCRIPTION
Change old  QueryClient apis to return Vec<T> directly instead of wrapping an iterator.
All use cases of the query client api are converting the iter into a Vec right after the api call. New apis are already returning Vec directly.
This leads to code reduction and simplification.