### PR TITLE
Use spawn_blocking for IFabricAsyncOperationCallback::Invoke

### DIFF
--- a/crates/libs/core/src/runtime/executor.rs
+++ b/crates/libs/core/src/runtime/executor.rs
@@ -10,16 +10,19 @@ use std::{fmt::Debug, future::Future, pin::Pin};
 pub trait Executor: Clone + Sync + Send + 'static {
     // Required functions
 
-    /// spawns the task to run in background, and returns a join handle
-    /// where the future's result can be awaited.
-    /// If the future panics, the join handle should return an error code.
+    /// spawns the task to run in background.
     /// This is primarily used by mssf Bridge to execute user app async callbacks/notifications.
-    /// User app impl future may panic, and mssf propagates panic as an error in JoinHandle
-    /// to SF.
     fn spawn<F>(&self, future: F)
     where
         F: Future + Send + 'static,
         F::Output: Send;
+
+    /// Runs the provided function on an executor dedicated to blocking
+    /// operations.
+    fn spawn_blocking<F, R>(&self, func: F)
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static;
 }
 
 /// Runtime independent sleep trait.

--- a/crates/libs/core/src/sync/bridge_context.rs
+++ b/crates/libs/core/src/sync/bridge_context.rs
@@ -106,7 +106,12 @@ where
             let self_impl: &BridgeContext<T> = unsafe { self_cp.as_impl() };
             self_impl.set_content(task_res);
             let cb = unsafe { self_cp.Callback().unwrap() };
-            unsafe { cb.Invoke(&self_cp) };
+
+            // We move the callback invocation off of the tokio I/O thread as they take locks
+            // and may block.
+            rt_cp.spawn_blocking(move || {
+                unsafe { cb.Invoke(&self_cp) };
+            })
         };
         /// Propagate the span so that the executor has the right trace.
         /// The trace would likely have BeginXXX as the function where spawn()

--- a/crates/libs/util/src/tokio/mod.rs
+++ b/crates/libs/util/src/tokio/mod.rs
@@ -68,6 +68,14 @@ impl Executor for TokioExecutor {
     {
         self.rt.spawn(future);
     }
+
+    fn spawn_blocking<F, R>(&self, func: F)
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.rt.spawn_blocking(func);
+    }
 }
 
 /// Sleep timer implementation for tokio


### PR DESCRIPTION
IFabricAsyncOperationCallback::Invoke can take locks and they are not always released quickly. Therefore, we do not want to invoke it directly from tokio I/O threads. spawn_blocking is used to move the callback invocation to a tokio thread_pool thread so that I/O threads (a scarce resource) remain available.