### PR TITLE
[Runtime] Use move instead of ref in traits

### DIFF
--- a/crates/libs/core/src/runtime/stateful.rs
+++ b/crates/libs/core/src/runtime/stateful.rs
@@ -42,7 +42,7 @@ pub trait LocalStatefulServiceReplica: Send + Sync + 'static {
     async fn open(
         &self,
         openmode: OpenMode,
-        partition: &StatefulServicePartition,
+        partition: StatefulServicePartition,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<impl PrimaryReplicator>;
 
@@ -85,8 +85,8 @@ pub trait LocalReplicator: Send + Sync + 'static {
     /// Replicator change_role is called before Replica change_role.
     async fn change_role(
         &self,
-        epoch: &Epoch,
-        role: &ReplicaRole,
+        epoch: Epoch,
+        role: ReplicaRole,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 
@@ -100,7 +100,7 @@ pub trait LocalReplicator: Send + Sync + 'static {
     /// Called only on active/idle secondary replicas. Primary replica gets new epoch via change_role call.
     async fn update_epoch(
         &self,
-        epoch: &Epoch,
+        epoch: Epoch,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 
@@ -167,8 +167,8 @@ pub trait LocalPrimaryReplicator: Replicator {
     /// must_catchup -> Set to true only for one replica in the current configuration.
     fn update_catch_up_replica_set_configuration(
         &self,
-        currentconfiguration: &ReplicaSetConfig,
-        previousconfiguration: &ReplicaSetConfig,
+        currentconfiguration: ReplicaSetConfig,
+        previousconfiguration: ReplicaSetConfig,
     ) -> crate::Result<()>;
 
     /// Informs the replicator about the current replica set configuration, and there
@@ -177,7 +177,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     /// Replicas here are not marked as must_catchup.
     fn update_current_replica_set_configuration(
         &self,
-        currentconfiguration: &ReplicaSetConfig,
+        currentconfiguration: ReplicaSetConfig,
     ) -> crate::Result<()>;
 
     /// Called on primary to wait for replicas to catch up, before
@@ -232,7 +232,7 @@ pub trait LocalPrimaryReplicator: Replicator {
     /// by calling update_x_configuration().
     async fn build_replica(
         &self,
-        replica: &ReplicaInformation,
+        replica: ReplicaInformation,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<()>;
 

--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -196,7 +196,7 @@ where
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner
-                .change_role(&epoch2, &role2, token)
+                .change_role(epoch2, role2, token)
                 .await
                 .map_err(crate::WinError::from)
         })
@@ -227,7 +227,7 @@ where
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner
-                .update_epoch(&epoch2, token)
+                .update_epoch(epoch2, token)
                 .await
                 .map_err(crate::WinError::from)
         })
@@ -474,7 +474,7 @@ where
         let cc = ReplicaSetConfig::from(unsafe { currentconfiguration.as_ref().unwrap() });
         let pc = ReplicaSetConfig::from(unsafe { previousconfiguration.as_ref().unwrap() });
         self.inner
-            .update_catch_up_replica_set_configuration(&cc, &pc)
+            .update_catch_up_replica_set_configuration(cc, pc)
             .map_err(crate::WinError::from)
     }
 
@@ -520,7 +520,7 @@ where
     ) -> crate::WinResult<()> {
         let c = ReplicaSetConfig::from(unsafe { currentconfiguration.as_ref() }.unwrap());
         self.inner
-            .update_current_replica_set_configuration(&c)
+            .update_current_replica_set_configuration(c)
             .map_err(crate::WinError::from)
     }
 
@@ -544,7 +544,7 @@ where
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner
-                .build_replica(&r, token)
+                .build_replica(r, token)
                 .await
                 .map_err(crate::WinError::from)
         })
