### PR TITLE
Initial support for mock tests for stateful services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ version = "0.1.0"
 dependencies = [
  "mssf-core",
  "mssf-util",
+ "test-log",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -20,7 +20,11 @@ pub mod package_change;
 
 pub mod runtime_wrapper;
 
-pub mod stateful;
+mod stateful_traits;
+pub use stateful_traits::{
+    IPrimaryReplicator, IReplicator, IStatefulServiceFactory, IStatefulServicePartition,
+    IStatefulServiceReplica,
+};
 
 pub mod stateful_bridge;
 

--- a/crates/libs/core/src/runtime/runtime_wrapper.rs
+++ b/crates/libs/core/src/runtime/runtime_wrapper.rs
@@ -5,8 +5,8 @@ use mssf_com::FabricRuntime::{
 };
 
 use super::{
-    create_com_runtime, executor::Executor, stateful::StatefulServiceFactory,
-    stateful_bridge::StatefulServiceFactoryBridge, stateless_bridge::StatelessServiceFactoryBridge,
+    create_com_runtime, executor::Executor, stateful_bridge::StatefulServiceFactoryBridge,
+    stateful_traits::IStatefulServiceFactory, stateless_bridge::StatelessServiceFactoryBridge,
     stateless_traits::IStatelessServiceFactory,
 };
 pub struct Runtime<E>
@@ -26,14 +26,11 @@ where
         Ok(Runtime { com_impl: com, rt })
     }
 
