### PR TITLE
[FabricClient] Use BoxPool for update service api

### DIFF
--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -356,8 +356,8 @@ impl ServiceManagementClient {
         cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<()> {
         {
-            let desc_raw = desc.build_raw();
-            let ffi_raw = desc_raw.as_ffi();
+            let mut pool = BoxPool::new();
+            let ffi_raw = desc.get_raw_with_pool(&mut pool);
             self.update_service_internal(
                 name.as_raw(),
                 &ffi_raw,


### PR DESCRIPTION
Simplifies the FabricClient update_service ffi implementation using BoxPool, following the BoxPool user guide.