@@ -634,7 +634,7 @@ where
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner
-                .open(openmode2, &partition, token)
+                .open(openmode2, partition, token)
                 .await
                 .map(|s| {
                     let bridge: IFabricPrimaryReplicator =

--- a/crates/libs/core/src/runtime/stateless.rs
+++ b/crates/libs/core/src/runtime/stateless.rs
@@ -35,7 +35,7 @@ pub trait LocalStatelessServiceInstance: Send + Sync + 'static {
     /// clients that resolve the service via resolve_service_partition(uri).
     async fn open(
         &self,
-        partition: &StatelessServicePartition,
+        partition: StatelessServicePartition,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<WString>;
 

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -138,7 +138,7 @@ where
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner
-                .open(&partition_bridge, token)
+                .open(partition_bridge, token)
                 .await
                 .map(|s| IFabricStringResult::from(StringResult::new(s)))
                 .map_err(crate::WinError::from)

--- a/crates/libs/util/src/data.rs
+++ b/crates/libs/util/src/data.rs
@@ -76,15 +76,15 @@ impl Replicator for EmptyReplicator {
     #[tracing::instrument(fields(read_status = ?self.read_status(), write_status = ?self.write_status()), err, ret)]
     async fn change_role(
         &self,
-        epoch: &Epoch,
-        role: &ReplicaRole,
+        epoch: Epoch,
+        role: ReplicaRole,
         _: BoxedCancelToken,
     ) -> mssf_core::Result<()> {
         Ok(())
     }
 
     #[tracing::instrument(fields(read_status = ?self.read_status(), write_status = ?self.write_status()), err, ret)]
-    async fn update_epoch(&self, epoch: &Epoch, _: BoxedCancelToken) -> mssf_core::Result<()> {
+    async fn update_epoch(&self, epoch: Epoch, _: BoxedCancelToken) -> mssf_core::Result<()> {
         Ok(())
     }
 
@@ -113,8 +113,8 @@ impl PrimaryReplicator for EmptyReplicator {
     #[tracing::instrument(err, ret)]
     fn update_catch_up_replica_set_configuration(
         &self,
-        currentconfiguration: &ReplicaSetConfig,
-        previousconfiguration: &ReplicaSetConfig,
+        currentconfiguration: ReplicaSetConfig,
+        previousconfiguration: ReplicaSetConfig,
     ) -> mssf_core::Result<()> {
         Ok(())
     }
@@ -151,7 +151,7 @@ impl PrimaryReplicator for EmptyReplicator {
     #[tracing::instrument(err, ret)]
     fn update_current_replica_set_configuration(
         &self,
-        currentconfiguration: &ReplicaSetConfig,
+        currentconfiguration: ReplicaSetConfig,
     ) -> mssf_core::Result<()> {
         Ok(())
     }
@@ -159,7 +159,7 @@ impl PrimaryReplicator for EmptyReplicator {
     #[tracing::instrument(err, ret)]
     async fn build_replica(
         &self,
-        replica: &ReplicaInformation,
+        replica: ReplicaInformation,
         _: BoxedCancelToken,
     ) -> mssf_core::Result<()> {
         Ok(())

--- a/crates/samples/echomain-stateful2/src/statefulstore.rs
+++ b/crates/samples/echomain-stateful2/src/statefulstore.rs
@@ -137,7 +137,7 @@ impl StatefulServiceReplica for Replica {
     async fn open(
         &self,
         openmode: OpenMode,
-        partition: &StatefulServicePartition,
+        partition: StatefulServicePartition,
         _: BoxedCancelToken,
     ) -> mssf_core::Result<impl PrimaryReplicator> {
         self.ctx.init(partition.clone());
@@ -145,11 +145,11 @@ impl StatefulServiceReplica for Replica {
             "Replica::open {openmode:?}, {:?}",
             self.ctx.get_trace_read_write_status()
         );
-        self.svc.start_loop_in_background(partition);
+        self.svc.start_loop_in_background(&partition);
         // Use empty replicator
         Ok(EmptyReplicator::new(
             WString::from("Stateful2"),
-            Some(partition.clone()),
+            Some(partition),
         ))
     }
     async fn change_role(

--- a/crates/samples/echomain/src/service_instance.rs
+++ b/crates/samples/echomain/src/service_instance.rs
@@ -41,7 +41,7 @@ impl StatelessServiceInstance for ServiceInstance {
     #[tracing::instrument(skip(self, partition))]
     async fn open(
         &self,
-        partition: &StatelessServicePartition,
+        partition: StatelessServicePartition,
         _: BoxedCancelToken,
     ) -> mssf_core::Result<WString> {
         info!("open");
@@ -62,7 +62,7 @@ impl StatelessServiceInstance for ServiceInstance {
         self.task_.lock().await.set(Some(t));
         self.tx_.lock().await.set(Some(tx));
         // send health report
-        send_instance_health_report(partition);
+        send_instance_health_report(&partition);
         Ok(WString::from(self.ctx.get_addr()))
     }
 

--- a/crates/samples/kvstore/src/kvstore.rs
+++ b/crates/samples/kvstore/src/kvstore.rs
@@ -182,7 +182,7 @@ impl StatefulServiceReplica for Replica {
     async fn open(
         &self,
         openmode: OpenMode,
-        partition: &StatefulServicePartition,
+        partition: StatefulServicePartition,
         cancellation_token: BoxedCancelToken,
     ) -> mssf_core::Result<impl PrimaryReplicator> {
         // should be primary replicator


### PR DESCRIPTION
In user facing traits like StatefulServiceReplica, many params were passing by ref, and user ends up copying the ref in the callback.
But the refs do not need to be preserved in the interop layer, so it can be directly moved to user callback.
The reason it was implemented as ref in the first place was that SF FFI api is using ref/ptr, and I just blindly followed the pattern.
This PR changes those refs to move and it can get rid of user coping in most cases.