### PR TITLE
[util mock] Support secondary graceful restart testing

### DIFF
--- a/crates/libs/core/src/types/runtime/stateful.rs
+++ b/crates/libs/core/src/types/runtime/stateful.rs
@@ -126,7 +126,7 @@ impl From<FABRIC_REPLICA_STATUS> for ReplicaStatus {
 }
 
 // Safe wrapping for FABRIC_REPLICA_SET_CONFIGURATION
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReplicaSetConfig {
     pub replicas: Vec<ReplicaInformation>,
     pub write_quorum: u32,


### PR DESCRIPTION
Added to the test driver to gracefully restart secondary, executing rebuild workflows.
Fixed the create workflows to call catch up for each replica.
Support registering multiple service factories to simulate multi node setup. Replicas are created in round robin fashion from these factories.