### PR TITLE
Add Rust cache action to CI jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,8 @@ jobs:
     - name: Remove rust toolchain file to avoid conflict
       run: rm rust-toolchain.toml
 
+    - uses: Swatinem/rust-cache@v2
+
     - name: Run cargo check
       run: cargo +${{ matrix.rust-version }} check --all-targets
 
@@ -125,6 +127,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
           components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install cmake
         uses: lukka/get-cmake@latest
@@ -265,6 +269,8 @@ jobs:
       with:
         toolchain: ${{ needs.setup.outputs.rust-max-version }}
         components: rustfmt, clippy
+
+    - uses: Swatinem/rust-cache@v2
 
     - name: Verify rust-toolchain.toml matches expected version
       shell: bash


### PR DESCRIPTION
Adds `Swatinem/rust-cache@v2` to the `build`, `build-azl3`, and `generate` jobs to cache Cargo dependencies and build artifacts between runs.

### What this does
- Caches `~/.cargo` (registry, cache, git deps) and `./target` (dependency build artifacts)
- Cache is automatically keyed by OS, `rustc` version/host, `Cargo.lock`/`Cargo.toml` hashes, and job ID
- PR branches can restore caches from `main` on cold start

### Jobs updated
| Job | Runner |
|-----|--------|
| `build` | `windows-latest` |
| `build-azl3` | `ubuntu-latest` (Azure Linux 3 container) |
| `generate` | `windows-latest` |

### Jobs not updated
- `build-devcontainer` — builds inside a devcontainer, so host-level caching wouldn't apply to the container's build artifacts