### PR TITLE
Remove WStringWrap type

### DIFF
--- a/crates/libs/core/src/client/connection.rs
+++ b/crates/libs/core/src/client/connection.rs
@@ -8,7 +8,7 @@ use mssf_com::FabricClient::{
     IFabricGatewayInformationResult,
 };
 
-use crate::{strings::WStringWrap, types::NodeId};
+use crate::{WString, types::NodeId};
 
 /// Internal trait that rust code implements that can be bridged into IFabricClientConnectionEventHandler.
 /// Not exposed to user.
@@ -31,10 +31,10 @@ impl From<&IFabricGatewayInformationResult> for GatewayInformationResult {
     fn from(com: &IFabricGatewayInformationResult) -> Self {
         let info = unsafe { com.get_GatewayInformation().as_ref().unwrap() };
         Self {
-            node_address: WStringWrap::from(info.NodeAddress).into(),
+            node_address: WString::from(info.NodeAddress),
             node_id: info.NodeId.into(),
             node_instance_id: info.NodeInstanceId,
-            node_name: WStringWrap::from(info.NodeName).into(),
+            node_name: WString::from(info.NodeName),
         }
     }
 }

--- a/crates/libs/core/src/client/notification.rs
+++ b/crates/libs/core/src/client/notification.rs
@@ -13,8 +13,7 @@ use mssf_com::{
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::WStringWrap,
-    types::ServicePartitionInformation,
+    types::{ServicePartitionInformation, Uri},
 };
 
 use super::svc_mgmt_client::ResolvedServiceEndpoint;
