### PR TITLE
[core] Support cancellation token callback

### DIFF
--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -46,7 +46,7 @@ pub trait CancelToken: Send + Sync + 'static {
     /// Register a callback to be invoked when this token is cancelled.
     /// If this token is already cancelled, the callback is invoked immediately.
     ///
-    /// # Panics
+    /// # Panics (debug builds only)
     /// Panics if a callback has already been registered.
     fn on_cancel(&self, callback: Box<dyn FnOnce() + Send + Sync>);
 

--- a/crates/libs/core/src/sync/token.rs
+++ b/crates/libs/core/src/sync/token.rs
@@ -137,7 +137,7 @@ impl CancelToken for SimpleCancelToken {
             drop(slot);
             callback();
         } else {
-            assert!(slot.is_none(), "a callback has already been registered");
+            debug_assert!(slot.is_none(), "a callback has already been registered");
             *slot = Some(callback);
         }
     }

--- a/crates/libs/util/src/tokio/mod.rs
+++ b/crates/libs/util/src/tokio/mod.rs
@@ -154,7 +154,7 @@ impl CancelToken for TokioCancelToken {
             drop(slot);
             callback();
         } else {
-            assert!(slot.is_none(), "a callback has already been registered");
+            debug_assert!(slot.is_none(), "a callback has already been registered");
             *slot = Some(callback);
         }
     }

--- a/crates/libs/util/src/tokio/tests.rs
+++ b/crates/libs/util/src/tokio/tests.rs
@@ -771,22 +771,28 @@ mod cancel_token_tests {
         test_circular_cancel::<TokioCancelToken>();
     }
 
-    // --- double on_cancel panics ---
+    // --- double on_cancel panics (debug builds only) ---
 
     fn test_on_cancel_twice_panics<T: CancelToken + Clone + Default>() {
         let parent = T::default();
         parent.on_cancel(Box::new(|| {}));
-        parent.on_cancel(Box::new(|| {})); // should panic
+        parent.on_cancel(Box::new(|| {})); // should panic in debug builds
     }
 
     #[test]
-    #[should_panic(expected = "a callback has already been registered")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "a callback has already been registered")
+    )]
     fn simple_on_cancel_twice_panics() {
         test_on_cancel_twice_panics::<SimpleCancelToken>();
     }
 
     #[test]
-    #[should_panic(expected = "a callback has already been registered")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "a callback has already been registered")
+    )]
     fn tokio_on_cancel_twice_panics() {
         test_on_cancel_twice_panics::<TokioCancelToken>();
     }


### PR DESCRIPTION
User apps may use tokio_util::CancellationToken and mssf-core BoxedCancelToken is hard to link to it. In practice this difference forces the user to invent some logic to propagate the BoxedCancelToken signal to the tokio::CancellationToken using a backgound task.
This PR adds to the BoxedCancelToken to be able to inject an on_cancel callback for idiomatically propagate cancellation.
User can call tokio CancellationToken inside the callback.