### PR TITLE
Use mssf-core min supported SF version 10.1

### DIFF
--- a/crates/libs/core/src/client/mod.rs
+++ b/crates/libs/core/src/client/mod.rs
@@ -11,7 +11,7 @@ use connection::{ClientConnectionEventHandlerBridge, LambdaClientConnectionNotif
 use health_client::HealthClient;
 use mssf_com::FabricClient::{
     IFabricClientConnectionEventHandler, IFabricClientSettings2, IFabricHealthClient4,
-    IFabricPropertyManagementClient2, IFabricQueryClient10, IFabricServiceManagementClient6,
+    IFabricPropertyManagementClient2, IFabricQueryClient13, IFabricServiceManagementClient8,
     IFabricServiceNotificationEventHandler,
 };
 use notification::{
@@ -304,9 +304,9 @@ impl FabricClient {
         let com_property_client = com.clone();
         let com_service_client = com
             .clone()
-            .cast::<IFabricServiceManagementClient6>()
+            .cast::<IFabricServiceManagementClient8>()
             .unwrap();
-        let com_query_client = com.clone().cast::<IFabricQueryClient10>().unwrap();
+        let com_query_client = com.clone().cast::<IFabricQueryClient13>().unwrap();
         let com_health_client = com.clone().cast::<IFabricHealthClient4>().unwrap();
         Self {
             property_client: PropertyManagementClient::from(com_property_client),

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -9,7 +9,7 @@ use mssf_com::{
         IFabricGetApplicationListResult2, IFabricGetDeployedServiceReplicaDetailResult,
         IFabricGetNodeListResult2, IFabricGetPartitionListResult2,
         IFabricGetPartitionLoadInformationResult, IFabricGetReplicaListResult2,
-        IFabricQueryClient10,
+        IFabricQueryClient13,
     },
     FabricTypes::{
         FABRIC_APPLICATION_QUERY_DESCRIPTION,
@@ -35,7 +35,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct QueryClient {
-    com: IFabricQueryClient10,
+    com: IFabricQueryClient13,
 }
 
 // Internal implementation block
@@ -165,13 +165,13 @@ impl QueryClient {
     }
 }
 
-impl From<IFabricQueryClient10> for QueryClient {
-    fn from(com: IFabricQueryClient10) -> Self {
+impl From<IFabricQueryClient13> for QueryClient {
+    fn from(com: IFabricQueryClient13) -> Self {
         Self { com }
     }
 }
 
-impl From<QueryClient> for IFabricQueryClient10 {
+impl From<QueryClient> for IFabricQueryClient13 {
     fn from(value: QueryClient) -> Self {
         value.com
     }

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -7,7 +7,7 @@ use std::{ffi::c_void, time::Duration};
 
 use crate::{PCWSTR, WString, runtime::executor::BoxedCancelToken, types::Uri};
 use mssf_com::{
-    FabricClient::{IFabricResolvedServicePartitionResult, IFabricServiceManagementClient6},
+    FabricClient::{IFabricResolvedServicePartitionResult, IFabricServiceManagementClient8},
     FabricTypes::{
         FABRIC_PARTITION_KEY_TYPE, FABRIC_PARTITION_KEY_TYPE_INT64,
         FABRIC_PARTITION_KEY_TYPE_INVALID, FABRIC_PARTITION_KEY_TYPE_NONE,
@@ -33,11 +33,11 @@ use crate::types::{
 // Service Management Client
 #[derive(Debug, Clone)]
 pub struct ServiceManagementClient {
-    com: IFabricServiceManagementClient6,
+    com: IFabricServiceManagementClient8,
 }
 
 impl ServiceManagementClient {
-    pub fn get_com(&self) -> IFabricServiceManagementClient6 {
+    pub fn get_com(&self) -> IFabricServiceManagementClient8 {
         self.com.clone()
     }
 }
@@ -196,13 +196,13 @@ impl ServiceManagementClient {
     }
 }
 
-impl From<IFabricServiceManagementClient6> for ServiceManagementClient {
-    fn from(com: IFabricServiceManagementClient6) -> Self {
+impl From<IFabricServiceManagementClient8> for ServiceManagementClient {
+    fn from(com: IFabricServiceManagementClient8) -> Self {
         Self { com }
     }
 }
 
-impl From<ServiceManagementClient> for IFabricServiceManagementClient6 {
+impl From<ServiceManagementClient> for IFabricServiceManagementClient8 {
     fn from(value: ServiceManagementClient) -> Self {
         value.com
     }

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -16,6 +16,10 @@
 //! * ** Tokio **  -
 //!   A lot of the sophoisticated functionality in this crate requires Tokio.
 //!   However, even without tokio, some of the higher level wrappers over COM types have utility.
+//!
+//! # SF COM API Versions
+//! The minimum supported SF version for mssf is 10.1. mssf can be used on newer versions of SF,
+//! but some APIs are not available.
 
 // lib that contains all common extensions for the raw fabric apis.
 

--- a/crates/libs/core/src/runtime/config.rs
+++ b/crates/libs/core/src/runtime/config.rs
@@ -5,16 +5,17 @@
 
 use crate::{WString, error::ErrorCode, strings::StringResult};
 use mssf_com::{
-    FabricRuntime::IFabricConfigurationPackage,
+    FabricRuntime::{IFabricConfigurationPackage, IFabricConfigurationPackage2},
     FabricTypes::{
         FABRIC_CONFIGURATION_PARAMETER, FABRIC_CONFIGURATION_PARAMETER_EX1,
         FABRIC_CONFIGURATION_SECTION,
     },
 };
+use windows_core::Interface;
 
 #[derive(Debug, Clone)]
 pub struct ConfigurationPackage {
-    com: IFabricConfigurationPackage,
+    com: IFabricConfigurationPackage2,
 }
 
 pub struct ConfigurationPackageDesc {
@@ -28,13 +29,20 @@ pub struct ConfigurationSettings {
     pub sections: Vec<ConfigurationSection>,
 }
 
-impl From<IFabricConfigurationPackage> for ConfigurationPackage {
-    fn from(com: IFabricConfigurationPackage) -> Self {
+impl From<IFabricConfigurationPackage2> for ConfigurationPackage {
+    fn from(com: IFabricConfigurationPackage2) -> Self {
         Self { com }
     }
 }
 
-impl From<ConfigurationPackage> for IFabricConfigurationPackage {
+impl From<IFabricConfigurationPackage> for ConfigurationPackage {
+    fn from(value: IFabricConfigurationPackage) -> Self {
+        let com = value.cast::<IFabricConfigurationPackage2>().unwrap();
+        Self::from(com)
+    }
+}
+
+impl From<ConfigurationPackage> for IFabricConfigurationPackage2 {
     fn from(value: ConfigurationPackage) -> Self {
         value.com
     }

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -6,7 +6,7 @@
 use crate::Interface;
 
 use mssf_com::FabricCommon::{IFabricAsyncOperationCallback, IFabricAsyncOperationContext};
-use mssf_com::FabricRuntime::IFabricRuntime;
+use mssf_com::FabricRuntime::IFabricRuntime2;
 
 pub use self::runtime_wrapper::Runtime;
 
@@ -46,9 +46,9 @@ mod activation_context;
 pub use activation_context::{CodePackageActivationContext, CodePackageInfo};
 
 // creates fabric runtime
-pub fn create_com_runtime() -> crate::Result<IFabricRuntime> {
+pub fn create_com_runtime() -> crate::Result<IFabricRuntime2> {
     crate::API_TABLE
-        .fabric_create_runtime()
+        .fabric_create_runtime::<IFabricRuntime2>()
         .map_err(crate::Error::from)
 }
 

--- a/crates/libs/core/src/runtime/runtime_wrapper.rs
+++ b/crates/libs/core/src/runtime/runtime_wrapper.rs
@@ -1,7 +1,7 @@
 use crate::WString;
 /// safe wrapping for runtime
 use mssf_com::FabricRuntime::{
-    IFabricRuntime, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory,
+    IFabricRuntime2, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory,
 };
 
 use super::{
@@ -13,7 +13,7 @@ pub struct Runtime<E>
 where
     E: Executor,
 {
-    com_impl: IFabricRuntime,
+    com_impl: IFabricRuntime2,
     rt: E,
 }
 

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -10,8 +10,8 @@ use std::{ffi::c_void, sync::Arc};
 
 use crate::{Interface, WString, runtime::executor::BoxedCancelToken, strings::StringResult};
 use mssf_com::FabricRuntime::{
-    IFabricPrimaryReplicator, IFabricReplicator, IFabricReplicatorCatchupSpecificQuorum,
-    IFabricStatefulServicePartition3, IFabricStatefulServiceReplica,
+    IFabricKeyValueStoreReplica8, IFabricPrimaryReplicator, IFabricReplicator,
+    IFabricReplicatorCatchupSpecificQuorum, IFabricStatefulServicePartition3,
 };
 
 use crate::{
@@ -27,11 +27,11 @@ use super::{IPrimaryReplicator, IReplicator, IStatefulServiceReplica};
 use crate::types::{Epoch, OpenMode, ReplicaInformation, ReplicaSetConfig, ReplicaSetQuorumMode};
 
 pub struct StatefulServiceReplicaProxy {
-    com_impl: IFabricStatefulServiceReplica,
+    com_impl: IFabricKeyValueStoreReplica8,
 }
 
 impl StatefulServiceReplicaProxy {
-    pub fn new(com_impl: IFabricStatefulServiceReplica) -> StatefulServiceReplicaProxy {
+    pub fn new(com_impl: IFabricKeyValueStoreReplica8) -> StatefulServiceReplicaProxy {
         StatefulServiceReplicaProxy { com_impl }
     }
 }

--- a/crates/libs/core/src/runtime/store.rs
+++ b/crates/libs/core/src/runtime/store.rs
@@ -8,7 +8,7 @@ use std::ffi::c_void;
 use crate::{PCWSTR, WString};
 use mssf_com::{
     FabricRuntime::{
-        IFabricKeyValueStoreReplica2, IFabricStoreEventHandler, IFabricStoreEventHandler_Impl,
+        IFabricKeyValueStoreReplica8, IFabricStoreEventHandler, IFabricStoreEventHandler_Impl,
     },
     FabricTypes::{FABRIC_ESE_LOCAL_STORE_SETTINGS, FABRIC_LOCAL_STORE_KIND},
 };
@@ -35,7 +35,7 @@ pub fn create_com_key_value_store_replica(
     localstorekind: LocalStoreKind,
     localstoresettings: Option<&EseLocalStoreSettings>,
     storeeventhandler: &IFabricStoreEventHandler,
-) -> crate::Result<IFabricKeyValueStoreReplica2> {
+) -> crate::Result<IFabricKeyValueStoreReplica8> {
     let kind: FABRIC_LOCAL_STORE_KIND = localstorekind.into();
     let local_settings: Option<FABRIC_ESE_LOCAL_STORE_SETTINGS> =
         localstoresettings.map(|x| x.get_raw());
@@ -45,7 +45,7 @@ pub fn create_com_key_value_store_replica(
         None => std::ptr::null(),
     };
     crate::API_TABLE
-        .fabric_create_key_value_store_replica::<IFabricKeyValueStoreReplica2>(
+        .fabric_create_key_value_store_replica::<IFabricKeyValueStoreReplica8>(
             PCWSTR::from_raw(storename.as_ptr()),
             partitionid,
             replicaid,

--- a/crates/libs/core/src/runtime/store_proxy.rs
+++ b/crates/libs/core/src/runtime/store_proxy.rs
@@ -6,7 +6,7 @@
 use crate::{PCWSTR, runtime::executor::BoxedCancelToken};
 use mssf_com::{
     FabricRuntime::{
-        IFabricKeyValueStoreItemResult, IFabricKeyValueStoreReplica2, IFabricTransaction,
+        IFabricKeyValueStoreItemResult, IFabricKeyValueStoreReplica8, IFabricTransaction,
     },
     FabricTypes::{FABRIC_KEY_VALUE_STORE_ITEM, FABRIC_KEY_VALUE_STORE_ITEM_METADATA},
 };
@@ -18,7 +18,7 @@ use crate::types::TransactionIsolationLevel;
 // wrapp for kv store
 #[derive(Clone)]
 pub struct KVStoreProxy {
-    com_impl: IFabricKeyValueStoreReplica2,
+    com_impl: IFabricKeyValueStoreReplica8,
 }
 
 pub struct TransactionProxy {
@@ -51,7 +51,7 @@ impl KVStoreItemProxy {
 }
 
 impl KVStoreProxy {
-    pub fn new(com_impl: IFabricKeyValueStoreReplica2) -> KVStoreProxy {
+    pub fn new(com_impl: IFabricKeyValueStoreReplica8) -> KVStoreProxy {
         KVStoreProxy { com_impl }
     }
 

--- a/crates/samples/kvstore/src/kvstore.rs
+++ b/crates/samples/kvstore/src/kvstore.rs
@@ -4,9 +4,7 @@ use std::{
 };
 
 use mssf_com::{
-    FabricRuntime::{
-        IFabricKeyValueStoreReplica2, IFabricStatefulServiceReplica, IFabricStoreEventHandler,
-    },
+    FabricRuntime::{IFabricKeyValueStoreReplica8, IFabricStoreEventHandler},
     FabricTypes::FABRIC_REPLICATOR_ADDRESS,
 };
 use mssf_core::{
@@ -27,7 +25,6 @@ use tokio::{
     sync::oneshot::{self, Sender},
 };
 use tracing::info;
-use windows_core::Interface;
 
 pub struct Factory {
     replication_port: u32,
@@ -87,7 +84,7 @@ impl IStatefulServiceFactory for Factory {
             None,
             &handler,
         )?;
-        let kv_replica: IFabricStatefulServiceReplica = kv.clone().cast().unwrap();
+        let kv_replica: IFabricKeyValueStoreReplica8 = kv.clone();
         let proxy = StatefulServiceReplicaProxy::new(kv_replica);
 
         let svc = Service::new(kv, self.rt.clone());
@@ -116,7 +113,7 @@ pub struct Service {
 }
 
 impl Service {
-    pub fn new(com: IFabricKeyValueStoreReplica2, rt: TokioExecutor) -> Service {
+    pub fn new(com: IFabricKeyValueStoreReplica8, rt: TokioExecutor) -> Service {
         Service {
             kvproxy: KVStoreProxy::new(com),
             rt,


### PR DESCRIPTION
Update com objects versions that are present in 10.1.
Github action ci windows runner has 10.1 installed, so it validates this change does not break anything.
#255 