### PR TITLE
Collect onebox app core dump in ci

### DIFF
--- a/.devcontainer/azl3/docker-compose.yml
+++ b/.devcontainer/azl3/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     ports:
       - "19080:19080"
       - "19000:19000"
+    volumes:
+      - /tmp/artifacts/coredumps/onebox:/tmp/artifacts/coredumps # core dumps
   repo:
     build:
       context: ..
@@ -18,7 +20,7 @@ services:
     volumes:
       - ../../:/workspaces/repo # repo dir
       - ~/.ssh:/root/.ssh:ro # git creds
-      - /tmp/artifacts/coredumps:/tmp/artifacts/coredumps # core dumps
+      - /tmp/artifacts/coredumps/repo:/tmp/artifacts/coredumps # core dumps
     depends_on:
       - onebox
     

--- a/.devcontainer/u22/docker-compose.yml
+++ b/.devcontainer/u22/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     ports:
       - "19080:19080"
       - "19000:19000"
+    volumes:
+      - /tmp/artifacts/coredumps/onebox:/tmp/artifacts/coredumps # core dumps
   repo-u22:
     build:
       context: ..
@@ -18,7 +20,7 @@ services:
     volumes:
       - ../../:/workspaces/repo # repo dir
       - ~/.ssh:/root/.ssh:ro # git creds
-      - /tmp/artifacts/coredumps:/tmp/artifacts/coredumps # core dumps
+      - /tmp/artifacts/coredumps/repo:/tmp/artifacts/coredumps # core dumps
     depends_on:
       - onebox
     

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,7 +143,8 @@ jobs:
         run: |
           echo "Collecting core dumps"
           sudo chmod -R 777 /tmp/artifacts
-          if [ -d "/tmp/artifacts/coredumps" ] && [ "$(ls -A /tmp/artifacts/coredumps 2>/dev/null)" ]; then
+          ls -R /tmp/artifacts/coredumps
+          if [ -d "/tmp/artifacts/coredumps" ] && [ "$(find /tmp/artifacts/coredumps -type f -print -quit)" ]; then
             tar -czf artifacts.tar.gz -C /tmp artifacts || { echo "Fail to archive core dumps"; exit 1; }
             echo "Core dumps collected"
           else


### PR DESCRIPTION
Enable core dump collection for the onebox containers.
Mount different directories for repo and onebox containers for the core dump directory.
Verified dump is collected in the github artifacts.