### PR TITLE
[FabricClient] Simplify get_node_health ffi

### DIFF
--- a/crates/libs/core/src/client/health_client.rs
+++ b/crates/libs/core/src/client/health_client.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 use mssf_com::{
     FabricClient::{IFabricHealthClient4, IFabricNodeHealthResult},
     FabricTypes::{
-        FABRIC_APPLICATION_HEALTH_REPORT, FABRIC_CLUSTER_HEALTH_POLICY,
-        FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION, FABRIC_CLUSTER_HEALTH_REPORT,
-        FABRIC_DEPLOYED_APPLICATION_HEALTH_REPORT, FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_REPORT,
-        FABRIC_HEALTH_INFORMATION, FABRIC_HEALTH_REPORT, FABRIC_HEALTH_REPORT_KIND_APPLICATION,
+        FABRIC_APPLICATION_HEALTH_REPORT, FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION,
+        FABRIC_CLUSTER_HEALTH_REPORT, FABRIC_DEPLOYED_APPLICATION_HEALTH_REPORT,
+        FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_REPORT, FABRIC_HEALTH_INFORMATION,
+        FABRIC_HEALTH_REPORT, FABRIC_HEALTH_REPORT_KIND_APPLICATION,
         FABRIC_HEALTH_REPORT_KIND_CLUSTER, FABRIC_HEALTH_REPORT_KIND_DEPLOYED_APPLICATION,
         FABRIC_HEALTH_REPORT_KIND_DEPLOYED_SERVICE_PACKAGE, FABRIC_HEALTH_REPORT_KIND_INVALID,
         FABRIC_HEALTH_REPORT_KIND_NODE, FABRIC_HEALTH_REPORT_KIND_PARTITION,
@@ -316,31 +316,8 @@ impl HealthClient {
         cancellation_token: Option<BoxedCancelToken>,
     ) -> crate::Result<NodeHealthResult> {
         let com = {
-            let health_policy_raw =
-                desc.health_policy
-                    .as_ref()
-                    .map(|h| FABRIC_CLUSTER_HEALTH_POLICY {
-                        ConsiderWarningAsError: h.consider_warning_as_error,
-                        MaxPercentUnhealthyNodes: h.max_percent_unhealthy_nodes,
-                        MaxPercentUnhealthyApplications: h.max_percent_unhealthy_applications,
-                        Reserved: std::ptr::null_mut(),
-                    });
-            let event_filter_raw = desc.events_filter.as_ref().map(|f| {
-                mssf_com::FabricTypes::FABRIC_HEALTH_EVENTS_FILTER {
-                    HealthStateFilter: f.health_state_filter.bits() as u32,
-                    Reserved: std::ptr::null_mut(),
-                }
-            });
-            let desc_raw = mssf_com::FabricTypes::FABRIC_NODE_HEALTH_QUERY_DESCRIPTION {
-                NodeName: desc.node_name.as_pcwstr(),
-                HealthPolicy: health_policy_raw
-                    .as_ref()
-                    .map_or(std::ptr::null_mut(), |h| h as *const _ as *mut _),
-                EventsFilter: event_filter_raw
-                    .as_ref()
-                    .map_or(std::ptr::null_mut(), |f| f as *const _ as *mut _),
-                Reserved: std::ptr::null_mut(),
-            };
+            let mut pool = BoxPool::new();
+            let desc_raw = desc.get_raw_with_pool(&mut pool);
             self.get_node_health_internal(&desc_raw, timeout.as_millis() as u32, cancellation_token)
         }
         .await??;

--- a/crates/libs/core/src/types/client/health.rs
+++ b/crates/libs/core/src/types/client/health.rs
@@ -8,9 +8,9 @@ use mssf_com::FabricTypes::{
     FABRIC_APPLICATION_HEALTH_POLICY, FABRIC_APPLICATION_HEALTH_POLICY_MAP,
     FABRIC_APPLICATION_HEALTH_POLICY_MAP_ITEM, FABRIC_APPLICATION_HEALTH_STATES_FILTER,
     FABRIC_CLUSTER_HEALTH, FABRIC_CLUSTER_HEALTH_POLICY, FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION,
-    FABRIC_HEALTH_EVENT, FABRIC_HEALTH_EVENTS_FILTER, FABRIC_NODE_HEALTH_STATES_FILTER,
-    FABRIC_SERVICE_TYPE_HEALTH_POLICY, FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP,
-    FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP_ITEM,
+    FABRIC_HEALTH_EVENT, FABRIC_HEALTH_EVENTS_FILTER, FABRIC_NODE_HEALTH_QUERY_DESCRIPTION,
+    FABRIC_NODE_HEALTH_STATES_FILTER, FABRIC_SERVICE_TYPE_HEALTH_POLICY,
+    FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP, FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP_ITEM,
 };
 use windows_core::Win32::Foundation::FILETIME;
 
@@ -127,6 +127,17 @@ pub struct ClusterHealthPolicy {
     pub max_percent_unhealthy_applications: u8,
 }
 
+impl GetRaw<FABRIC_CLUSTER_HEALTH_POLICY> for ClusterHealthPolicy {
+    fn get_raw(&self) -> FABRIC_CLUSTER_HEALTH_POLICY {
+        FABRIC_CLUSTER_HEALTH_POLICY {
+            ConsiderWarningAsError: self.consider_warning_as_error,
+            MaxPercentUnhealthyNodes: self.max_percent_unhealthy_nodes,
+            MaxPercentUnhealthyApplications: self.max_percent_unhealthy_applications,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
 /// FABRIC_HEALTH_EVENTS_FILTER
 #[derive(Debug, Clone)]
 pub struct HealthEventsFilter {
@@ -161,6 +172,25 @@ pub struct NodeHealthQueryDescription {
     pub node_name: WString,
     pub health_policy: Option<ClusterHealthPolicy>,
     pub events_filter: Option<HealthEventsFilter>,
+}
+
+impl GetRawWithBoxPool<FABRIC_NODE_HEALTH_QUERY_DESCRIPTION> for NodeHealthQueryDescription {
+    fn get_raw_with_pool(&self, pool: &mut BoxPool) -> FABRIC_NODE_HEALTH_QUERY_DESCRIPTION {
+        FABRIC_NODE_HEALTH_QUERY_DESCRIPTION {
+            NodeName: self.node_name.as_pcwstr(),
+            HealthPolicy: self
+                .health_policy
+                .as_ref()
+                .map(|h| pool.push(Box::new(h.get_raw())))
+                .unwrap_or(std::ptr::null()),
+            EventsFilter: self
+                .events_filter
+                .as_ref()
+                .map(|f| pool.push(Box::new(f.get_raw())))
+                .unwrap_or(std::ptr::null()),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
 }
 
 /// IFabricNodeHealthResult and FABRIC_NODE_HEALTH
@@ -347,15 +377,10 @@ pub struct ClusterHealthQueryDescription {
 
 impl GetRawWithBoxPool<FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION> for ClusterHealthQueryDescription {
     fn get_raw_with_pool(&self, pool: &mut BoxPool) -> FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION {
-        let health_policy = self.health_policy.as_ref().map(|policy| {
-            let raw = Box::new(FABRIC_CLUSTER_HEALTH_POLICY {
-                ConsiderWarningAsError: policy.consider_warning_as_error,
-                MaxPercentUnhealthyNodes: policy.max_percent_unhealthy_nodes,
-                MaxPercentUnhealthyApplications: policy.max_percent_unhealthy_applications,
-                Reserved: std::ptr::null_mut(),
-            });
-            pool.push(raw)
-        });
+        let health_policy = self
+            .health_policy
+            .as_ref()
+            .map(|policy| pool.push(Box::new(policy.get_raw())));
         let application_health_policy_map =
             self.application_health_policy_map.as_ref().map(|policies| {
                 let mut items = Vec::new();


### PR DESCRIPTION
Change get_node_health ffi code to use BoxPool pattern. Reduced manual ffi code.
mssf-util monitoring health tests covers this code path.