### PR TITLE
[onebox] Update linux onebox to use sf 11.4

### DIFF
--- a/.devcontainer/azl3/Dockerfile
+++ b/.devcontainer/azl3/Dockerfile
@@ -10,7 +10,7 @@ RUN tdnf install --noplugins --skipsignature -y \
 # install sf
 RUN mkdir -p /var/opt/microsoft/servicefabric/ && echo "Accepted" | tee /var/opt/microsoft/servicefabric/accepted-eula-ga
 
-ENV SF_VERSION=11.2.298.5
+ENV SF_VERSION=11.4.211.5
 RUN wget https://download.microsoft.com/download/3/1/F/31F3FEEB-F073-4E27-A98B-8E691FF74F40/ServiceFabric.AL.${SF_VERSION}.rpm
 RUN tdnf install -y ./ServiceFabric.AL.${SF_VERSION}.rpm
 RUN rm ServiceFabric.AL.${SF_VERSION}.rpm

--- a/.devcontainer/u22/Dockerfile
+++ b/.devcontainer/u22/Dockerfile
@@ -31,7 +31,7 @@ RUN echo "servicefabric servicefabric/accepted-eula-ga select true" | debconf-se
   && echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true" | debconf-set-selections
 # RUN apt-get install -y servicefabricsdkcommon
 
-ENV SF_VERSION=11.1.208.4
+ENV SF_VERSION=11.4.205.4
 RUN wget https://download.microsoft.com/download/3/1/F/31F3FEEB-F073-4E27-A98B-8E691FF74F40/ServiceFabric.U22.${SF_VERSION}.deb
 RUN apt-get install -y ./ServiceFabric.U22.${SF_VERSION}.deb
 RUN rm ServiceFabric.U22.${SF_VERSION}.deb


### PR DESCRIPTION
This new version should have fixed the FabricGateway crash dumps problem.