-    pub fn register_stateless_service_factory<F>(
+    pub fn register_stateless_service_factory(
         &self,
         servicetypename: &WString,
-        factory: F,
-    ) -> crate::Result<()>
-    where
-        F: IStatelessServiceFactory + 'static,
-    {
+        factory: Box<dyn IStatelessServiceFactory>,
+    ) -> crate::Result<()> {
         let rt_cp = self.rt.clone();
         let bridge: IFabricStatelessServiceFactory =
             StatelessServiceFactoryBridge::create(factory, rt_cp).into();
@@ -47,7 +44,7 @@ where
     pub fn register_stateful_service_factory(
         &self,
         servicetypename: &WString,
-        factory: impl StatefulServiceFactory + 'static,
+        factory: Box<dyn IStatefulServiceFactory>,
     ) -> crate::Result<()> {
         let rt_cp = self.rt.clone();
         let bridge: IFabricStatefulServiceFactory =

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -28,29 +28,29 @@ use crate::runtime::{
 };
 
 #[implement(IFabricStatelessServiceFactory)]
-pub struct StatelessServiceFactoryBridge<E, F>
+pub struct StatelessServiceFactoryBridge<E>
 where
     E: Executor + 'static,
-    F: IStatelessServiceFactory + 'static,
 {
-    inner: F,
+    inner: Box<dyn IStatelessServiceFactory>,
     rt: E,
 }
 
-impl<E, F> StatelessServiceFactoryBridge<E, F>
+impl<E> StatelessServiceFactoryBridge<E>
 where
     E: Executor,
-    F: IStatelessServiceFactory,
 {
-    pub fn create(factory: F, rt: E) -> StatelessServiceFactoryBridge<E, F> {
-        StatelessServiceFactoryBridge::<E, F> { inner: factory, rt }
+    pub fn create(
+        factory: Box<dyn IStatelessServiceFactory>,
+        rt: E,
+    ) -> StatelessServiceFactoryBridge<E> {
+        StatelessServiceFactoryBridge { inner: factory, rt }
     }
 }
 
-impl<E, F> IFabricStatelessServiceFactory_Impl for StatelessServiceFactoryBridge_Impl<E, F>
+impl<E> IFabricStatelessServiceFactory_Impl for StatelessServiceFactoryBridge_Impl<E>
 where
     E: Executor,
-    F: IStatelessServiceFactory,
 {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg_attr(

--- a/crates/libs/util/Cargo.toml
+++ b/crates/libs/util/Cargo.toml
@@ -20,8 +20,8 @@ tokio = { workspace = true, features = ["rt", "signal"], optional = true, defaul
 tokio-util = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 mssf-core = { workspace = true, default-features = false }
+mssf-com = { workspace = true }
 
 [dev-dependencies]
-mssf-com.workspace = true
 trait-variant.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/libs/util/src/mock/mod.rs
+++ b/crates/libs/util/src/mock/mod.rs
@@ -7,7 +7,12 @@
 // Mock utilities for testing.
 
 mod runtime;
-pub use runtime::{CreateServiceArg, StatelessServiceInstanceDriver};
+pub use runtime::{CreateStatelessServiceArg, StatelessServiceInstanceDriver};
 
 mod stateless;
 pub use stateless::StatelessServicePartitionMock;
+
+mod stateful;
+pub use stateful::{
+    CreateStatefulServicePartitionArg, StatefulServicePartitionDriver, StatefulServicePartitionMock,
+};

--- a/crates/libs/util/src/mock/runtime.rs
+++ b/crates/libs/util/src/mock/runtime.rs
@@ -26,7 +26,7 @@ impl StatelessServiceInstanceDriver {
     }
 }
 
-pub struct CreateServiceArg {
+pub struct CreateStatelessServiceArg {
     pub init_data: Vec<u8>,
     pub partition_id: GUID,
     pub instance_id: i64, // Currently partition id and instance id should be globally unique
@@ -39,7 +39,7 @@ pub struct CreateServiceArg {
 impl StatelessServiceInstanceDriver {
     pub async fn create_service_instance(
         &mut self,
-        desc: &CreateServiceArg,
+        desc: &CreateStatelessServiceArg,
     ) -> mssf_core::Result<()> {
         let service_instance = self
             .service_factory

--- a/crates/libs/util/src/mock/stateful.rs
+++ b/crates/libs/util/src/mock/stateful.rs
@@ -1,0 +1,452 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use mssf_core::{
+    GUID, WString,
+    runtime::IStatefulServicePartition,
+    sync::SimpleCancelToken,
+    types::{Epoch, ServicePartitionInformation, Uri},
+};
+
+#[derive(Clone)]
+pub struct StatefulServicePartitionMock {
+    info: mssf_core::types::ServicePartitionInformation,
+    read_status: Arc<Mutex<mssf_core::types::ServicePartitionAccessStatus>>,
+    write_status: Arc<Mutex<mssf_core::types::ServicePartitionAccessStatus>>,
+}
+
+impl StatefulServicePartitionMock {
+    pub fn new(info: mssf_core::types::ServicePartitionInformation) -> Self {
+        Self {
+            info,
+            read_status: Arc::new(Mutex::new(
+                mssf_core::types::ServicePartitionAccessStatus::ReconfigurationPending,
+            )),
+            write_status: Arc::new(Mutex::new(
+                mssf_core::types::ServicePartitionAccessStatus::ReconfigurationPending,
+            )),
+        }
+    }
+    pub fn new_boxed(
+        info: mssf_core::types::ServicePartitionInformation,
+    ) -> Box<dyn IStatefulServicePartition> {
+        Box::new(Self::new(info))
+    }
+    pub fn set_read_status(&self, status: mssf_core::types::ServicePartitionAccessStatus) {
+        *self.read_status.lock().unwrap() = status;
+    }
+    pub fn set_write_status(&self, status: mssf_core::types::ServicePartitionAccessStatus) {
+        *self.write_status.lock().unwrap() = status;
+    }
+}
+
+impl IStatefulServicePartition for StatefulServicePartitionMock {
+    fn create_replicator(
+        &self,
+    ) -> mssf_core::Result<Box<dyn mssf_core::runtime::IPrimaryReplicator>> {
+        unimplemented!("Not implemented")
+    }
+
+    fn get_partition_information(
+        &self,
+    ) -> mssf_core::Result<mssf_core::types::ServicePartitionInformation> {
+        Ok(self.info.clone())
+    }
+
+    fn get_read_status(&self) -> mssf_core::Result<mssf_core::types::ServicePartitionAccessStatus> {
+        Ok(self.read_status.lock().unwrap().clone())
+    }
+
+    fn get_write_status(
+        &self,
+    ) -> mssf_core::Result<mssf_core::types::ServicePartitionAccessStatus> {
+        Ok(self.write_status.lock().unwrap().clone())
+    }
+
+    fn report_load(&self, _metrics: &[mssf_core::types::LoadMetric]) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    fn report_fault(&self, _fault_type: mssf_core::types::FaultType) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    fn report_move_cost(&self, _move_cost: mssf_core::types::MoveCost) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    fn report_partition_health(
+        &self,
+        _healthinfo: &mssf_core::types::HealthInformation,
+    ) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    fn report_replica_health(
+        &self,
+        _healthinfo: &mssf_core::types::HealthInformation,
+    ) -> mssf_core::Result<()> {
+        Ok(())
+    }
+
+    fn try_get_com(
+        &self,
+    ) -> mssf_core::Result<&mssf_com::FabricRuntime::IFabricStatefulServicePartition> {
+        Err(mssf_core::ErrorCode::FABRIC_E_OPERATION_NOT_SUPPORTED.into())
+    }
+
+    fn clone_box(&self) -> Box<dyn IStatefulServicePartition> {
+        Box::new(self.clone())
+    }
+}
+
+pub struct CreateStatefulServicePartitionArg {
+    pub partition_id: GUID,
+    pub replica_count: usize,
+    pub init_data: Vec<u8>,
+    pub service_name: Uri,
+    pub service_type_name: WString,
+}
+
+/// Test driver for a single stateful service replica.
+pub struct StatefulServicePartitionDriver {
+    service_factory: Box<dyn mssf_core::runtime::IStatefulServiceFactory>,
+    replica_index: i64,
+    epoch_index: Epoch,
+    partition_state: PartitionState,
+}
+
+struct PartitionState {
+    pub replica_states: HashMap<i64, StatefulServiceReplicaState>,
+    pub primary_index: i64,
+    pub epoch: Epoch,
+}
+
+struct StatefulServiceReplicaState {
+    pub replica: Box<dyn mssf_core::runtime::IStatefulServiceReplica>,
+    pub replicator: Box<dyn mssf_core::runtime::IPrimaryReplicator>,
+    pub partition: StatefulServicePartitionMock,
+    pub _replica_address: WString,
+    pub _replicator_address: WString,
+}
+
+impl StatefulServicePartitionDriver {
+    pub fn new(service_factory: Box<dyn mssf_core::runtime::IStatefulServiceFactory>) -> Self {
+        Self {
+            service_factory,
+            replica_index: 1,
+            epoch_index: Epoch {
+                data_loss_number: 0,
+                configuration_number: 1,
+            },
+            partition_state: PartitionState {
+                replica_states: HashMap::new(),
+                primary_index: 1, // First replica is the primary.
+                epoch: Epoch {
+                    data_loss_number: 0,
+                    configuration_number: 1,
+                },
+            },
+        }
+    }
+
+    fn next_replica_index(&mut self) -> i64 {
+        let idx = self.replica_index;
+        self.replica_index += 1;
+        idx
+    }
+
+    fn next_epoch_index(&mut self) -> Epoch {
+        let idx = self.epoch_index.clone();
+        self.epoch_index.configuration_number += 1;
+        idx
+    }
+
+    /// Create a stateful service partition with the specified number of replicas.
+    /// The first replica is the primary.
+    /// Runs the replica build steps.
+    pub async fn create_service_partition(
+        &mut self,
+        desc: &CreateStatefulServicePartitionArg,
+    ) -> mssf_core::Result<()> {
+        assert!(desc.replica_count > 0);
+        assert!(self.partition_state.replica_states.is_empty());
+
+        let mut replicas = HashMap::new();
+        let mut replicators = HashMap::new();
+        let mut replica_addresses = HashMap::new();
+        let mut replicator_addresses = HashMap::new();
+        let mut replica_infos = HashMap::new();
+        let mut partitions = HashMap::new();
+
+        for _ in 0..desc.replica_count {
+            let id = self.next_replica_index();
+            let replica = self
+                .service_factory
+                .create_replica(
+                    desc.service_type_name.clone(),
+                    desc.service_name.clone(),
+                    &desc.init_data,
+                    desc.partition_id,
+                    id,
+                )
+                .inspect_err(|e| {
+                    tracing::error!("Failed to create stateful service replica: {:?}", e)
+                })?;
+            let prev = replicas.insert(id, replica);
+            assert!(prev.is_none(), "Service replica already exists");
+        }
+
+        // open all replicas
+        for (id, replica) in &replicas {
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+            // TODO: support other partition schemes.
+            let partition =
+                StatefulServicePartitionMock::new(ServicePartitionInformation::Singleton(
+                    mssf_core::types::SingletonPartitionInformation {
+                        id: desc.partition_id,
+                    },
+                ));
+            let replctr = replica
+                .open(
+                    mssf_core::types::OpenMode::New,
+                    partition.clone_box(),
+                    cancellation_token,
+                )
+                .await?;
+            replicators.insert(*id, replctr);
+            partitions.insert(*id, partition);
+        }
+
+        // open all replicators
+        for (id, replctr) in &replicators {
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+
+            let replctr_addr = replctr.open(cancellation_token).await?;
+            replicator_addresses.insert(*id, replctr_addr);
+        }
+
+        // assign roles to replicators. for simplicity, we assume the first replica is the primary.
+        let primary_index = 1;
+        let epoch = self.next_epoch_index();
+        for (id, rplctr) in &replicators {
+            let epoch_cp = epoch.clone();
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+            if *id == primary_index {
+                rplctr
+                    .change_role(
+                        epoch_cp,
+                        mssf_core::types::ReplicaRole::Primary,
+                        cancellation_token,
+                    )
+                    .await?;
+                self.partition_state.primary_index = primary_index;
+            } else {
+                rplctr
+                    .change_role(
+                        epoch_cp,
+                        mssf_core::types::ReplicaRole::IdleSecondary,
+                        cancellation_token,
+                    )
+                    .await?;
+            }
+        }
+
+        // assign roles to replicas. First one is primary.
+        for (id, replica) in &replicas {
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+            let replica_addr = if *id == self.partition_state.primary_index {
+                replica
+                    .change_role(mssf_core::types::ReplicaRole::Primary, cancellation_token)
+                    .await?
+            } else {
+                replica
+                    .change_role(
+                        mssf_core::types::ReplicaRole::IdleSecondary,
+                        cancellation_token,
+                    )
+                    .await?
+            };
+            replica_addresses.insert(*id, replica_addr);
+        }
+
+        // build secondaries.
+        let primary = replicators
+            .get(&self.partition_state.primary_index)
+            .unwrap();
+        for id in replicas.keys() {
+            if *id == self.partition_state.primary_index {
+                let replica_info = mssf_core::types::ReplicaInformation {
+                    replicator_address: replicator_addresses.get(id).unwrap().clone(),
+                    id: *id,
+                    role: mssf_core::types::ReplicaRole::Primary,
+                    status: mssf_core::types::ReplicaStatus::Up,
+                    current_progress: 0,
+                    catch_up_capability: 0,
+                    must_catch_up: false,
+                };
+                replica_infos.insert(*id, replica_info);
+                continue;
+            }
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+            let replica_info = mssf_core::types::ReplicaInformation {
+                replicator_address: replicator_addresses.get(id).unwrap().clone(),
+                id: *id,
+                role: mssf_core::types::ReplicaRole::IdleSecondary,
+                status: mssf_core::types::ReplicaStatus::Up,
+                current_progress: 0,
+                catch_up_capability: 0,
+                must_catch_up: false,
+            };
+            replica_infos.insert(*id, replica_info.clone());
+            primary
+                .build_replica(replica_info, cancellation_token)
+                .await?;
+        }
+
+        // update catch up replica set config
+        let currentconfiguration = mssf_core::types::ReplicaSetConfig {
+            replicas: replica_infos.values().cloned().collect(),
+            write_quorum: (replicas.len() / 2 + 1) as u32,
+        };
+        let priv_config = mssf_core::types::ReplicaSetConfig {
+            replicas: vec![],
+            write_quorum: 0,
+        };
+        primary.update_catch_up_replica_set_configuration(currentconfiguration, priv_config)?;
+
+        // wait for catch up
+        primary
+            .wait_for_catch_up_quorum(
+                mssf_core::types::ReplicaSetQuorumMode::All,
+                SimpleCancelToken::new_boxed(),
+            )
+            .await?;
+
+        // Change secondaries to active secondaries.
+        for (id, replica) in &replicas {
+            if *id == 1 {
+                continue;
+            }
+            let cancellation_token = SimpleCancelToken::new_boxed();
+            replica
+                .change_role(
+                    mssf_core::types::ReplicaRole::ActiveSecondary,
+                    cancellation_token,
+                )
+                .await?;
+            // update the replica info
+            replica_infos.get_mut(id).unwrap().role =
+                mssf_core::types::ReplicaRole::ActiveSecondary;
+        }
+        // update current configuration
+        {
+            let currentconfiguration = mssf_core::types::ReplicaSetConfig {
+                replicas: replica_infos.values().cloned().collect(),
+                write_quorum: (replicas.len() / 2 + 1) as u32,
+            };
+            primary.update_current_replica_set_configuration(currentconfiguration)?;
+        }
+
+        // Update read write status.
+        for (id, partition) in &partitions {
+            if *id == self.partition_state.primary_index {
+                partition.set_read_status(mssf_core::types::ServicePartitionAccessStatus::Granted);
+                partition.set_write_status(mssf_core::types::ServicePartitionAccessStatus::Granted);
+            } else {
+                partition
+                    .set_read_status(mssf_core::types::ServicePartitionAccessStatus::NotPrimary);
+                partition
+                    .set_write_status(mssf_core::types::ServicePartitionAccessStatus::NotPrimary);
+            }
+        }
+
+        // Save the state.
+        for (id, replica) in replicas {
+            let state = StatefulServiceReplicaState {
+                replica,
+                replicator: replicators.remove(&id).unwrap(),
+                _replica_address: replica_addresses.remove(&id).unwrap(),
+                _replicator_address: replicator_addresses.remove(&id).unwrap(),
+                partition: partitions.remove(&id).unwrap(),
+            };
+            self.partition_state.replica_states.insert(id, state);
+        }
+        self.partition_state.epoch = epoch;
+        Ok(())
+    }
+
+    pub async fn delete_service_partition(&mut self) -> mssf_core::Result<()> {
+        // Not sure if the sequence is correct.
+
+        // Change read write status to pending
+        for state in self.partition_state.replica_states.values_mut() {
+            state.partition.set_read_status(
+                mssf_core::types::ServicePartitionAccessStatus::ReconfigurationPending,
+            );
+            state.partition.set_write_status(
+                mssf_core::types::ServicePartitionAccessStatus::ReconfigurationPending,
+            );
+        }
+
+        // Change primary to active secondary
+        let primary = self
+            .partition_state
+            .replica_states
+            .get_mut(&1)
+            .expect("Primary replica not found");
+
+        let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+        primary
+            .replica
+            .change_role(
+                mssf_core::types::ReplicaRole::ActiveSecondary,
+                cancellation_token,
+            )
+            .await?;
+        primary
+            .replicator
+            .change_role(
+                self.partition_state.epoch.clone(), // Epoch is unchanged.
+                mssf_core::types::ReplicaRole::ActiveSecondary,
+                SimpleCancelToken::new_boxed(),
+            )
+            .await?;
+
+        // change role to none for all replicas
+        for state in self.partition_state.replica_states.values_mut() {
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+            state
+                .replica
+                .change_role(mssf_core::types::ReplicaRole::None, cancellation_token)
+                .await?;
+            state
+                .replicator
+                .change_role(
+                    self.partition_state.epoch.clone(), // Epoch is unchanged.
+                    mssf_core::types::ReplicaRole::None,
+                    SimpleCancelToken::new_boxed(),
+                )
+                .await?;
+        }
+
+        // close all replicas and replicators
+        for state in self.partition_state.replica_states.values_mut() {
+            let cancellation_token = mssf_core::sync::SimpleCancelToken::new_boxed();
+            state.replica.close(cancellation_token.clone()).await?;
+            state.replicator.close(cancellation_token).await?;
+        }
+
+        // clear the state
+        self.partition_state.replica_states.clear();
+
+        Ok(())
+    }
+}

--- a/crates/samples/echomain-stateful2/Cargo.toml
+++ b/crates/samples/echomain-stateful2/Cargo.toml
@@ -14,3 +14,6 @@ tokio-util.workspace = true
 trait-variant.workspace = true
 mssf-core = { workspace = true, default-features = true }
 mssf-util = { workspace = true, default-features = true }
+
+[dev-dependencies]
+test-log.workspace = true

--- a/crates/samples/echomain-stateful2/src/main.rs
+++ b/crates/samples/echomain-stateful2/src/main.rs
@@ -18,6 +18,8 @@ mod test;
 #[cfg(test)]
 mod test2;
 
+const SERVICE_TYPE_NAME: &str = "StatefulEchoAppService";
+
 fn main() -> mssf_core::Result<()> {
     tracing_subscriber::fmt().init();
     info!("main start");
@@ -31,9 +33,9 @@ fn main() -> mssf_core::Result<()> {
         .unwrap();
     let hostname = get_hostname().expect("cannot get hostname");
 
-    let factory = Factory::create(endpoint.port, hostname, e.clone());
+    let factory = Box::new(Factory::create(endpoint.port, hostname, e.clone()));
     runtime
-        .register_stateful_service_factory(&WString::from("StatefulEchoAppService"), factory)
+        .register_stateful_service_factory(&WString::from(SERVICE_TYPE_NAME), factory)
         .unwrap();
 
     e.block_until_ctrlc();

--- a/crates/samples/echomain/src/main.rs
+++ b/crates/samples/echomain/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> mssf_core::Result<()> {
 
     let runtime = mssf_core::runtime::Runtime::create(e.clone()).unwrap();
     let app_ctx = AppContext::new(port, hostname, e.clone());
-    let factory = service_factory::ServiceFactory::new(Arc::new(app_ctx));
+    let factory = Box::new(service_factory::ServiceFactory::new(Arc::new(app_ctx)));
     runtime
         .register_stateless_service_factory(&WString::from("EchoAppService"), factory)
         .unwrap();

--- a/crates/samples/echomain/src/test.rs
+++ b/crates/samples/echomain/src/test.rs
@@ -538,7 +538,7 @@ async fn test_mock() {
     let factory = Box::new(crate::service_factory::ServiceFactory::new(app_ctx.clone()));
     let mut driver = mssf_util::mock::StatelessServiceInstanceDriver::new(factory);
 
-    let create_arg = mssf_util::mock::CreateServiceArg {
+    let create_arg = mssf_util::mock::CreateStatelessServiceArg {
         init_data: vec![],
         partition_id: GUID::new().unwrap(),
         instance_id: 1,

--- a/crates/samples/kvstore/src/main.rs
+++ b/crates/samples/kvstore/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> mssf_core::Result<()> {
         .get_endpoint_resource(&WString::from("KvReplicatorEndpoint"))
         .unwrap();
 
-    let factory = Factory::create(endpoint.port, e.clone());
+    let factory = Box::new(Factory::create(endpoint.port, e.clone()));
     runtime
         .register_stateful_service_factory(&WString::from("KvStoreService"), factory)
         .unwrap();


### PR DESCRIPTION
Added StatefulServicePartitionDriver to test stateful service factory, replica and replicator in unit test.
Currently it only supports partition creation (with replica build) and partition deletion ochestration.
In future restart secondary and force remove will be supported.

Refactored the stateful traits to use async_traits to align with mocks.