### PR TITLE
[core] Use Arc instead of Box for Partition object

### DIFF
--- a/crates/libs/core/src/runtime/stateful_bridge.rs
+++ b/crates/libs/core/src/runtime/stateful_bridge.rs
@@ -624,7 +624,7 @@ where
             .unwrap()
             .cast::<IFabricStatefulServicePartition3>()
             .expect("cannot query interface");
-        let partition = Box::new(StatefulServicePartition::from(&com_partition));
+        let partition = Arc::new(StatefulServicePartition::from(&com_partition));
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -6,13 +6,9 @@
 // stateful_proxy is a wrapper layer around com api,
 // making manipulating com simple.
 
-use std::ffi::c_void;
+use std::{ffi::c_void, sync::Arc};
 
-use crate::{
-    Interface, WString,
-    runtime::{IStatefulServicePartition, executor::BoxedCancelToken},
-    strings::StringResult,
-};
+use crate::{Interface, WString, runtime::executor::BoxedCancelToken, strings::StringResult};
 use mssf_com::FabricRuntime::{
     IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
     IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
@@ -49,7 +45,7 @@ impl IStatefulServiceReplica for StatefulServiceReplicaProxy {
     async fn open(
         &self,
         openmode: OpenMode,
-        partition: Box<dyn super::IStatefulServicePartition>,
+        partition: Arc<dyn super::IStatefulServicePartition>,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<Box<dyn IPrimaryReplicator>> {
         let com1 = &self.com_impl;
@@ -440,10 +436,6 @@ impl super::IStatefulServicePartition for StatefulServicePartition {
         &self,
     ) -> crate::Result<&mssf_com::FabricRuntime::IFabricStatefulServicePartition> {
         Ok(&self.com_impl)
-    }
-
-    fn clone_box(&self) -> Box<dyn IStatefulServicePartition> {
-        Box::new(self.clone())
     }
 }
 

--- a/crates/libs/core/src/runtime/stateful_traits.rs
+++ b/crates/libs/core/src/runtime/stateful_traits.rs
@@ -40,7 +40,7 @@ pub trait IStatefulServiceReplica: Send + Sync + 'static {
     async fn open(
         &self,
         openmode: OpenMode,
-        partition: Box<dyn IStatefulServicePartition>,
+        partition: std::sync::Arc<dyn IStatefulServicePartition>,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<Box<dyn IPrimaryReplicator>>;
 
@@ -310,9 +310,6 @@ pub trait IStatefulServicePartition: Send + Sync + 'static {
     fn try_get_com(
         &self,
     ) -> crate::Result<&mssf_com::FabricRuntime::IFabricStatefulServicePartition>;
-
-    /// Clones the partition object.
-    fn clone_box(&self) -> Box<dyn IStatefulServicePartition>;
 }
 
 impl std::fmt::Debug for dyn IStatefulServicePartition {

--- a/crates/libs/core/src/runtime/stateless_bridge.rs
+++ b/crates/libs/core/src/runtime/stateless_bridge.rs
@@ -135,7 +135,7 @@ where
         let (ctx, token) = BridgeContext::make(callback);
         ctx.spawn(&self.rt, async move {
             inner
-                .open(Box::new(partition_bridge), token)
+                .open(Arc::new(partition_bridge), token)
                 .await
                 .map(|s| IFabricStringResult::from(StringResult::new(s)))
                 .map_err(crate::WinError::from)

--- a/crates/libs/core/src/runtime/stateless_traits.rs
+++ b/crates/libs/core/src/runtime/stateless_traits.rs
@@ -5,6 +5,8 @@
 
 #![deny(non_snake_case)] // this file is safe rust
 
+use std::sync::Arc;
+
 use crate::WString;
 use crate::runtime::executor::BoxedCancelToken;
 use crate::types::ServicePartitionInformation;
@@ -35,7 +37,7 @@ pub trait IStatelessServiceInstance: Send + Sync + 'static {
     /// clients that resolve the service via resolve_service_partition(uri).
     async fn open(
         &self,
-        partition: Box<dyn IStatelessServicePartition>,
+        partition: Arc<dyn IStatelessServicePartition>,
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<WString>;
 

--- a/crates/libs/util/src/data.rs
+++ b/crates/libs/util/src/data.rs
@@ -25,7 +25,7 @@ use mssf_core::{
 #[derive(Clone)]
 pub struct EmptyReplicator {
     name: WString,
-    partition: Option<Arc<Box<dyn IStatefulServicePartition>>>,
+    partition: Option<Arc<dyn IStatefulServicePartition>>,
 }
 
 impl EmptyReplicator {
@@ -57,12 +57,9 @@ impl EmptyReplicator {
     /// Create a new empty replicator with a name for tracing purpose.
     pub fn new(
         name: WString,
-        partition: Option<Box<dyn IStatefulServicePartition>>,
+        partition: Option<Arc<dyn IStatefulServicePartition>>,
     ) -> EmptyReplicator {
-        EmptyReplicator {
-            name,
-            partition: partition.map(Arc::new),
-        }
+        EmptyReplicator { name, partition }
     }
 }
 

--- a/crates/libs/util/src/mock/runtime.rs
+++ b/crates/libs/util/src/mock/runtime.rs
@@ -59,7 +59,7 @@ impl StatelessServiceInstanceDriver {
 
         let instance_ref = self.instance.as_ref().unwrap();
         let partition =
-            StatelessServicePartitionMock::new_boxed(ServicePartitionInformation::Singleton(
+            StatelessServicePartitionMock::new_arc(ServicePartitionInformation::Singleton(
                 mssf_core::types::SingletonPartitionInformation {
                     id: desc.partition_id,
                 },

--- a/crates/libs/util/src/mock/stateful.rs
+++ b/crates/libs/util/src/mock/stateful.rs
@@ -101,10 +101,6 @@ impl IStatefulServicePartition for StatefulServicePartitionMock {
     ) -> mssf_core::Result<&mssf_com::FabricRuntime::IFabricStatefulServicePartition> {
         Err(mssf_core::ErrorCode::FABRIC_E_OPERATION_NOT_SUPPORTED.into())
     }
-
-    fn clone_box(&self) -> Box<dyn IStatefulServicePartition> {
-        Box::new(self.clone())
-    }
 }
 
 pub struct CreateStatefulServicePartitionArg {
@@ -217,7 +213,7 @@ impl StatefulServicePartitionDriver {
             let replctr = replica
                 .open(
                     mssf_core::types::OpenMode::New,
-                    partition.clone_box(),
+                    Arc::new(partition.clone()),
                     cancellation_token,
                 )
                 .await?;

--- a/crates/libs/util/src/mock/stateless.rs
+++ b/crates/libs/util/src/mock/stateless.rs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use std::sync::Arc;
+
 use mssf_core::{runtime::IStatelessServicePartition, types::ServicePartitionInformation};
 
 /// Mock for IStatelessServicePartition
@@ -16,8 +18,8 @@ impl StatelessServicePartitionMock {
     pub fn new(info: ServicePartitionInformation) -> Self {
         Self { info }
     }
-    pub fn new_boxed(info: ServicePartitionInformation) -> Box<dyn IStatelessServicePartition> {
-        Box::new(Self::new(info))
+    pub fn new_arc(info: ServicePartitionInformation) -> Arc<dyn IStatelessServicePartition> {
+        Arc::new(Self::new(info))
     }
 }
 

--- a/crates/samples/echomain-stateful2/src/echo.rs
+++ b/crates/samples/echomain-stateful2/src/echo.rs
@@ -6,6 +6,7 @@
 // echo server impl using tokio
 
 use std::io::Error;
+use std::sync::Arc;
 
 use mssf_core::types::LoadMetric;
 use mssf_core::{WString, runtime::IStatefulServicePartition};
@@ -23,7 +24,7 @@ pub fn get_addr(port: u32, hostname: WString) -> String {
 
 /// Report load for the app via SF partition api periodically
 pub async fn report_load_loop(
-    partition: Box<dyn IStatefulServicePartition>,
+    partition: Arc<dyn IStatefulServicePartition>,
     token: CancellationToken,
 ) {
     let mut value = 0;
@@ -57,7 +58,7 @@ pub async fn start_load_report(
     token: CancellationToken,
     port: u32,
     hostname: WString,
-    partition: Box<dyn IStatefulServicePartition>,
+    partition: Arc<dyn IStatefulServicePartition>,
 ) -> Result<(), Error> {
     let addr = get_addr(port, hostname);
     info!("start_load_report without listener: {}", addr);

--- a/crates/samples/echomain/src/service_instance.rs
+++ b/crates/samples/echomain/src/service_instance.rs
@@ -43,7 +43,7 @@ impl IStatelessServiceInstance for ServiceInstance {
     #[tracing::instrument(skip(self, partition, _token))]
     async fn open(
         &self,
-        partition: Box<dyn IStatelessServicePartition>,
+        partition: Arc<dyn IStatelessServicePartition>,
         _token: BoxedCancelToken,
     ) -> mssf_core::Result<WString> {
         info!("open");

--- a/crates/samples/kvstore/src/kvstore.rs
+++ b/crates/samples/kvstore/src/kvstore.rs
@@ -1,4 +1,7 @@
-use std::{cell::Cell, sync::Mutex};
+use std::{
+    cell::Cell,
+    sync::{Arc, Mutex},
+};
 
 use mssf_com::{
     FabricRuntime::{
@@ -184,7 +187,7 @@ impl IStatefulServiceReplica for Replica {
     async fn open(
         &self,
         openmode: OpenMode,
-        partition: Box<dyn IStatefulServicePartition>,
+        partition: Arc<dyn IStatefulServicePartition>,
         cancellation_token: BoxedCancelToken,
     ) -> mssf_core::Result<Box<dyn IPrimaryReplicator>> {
         // should be primary replicator


### PR DESCRIPTION
dyn IStatefulServicePartition and dyn IStatelessServicePartition trait implementations in practice always require cloning in applications. So, it is better to change it to Arc from Box, so that application can avoid wrap another layer of Arc. And the trait does not have to implement clone_box() function to implement boxed clone.