### PR TITLE
[util] Only support multi-thread tokio runtime

### DIFF
--- a/crates/libs/util/src/tokio/mod.rs
+++ b/crates/libs/util/src/tokio/mod.rs
@@ -25,6 +25,11 @@ pub struct TokioExecutor {
 
 impl TokioExecutor {
     pub fn new(rt: Handle) -> TokioExecutor {
+        assert_eq!(
+            rt.runtime_flavor(),
+            tokio::runtime::RuntimeFlavor::MultiThread,
+            "TokioExecutor requires a multi-threaded tokio runtime"
+        );
         TokioExecutor { rt }
     }
 

--- a/crates/libs/util/src/tokio/tests.rs
+++ b/crates/libs/util/src/tokio/tests.rs
@@ -278,7 +278,7 @@ mod proxy_test {
     /// Constructs various test trait objects of different
     /// Bridge and Proxy nested wrapping and run cancellation tests
     /// for each of them.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_cancel() {
         let h = tokio::runtime::Handle::current();
         let expected_data1 = "mydata1";
@@ -375,7 +375,7 @@ mod proxy_test {
     const TEST_DATA: &str = "data";
     /// Very simple benchmark to check the bridge layer performance.
     /// Adding a bridge layer should not introduce much perf degradation.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn small_bench_test() {
         // Run get data function for IMyObj with different layers of wrapping.
         // All wrappings are run in parallel to reduce test run time.
@@ -437,7 +437,7 @@ mod proxy_test {
         count
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_user_code_panic() {
         let h = tokio::runtime::Handle::current();
         let expected_data1 = "mydata1";


### PR DESCRIPTION
The executor uses block_in_place and spawn_blocking, which requires multi-thread runtime.