### PR TITLE
[test] Fix test request succeeded before cancel

### DIFF
--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -68,8 +68,10 @@ async fn test_fabric_client() {
         let token = SimpleCancelToken::new_boxed();
         let list = qc.get_node_list(&desc, timeout, Some(token.clone()));
         token.cancel();
-        let err = list.await.expect_err("request should be cancelled");
-        assert_eq!(err, ErrorCode::E_ABORT.into());
+        // It is possible that the request is already success before cancel.
+        if let Err(err) = list.await {
+            assert_eq!(err, ErrorCode::E_ABORT.into());
+        }
     }
 
     let smgr = c.get_service_manager();


### PR DESCRIPTION
The request in test can succeed before cancel is issued, making the test flakey:
https://github.com/Azure/service-fabric-rs/actions/runs/24399092430/job/71265359653
It has been observed a few times in the past.