@@ -30,7 +29,7 @@ pub trait ServiceNotificationEventHandler: 'static {
 /// If endpoint list is empty, the service is removed.
 #[derive(Debug, Clone)]
 pub struct ServiceNotification {
-    pub service_name: crate::WString,
+    pub service_name: Uri,
     pub partition_info: Option<ServicePartitionInformation>,
     pub partition_id: crate::GUID,
     pub endpoints: ServiceEndpointList,
@@ -42,7 +41,7 @@ impl From<IFabricServiceNotification> for ServiceNotification {
         // SF guarantees this is not null.
         let raw = unsafe { com.get_Notification().as_ref().unwrap() };
         Self {
-            service_name: WStringWrap::from(crate::PCWSTR(raw.ServiceName.0)).into(),
+            service_name: Uri::from(raw.ServiceName),
             partition_info: unsafe {
                 // It is possible for partition info to be null,
                 // that is why we make the field as an option.

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -27,7 +27,6 @@ use crate::sync::{FabricReceiver, fabric_begin_end_proxy};
 
 use crate::{
     iter::{FabricIter, FabricListAccessor},
-    strings::WStringWrap,
     types::{
         RemoveReplicaDescription, RestartReplicaDescription, ServiceNotificationFilterDescription,
     },
@@ -412,7 +411,7 @@ impl PartitionKeyType {
             ServicePartitionKind::Named => {
                 let x = data as *mut u16;
                 assert!(!x.is_null());
-                let s = WStringWrap::from(PCWSTR::from_raw(x)).into();
+                let s = WString::from(PCWSTR::from_raw(x));
                 PartitionKeyType::String(s)
             }
         }
@@ -624,7 +623,7 @@ impl From<&FABRIC_RESOLVED_SERVICE_ENDPOINT> for ResolvedServiceEndpoint {
     fn from(value: &FABRIC_RESOLVED_SERVICE_ENDPOINT) -> Self {
         let raw = value;
         Self {
-            address: WStringWrap::from(raw.Address).into(),
+            address: WString::from(raw.Address),
             role: raw.Role.into(),
         }
     }

--- a/crates/libs/core/src/runtime/activation_context.rs
+++ b/crates/libs/core/src/runtime/activation_context.rs
@@ -13,8 +13,7 @@ use mssf_com::{
 
 use crate::{
     Error, PCWSTR, WString,
-    strings::WStringWrap,
-    types::{EndpointResourceDescription, HealthInformation, HealthReportSendOption},
+    types::{EndpointResourceDescription, HealthInformation, HealthReportSendOption, Uri},
 };
 
 use super::{
@@ -45,7 +44,7 @@ pub struct CodePackageInfo {
     pub work_directory: WString,
     pub log_directory: WString,
     pub temp_directory: WString,
-    pub application_name: WString,
+    pub application_name: Uri,
     pub application_type_name: WString,
     pub service_listen_address: WString,
     pub service_publish_address: WString,
@@ -94,32 +93,22 @@ impl CodePackageActivationContext {
 
     pub fn get_code_package_info(&self) -> CodePackageInfo {
         CodePackageInfo {
-            context_id: WStringWrap::from(unsafe { self.com_impl.get_ContextId() }).into(),
-            code_package_name: WStringWrap::from(unsafe { self.com_impl.get_CodePackageName() })
-                .into(),
-            code_package_version: WStringWrap::from(unsafe {
-                self.com_impl.get_CodePackageVersion()
-            })
-            .into(),
-            work_directory: WStringWrap::from(unsafe { self.com_impl.get_WorkDirectory() }).into(),
-            log_directory: WStringWrap::from(unsafe { self.com_impl.get_LogDirectory() }).into(),
-            temp_directory: WStringWrap::from(unsafe { self.com_impl.get_TempDirectory() }).into(),
-            application_name: WStringWrap::from(PCWSTR(unsafe {
-                self.com_impl.get_ApplicationName().0
-            }))
-            .into(),
-            application_type_name: WStringWrap::from(unsafe {
+            context_id: WString::from(unsafe { self.com_impl.get_ContextId() }),
+            code_package_name: WString::from(unsafe { self.com_impl.get_CodePackageName() }),
+            code_package_version: WString::from(unsafe { self.com_impl.get_CodePackageVersion() }),
+            work_directory: WString::from(unsafe { self.com_impl.get_WorkDirectory() }),
+            log_directory: WString::from(unsafe { self.com_impl.get_LogDirectory() }),
+            temp_directory: WString::from(unsafe { self.com_impl.get_TempDirectory() }),
+            application_name: Uri::from(unsafe { self.com_impl.get_ApplicationName() }),
+            application_type_name: WString::from(unsafe {
                 self.com_impl.get_ApplicationTypeName()
-            })
-            .into(),
-            service_listen_address: WStringWrap::from(unsafe {
+            }),
+            service_listen_address: WString::from(unsafe {
                 self.com_impl.get_ServiceListenAddress()
-            })
-            .into(),
-            service_publish_address: WStringWrap::from(unsafe {
+            }),
+            service_publish_address: WString::from(unsafe {
                 self.com_impl.get_ServicePublishAddress()
-            })
-            .into(),
+            }),
         }
     }
 

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -6,11 +6,12 @@
 use std::time::Duration;
 
 use crate::runtime::executor::BoxedCancelToken;
+use crate::strings::StringResult;
 use crate::{Interface, WString};
 use mssf_com::FabricRuntime::{IFabricNodeContextResult, IFabricNodeContextResult2};
 
 use crate::sync::fabric_begin_end_proxy;
-use crate::{strings::WStringWrap, types::NodeId};
+use crate::types::NodeId;
 
 pub fn get_com_node_context(
     timeout_milliseconds: u32,
@@ -58,7 +59,7 @@ impl NodeContext {
     pub fn get_directory(&self, logical_directory_name: &WString) -> crate::Result<WString> {
         let com2 = self.com.cast::<IFabricNodeContextResult2>()?;
         let dir = unsafe { com2.GetDirectory(logical_directory_name.as_pcwstr()) }?;
-        Ok(WStringWrap::from(&dir).into())
+        Ok(StringResult::from(&dir).into_inner())
     }
 }
 
@@ -69,9 +70,9 @@ impl From<&IFabricNodeContextResult> for NodeContext {
         let raw_ref = unsafe { raw.as_ref() }.unwrap();
         Self {
             com: value.clone(),
-            node_name: WStringWrap::from(raw_ref.NodeName).into(),
-            node_type: WStringWrap::from(raw_ref.NodeType).into(),
-            ip_address_or_fqdn: WStringWrap::from(raw_ref.IPAddressOrFQDN).into(),
+            node_name: WString::from(raw_ref.NodeName),
+            node_type: WString::from(raw_ref.NodeType),
+            ip_address_or_fqdn: WString::from(raw_ref.IPAddressOrFQDN),
             node_instance_id: raw_ref.NodeInstanceId,
             node_id: raw_ref.NodeId.into(),
         }

--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -19,10 +19,10 @@ pub trait StatefulServiceFactory {
     /// Called by Service Fabric to create a stateful service replica for a particular service.
     fn create_replica(
         &self,
-        servicetypename: &crate::WString,
-        servicename: &crate::WString,
+        servicetypename: crate::WString,
+        servicename: crate::types::Uri,
         initializationdata: &[u8],
-        partitionid: &crate::GUID,
+        partitionid: crate::GUID,
         replicaid: i64,
     ) -> crate::Result<impl StatefulServiceReplica>;
 }

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -8,7 +8,7 @@
 
 use std::ffi::c_void;
 
-use crate::{Interface, WString, runtime::executor::BoxedCancelToken};
+use crate::{Interface, WString, runtime::executor::BoxedCancelToken, strings::StringResult};
 use mssf_com::FabricRuntime::{
     IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
     IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
@@ -16,7 +16,6 @@ use mssf_com::FabricRuntime::{
 
 use crate::{
     error::ErrorCode,
-    strings::WStringWrap,
     sync::fabric_begin_end_proxy,
     types::{
         FaultType, HealthInformation, LoadMetric, LoadMetricListRef, MoveCost, ReplicaRole,
@@ -94,7 +93,7 @@ impl StatefulServiceReplica for StatefulServiceReplicaProxy {
             Some(cancellation_token),
         );
         let addr = rx.await??;
-        Ok(WStringWrap::from(&addr).into())
+        Ok(StringResult::from(&addr).into_inner())
     }
 
     #[cfg_attr(
@@ -145,7 +144,7 @@ impl Replicator for ReplicatorProxy {
             Some(cancellation_token),
         );
         let addr = rx.await??;
-        Ok(WStringWrap::from(&addr).into())
+        Ok(StringResult::from(&addr).into_inner())
     }
     #[cfg_attr(
         feature = "tracing",

--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -16,10 +16,10 @@ pub trait StatelessServiceFactory {
     /// Creates a stateless service instance for a particular service. This method is called by Service Fabric.
     fn create_instance(
         &self,
-        servicetypename: &WString,
-        servicename: &WString,
+        servicetypename: WString,
+        servicename: crate::types::Uri,
         initializationdata: &[u8],
-        partitionid: &crate::GUID,
+        partitionid: crate::GUID,
         instanceid: i64,
     ) -> crate::Result<impl StatelessServiceInstance>;
 }

--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -10,8 +10,6 @@ use std::time::SystemTime;
 use crate::WString;
 use mssf_com::FabricTypes::FABRIC_LOAD_METRIC_REPORT;
 
-use crate::strings::WStringWrap;
-
 /// Wrapper for FABRIC_LOAD_METRIC_REPORT
 #[derive(Debug, Clone)]
 pub struct LoadMetricReport {
@@ -23,7 +21,7 @@ pub struct LoadMetricReport {
 impl From<&FABRIC_LOAD_METRIC_REPORT> for LoadMetricReport {
     fn from(value: &FABRIC_LOAD_METRIC_REPORT) -> Self {
         Self {
-            name: WStringWrap::from(value.Name).into(),
+            name: WString::from(value.Name),
             value: value.Value,
             last_reported_utc: SystemTime::UNIX_EPOCH, // TODO: convert Win32 FILETIME to SystemTime in Unix or Win32 depending on the platform
         }

--- a/crates/libs/core/src/types/common/partition.rs
+++ b/crates/libs/core/src/types/common/partition.rs
@@ -24,8 +24,6 @@ use mssf_com::FabricTypes::{
 };
 use windows_core::PCWSTR;
 
-use crate::strings::WStringWrap;
-
 // FABRIC_SERVICE_PARTITION_INFORMATION
 #[derive(Debug, Clone)]
 pub enum ServicePartitionInformation {
@@ -73,7 +71,7 @@ impl From<&FABRIC_NAMED_PARTITION_INFORMATION> for NamedPartitionInfomation {
     fn from(value: &FABRIC_NAMED_PARTITION_INFORMATION) -> Self {
         Self {
             id: value.Id,
-            name: WStringWrap::from(value.Name).into(),
+            name: WString::from(value.Name),
         }
     }
 }

--- a/crates/libs/core/src/types/common/security_credentials/claims_credentials.rs
+++ b/crates/libs/core/src/types/common/security_credentials/claims_credentials.rs
@@ -92,7 +92,6 @@ mod test {
     };
     use std::sync::{Arc, Mutex};
 
-    use crate::strings::WStringWrap;
     use crate::types::mockifabricclientsettings::MockIFabricClientSettings;
     use crate::types::mockifabricclientsettings::test_constants::*;
     use crate::types::mockifabricclientsettings::test_utilities::check_array_parameter;
@@ -232,9 +231,7 @@ mod test {
                     )
                 };
 
-                let local_claim = WStringWrap::from(value_ref.LocalClaims)
-                    .into_wstring()
-                    .to_string_lossy();
+                let local_claim = WString::from(value_ref.LocalClaims).to_string_lossy();
                 assert_eq!(&local_claim, TEST_CLAIMS);
 
                 assert_eq!(

--- a/crates/libs/core/src/types/common/security_credentials/windows_credentials.rs
+++ b/crates/libs/core/src/types/common/security_credentials/windows_credentials.rs
@@ -71,7 +71,6 @@ mod test {
     };
     use std::sync::{Arc, Mutex};
 
-    use crate::strings::WStringWrap;
     use crate::types::mockifabricclientsettings::MockIFabricClientSettings;
     use crate::types::mockifabricclientsettings::test_utilities::check_array_parameter;
 
@@ -185,9 +184,7 @@ mod test {
                     )
                 };
 
-                let remote_spn = WStringWrap::from(value_ref.RemoteSpn)
-                    .into_wstring()
-                    .to_string_lossy();
+                let remote_spn = WString::from(value_ref.RemoteSpn).to_string_lossy();
                 assert_eq!(&remote_spn, TEST_REMOTE_SPN_1);
 
                 assert_eq!(

--- a/crates/libs/core/src/types/common/security_credentials/x509_credentials.rs
+++ b/crates/libs/core/src/types/common/security_credentials/x509_credentials.rs
@@ -159,7 +159,6 @@ mod test {
     };
     use std::sync::{Arc, Mutex};
 
-    use crate::strings::WStringWrap;
     use crate::types::mockifabricclientsettings::MockIFabricClientSettings;
     use crate::types::mockifabricclientsettings::test_constants::*;
     use crate::types::mockifabricclientsettings::test_utilities::check_array_parameter;
@@ -244,17 +243,14 @@ mod test {
                 assert_eq!(value_ref.FindType, FABRIC_X509_FIND_TYPE_FINDBYSUBJECTNAME);
                 let find_val_ptr = value_ref.FindValue as *const u16;
                 assert!(!find_val_ptr.is_null() && find_val_ptr.is_aligned());
-                let val_str = WStringWrap::from(PCWSTR::from_raw(find_val_ptr))
-                    .into_wstring()
-                    .to_string_lossy();
+                let val_str = WString::from(PCWSTR::from_raw(find_val_ptr)).to_string_lossy();
                 assert_eq!(val_str.as_str(), TEST_SERVER_NAME_1);
                 assert_eq!(
                     value_ref.StoreLocation,
                     FABRIC_X509_STORE_LOCATION_CURRENTUSER
                 );
                 assert_eq!(
-                    WStringWrap::from(value_ref.StoreName)
-                        .into_wstring()
+                    WString::from(value_ref.StoreName)
                         .to_string_lossy()
                         .as_str(),
                     TEST_STORE_2
@@ -302,17 +298,14 @@ mod test {
                 assert_eq!(value_ref.FindType, FABRIC_X509_FIND_TYPE_FINDBYTHUMBPRINT);
                 let find_val_ptr = value_ref.FindValue as *const u16;
                 assert!(!find_val_ptr.is_null() && find_val_ptr.is_aligned());
-                let val_str = WStringWrap::from(PCWSTR::from_raw(find_val_ptr))
-                    .into_wstring()
-                    .to_string_lossy();
+                let val_str = WString::from(PCWSTR::from_raw(find_val_ptr)).to_string_lossy();
                 assert_eq!(val_str.as_str(), TEST_THUMBPRINT_1);
                 assert_eq!(
                     value_ref.StoreLocation,
                     FABRIC_X509_STORE_LOCATION_LOCALMACHINE
                 );
                 assert_eq!(
-                    WStringWrap::from(value_ref.StoreName)
-                        .into_wstring()
+                    WString::from(value_ref.StoreName)
                         .to_string_lossy()
                         .as_str(),
                     TEST_STORE_1

--- a/crates/libs/core/src/types/mockifabricclientsettings.rs
+++ b/crates/libs/core/src/types/mockifabricclientsettings.rs
@@ -26,9 +26,7 @@ pub(crate) mod test_constants {
 }
 
 pub(crate) mod test_utilities {
-    use windows_core::PCWSTR;
-
-    use crate::strings::WStringWrap;
+    use windows_core::{PCWSTR, WString};
 
     /// # SAFETY
     /// * This is test code, intended to be used with Miri to validate that all reads SF might do of a pointer / length pair are defined behavior
@@ -59,9 +57,7 @@ pub(crate) mod test_utilities {
                 );
                 // SAFETY: caller promises it's within lifetime. non-null and alignment is checked above
                 let actual_value = unsafe { actual_value_ptr.as_ref() }.unwrap();
-                let actual_val_str = WStringWrap::from(*actual_value)
-                    .into_wstring()
-                    .to_string_lossy();
+                let actual_val_str = WString::from(*actual_value).to_string_lossy();
                 assert_eq!(
                     *expected_value,
                     actual_val_str.as_str(),

--- a/crates/libs/core/src/types/runtime/health.rs
+++ b/crates/libs/core/src/types/runtime/health.rs
@@ -1,7 +1,7 @@
 use crate::PCWSTR;
 use mssf_com::FabricTypes::{FABRIC_HEALTH_INFORMATION, FABRIC_HEALTH_REPORT_SEND_OPTIONS};
 
-use crate::{WString, strings::WStringWrap, types::HealthState};
+use crate::{WString, types::HealthState};
 
 pub type SequenceNumber = i64;
 
@@ -40,11 +40,11 @@ pub struct HealthInformation {
 impl From<&FABRIC_HEALTH_INFORMATION> for HealthInformation {
     fn from(value: &FABRIC_HEALTH_INFORMATION) -> Self {
         Self {
-            source_id: WStringWrap::from(value.SourceId).into(),
-            property: WStringWrap::from(value.Property).into(),
+            source_id: WString::from(value.SourceId),
+            property: WString::from(value.Property),
             time_to_live_seconds: value.TimeToLiveSeconds,
             state: HealthState::from(&value.State),
-            description: WStringWrap::from(value.Description).into(),
+            description: WString::from(value.Description),
             sequence_number: value.SequenceNumber,
             remove_when_expired: value.RemoveWhenExpired,
         }

--- a/crates/libs/core/src/types/runtime/mod.rs
+++ b/crates/libs/core/src/types/runtime/mod.rs
@@ -11,7 +11,7 @@ pub mod store;
 
 use mssf_com::FabricTypes::FABRIC_ENDPOINT_RESOURCE_DESCRIPTION;
 
-use crate::{WString, strings::WStringWrap};
+use crate::WString;
 
 #[derive(Debug)]
 pub struct EndpointResourceDescription {
@@ -25,11 +25,11 @@ pub struct EndpointResourceDescription {
 impl From<&FABRIC_ENDPOINT_RESOURCE_DESCRIPTION> for EndpointResourceDescription {
     fn from(e: &FABRIC_ENDPOINT_RESOURCE_DESCRIPTION) -> Self {
         EndpointResourceDescription {
-            name: WStringWrap::from(e.Name).into(),
-            protocol: WStringWrap::from(e.Protocol).into(),
-            r#type: WStringWrap::from(e.Type).into(),
+            name: WString::from(e.Name),
+            protocol: WString::from(e.Protocol),
+            r#type: WString::from(e.Type),
             port: e.Port,
-            certificate_name: WStringWrap::from(e.CertificateName).into(),
+            certificate_name: WString::from(e.CertificateName),
         }
     }
 }

--- a/crates/libs/core/src/types/runtime/stateful.rs
+++ b/crates/libs/core/src/types/runtime/stateful.rs
@@ -17,7 +17,7 @@ use mssf_com::FabricTypes::{
     FABRIC_REPLICA_STATUS_INVALID, FABRIC_REPLICA_STATUS_UP,
 };
 
-use crate::{strings::WStringWrap, types::ReplicaRole};
+use crate::types::ReplicaRole;
 
 #[derive(Debug)]
 pub enum OpenMode {
@@ -228,7 +228,7 @@ impl From<&FABRIC_REPLICA_INFORMATION> for ReplicaInformation {
             id: r.Id,
             role: (&r.Role).into(),
             status: r.Status.into(),
-            replicator_address: WStringWrap::from(r.ReplicatorAddress).into(),
+            replicator_address: WString::from(r.ReplicatorAddress),
             current_progress: r.CurrentProgress,
             catch_up_capability: r.CatchUpCapability,
             must_catch_up: must_catchup,

--- a/crates/samples/client/src/main.rs
+++ b/crates/samples/client/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> mssf_core::Result<()> {
         let node: FABRIC_NODE_QUERY_RESULT_ITEM = unsafe { *node_list };
         println!(
             "node info: name: {}",
-            mssf_core::WString::from(mssf_core::strings::WStringWrap::from(node.NodeName))
+            mssf_core::WString::from(node.NodeName)
         );
     }
 

--- a/crates/samples/echomain-stateful/src/app.rs
+++ b/crates/samples/echomain-stateful/src/app.rs
@@ -25,7 +25,7 @@ use mssf_com::FabricTypes::{
     FABRIC_REPLICA_SET_QUORUM_MODE, FABRIC_URI,
 };
 use mssf_core::WString;
-use mssf_core::{strings::WStringWrap, sync::wait::AsyncContext};
+use mssf_core::sync::wait::AsyncContext;
 use tokio::sync::oneshot::{self, Sender};
 use tracing::info;
 use windows_core::implement;
@@ -80,7 +80,7 @@ impl IFabricStatefulServiceFactory_Impl for StatefulServiceFactory_Impl {
         }
         info!(
             "servicetypename: {}, servicename: {:?}, initdata: {}, partitionid: {:?}, instanceid {}",
-            mssf_core::strings::WStringWrap::from(*servicetypename).into_wstring(),
+            mssf_core::WString::from(*servicetypename),
             servicename,
             init_data,
             partitionid,
@@ -128,7 +128,8 @@ impl IFabricReplicator_Impl for AppFabricReplicator_Impl {
         info!("AppFabricReplicator::EndOpen");
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
         info!("AppFabricReplicator::EndOpen {}", addr);
-        let str_res: IFabricStringResult = WStringWrap::from(WString::from(addr)).into();
+        let str_res: IFabricStringResult =
+            mssf_core::strings::StringResult::new(addr.into()).into();
         Ok(str_res)
     }
 
@@ -430,7 +431,8 @@ impl IFabricStatefulServiceReplica_Impl for AppInstance_Impl {
         info!("AppInstance::EndChangeRole");
         let addr = echo::get_addr(self.port_, self.hostname_.clone());
         info!("AppInstance::EndChangeRole {}", addr);
-        let str_res: IFabricStringResult = WStringWrap::from(WString::from(addr)).into();
+        let str_res: IFabricStringResult =
+            mssf_core::strings::StringResult::new(addr.into()).into();
         Ok(str_res)
     }
 }

--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -50,10 +50,10 @@ fn get_addr(port: u32, hostname: WString) -> String {
 impl StatefulServiceFactory for Factory {
     fn create_replica(
         &self,
-        servicetypename: &mssf_core::WString,
-        servicename: &mssf_core::WString,
+        servicetypename: mssf_core::WString,
+        servicename: mssf_core::types::Uri,
         initializationdata: &[u8],
-        partitionid: &mssf_core::GUID,
+        partitionid: mssf_core::GUID,
         replicaid: i64,
     ) -> Result<impl StatefulServiceReplica + 'static, Error> {
         info!(

--- a/crates/samples/echomain/src/service_factory.rs
+++ b/crates/samples/echomain/src/service_factory.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use mssf_core::{
     WString,
     runtime::stateless::{StatelessServiceFactory, StatelessServiceInstance},
+    types::Uri,
 };
 use tracing::info;
 
@@ -28,10 +29,10 @@ impl StatelessServiceFactory for ServiceFactory {
     #[tracing::instrument(skip(self))]
     fn create_instance(
         &self,
-        servicetypename: &WString,
-        servicename: &WString,
+        servicetypename: WString,
+        servicename: Uri,
         initializationdata: &[u8],
-        partitionid: &mssf_core::GUID,
+        partitionid: mssf_core::GUID,
         instanceid: i64,
     ) -> mssf_core::Result<impl StatelessServiceInstance> {
         info!("create_instance");

--- a/crates/samples/kvstore/src/kvstore.rs
+++ b/crates/samples/kvstore/src/kvstore.rs
@@ -50,10 +50,10 @@ fn get_addr(port: u32, hostname: WString) -> String {
 impl StatefulServiceFactory for Factory {
     fn create_replica(
         &self,
-        servicetypename: &WString,
-        servicename: &WString,
+        servicetypename: WString,
+        servicename: mssf_core::types::Uri,
         initializationdata: &[u8],
-        partitionid: &GUID,
+        partitionid: GUID,
         replicaid: i64,
     ) -> Result<impl StatefulServiceReplica, Error> {
         info!(
@@ -76,7 +76,7 @@ impl StatefulServiceFactory for Factory {
         let handler: IFabricStoreEventHandler = DummyStoreEventHandler {}.into();
         let kv = create_com_key_value_store_replica(
             &WString::from("mystorename"),
-            *partitionid,
+            partitionid,
             replicaid,
             &settings,
             LocalStoreKind::Ese,


### PR DESCRIPTION
WString supports direct FFI conversion with PCWSTR since the custom implementation in mssf-pal.
WStringWrap originally was created to interoperate with widnows HSTRING, and it is no longer needed.
Modified all WStringWrap usage to use WString directly.
Changed to use Uri type when the FFI type is FABRIC_URI.
Changed the signature of stateless and stateful factories to move the WString to avoid user coping.
