### PR TITLE
[test] Add gRPC-driven test control driver to the reflection sample

### DIFF
--- a/.github/skills/onebox-deploy-test/SKILL.md
+++ b/.github/skills/onebox-deploy-test/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: onebox-deploy-test
+description: 'Build the Rust SF samples, deploy them to the local Linux onebox cluster, and run the integration test suite. Use when the user asks to "run the integration tests", "deploy to onebox and test", "redeploy and re-run", "verify on a real cluster", "bring up onebox", or after non-trivial changes to crates/samples/* or crates/libs/* that need end-to-end validation. Covers cmake build, sfctl provisioning, cluster health waits, and `cargo test --all -- --nocapture`.'
+---
+
+# Onebox Deploy & Test (Linux)
+
+End-to-end loop for validating changes against a real Service Fabric onebox
+cluster running in the devcontainer. Mirrors what CI does in
+[`.github/workflows/build.yaml`](../../workflows/build.yaml) under the
+`build-devcontainer` job (`u22` and `azl3` matrix entries).
+
+## When to Use
+
+- The user wants to validate a change end-to-end on a real cluster, not just `cargo test --lib`.
+- Trigger phrases: "deploy and test", "run the integration tests", "redeploy onebox", "bring up the cluster and run", "full e2e", "what CI runs".
+- Changes touched any of: `crates/samples/echomain/`, `crates/samples/echomain-stateful/`, `crates/samples/reflection/`, `crates/samples/kvstore/`, `crates/libs/com/`, `crates/libs/core/`, `crates/libs/util/`, `crates/libs/pal/`, the `proto/` directories, `manifests/`, or [build.rs](../../../crates/samples/reflection/build.rs).
+- A previous test run failed and you want to redeploy clean.
+
+## When NOT to Use
+
+- Pure unit-test runs (`cargo test --lib` is enough).
+- Doc-only changes.
+- Refactors that don't touch SF-facing code paths.
+- The user is on Windows — this skill assumes the Linux devcontainer setup where the `onebox` and `repo-u22` containers run side by side. For Windows, defer to `.\onebox\windows\StartOnebox.ps1` and `.\scripts\reflection_ctl.ps1`.
+
+## Preconditions
+
+Run a quick check before doing anything else; if any fails, stop and report:
+
+1. **Inside the devcontainer.** Confirm with `cat /etc/os-release | head -2` (expect `Ubuntu` or `Azure Linux`) and `command -v sfctl` (must succeed). The host machine doesn't have SF or `sfctl` installed.
+2. **Onebox sibling container reachable.** `sfctl cluster select` should connect to the default `http://onebox:19080` (the sibling container's hostname). If it errors with `connection refused`, the onebox container hasn't finished starting — wait 10 s and retry up to 3 times.
+3. **Working tree compiles.** `cargo check -p samples_reflection -p samples_echomain -p samples_echomain_stateful` — fail fast if there's a build error before invoking the slow cmake path.
+
+## Procedure
+
+Run the steps below sequentially. Stop on the first failure unless the step is marked `(best-effort)`. All commands are run from the repo root (`/home/vscode/repo`).
+
+### Step 1 — Build everything via cmake
+
+`cmake` drives `cargo build` *and* packages every sample into `build/sf_apps/<app-name>/` (this is what `sfctl application upload` consumes).
+
+```bash
+# First-time only: configure the build directory.
+[ -f build/CMakeCache.txt ] || cmake . -DCMAKE_BUILD_TYPE=Debug -B build
+
+# Always: rebuild rust binaries + repackage SF apps.
+cmake --build build --config Debug
+```
+
+Expected outputs after success:
+- `build/sf_apps/samples_reflection/` (with `ApplicationManifest.xml`, `ServicePackage/`, etc.)
+- `build/sf_apps/samples_echomain/`
+- `build/sf_apps/samples_echomain_stateful/`
+- `build/sf_apps/kvstore/` *(Windows only — gated by `if(WIN32)` in the root CMakeLists)*
+
+If any are missing, inspect the cmake log around the failing target — the per-sample `CMakeLists.txt` files (e.g. [crates/samples/reflection/CMakeLists.txt](../../../crates/samples/reflection/CMakeLists.txt)) define what gets packaged.
+
+### Step 2 — Wait for the cluster to be healthy and provision apps
+
+The repo's [scripts/prepare_test_apps.sh](../../../scripts/prepare_test_apps.sh) does the entire wait-and-deploy loop with retries. Use it directly rather than re-implementing the logic:
+
+```bash
+bash ./scripts/prepare_test_apps.sh
+```
+
+This script:
+1. Waits up to ~150 s for `sfctl cluster select` to succeed.
+2. Waits for the cluster's aggregated health state to be `Ok` or `Warning`.
+3. Sleeps 5 s for the ImageStore to stabilise.
+4. Uploads + provisions + creates `EchoApp` (`fabric:/EchoApp`) and `ReflectionApp` (`fabric:/ReflectionApp`) with retries.
+5. Waits for both `EchoAppService` and `ReflectionAppService` to become resolvable.
+
+If the script fails:
+- `application upload` failures usually mean the onebox container is still warming up or the ImageStore isn't ready — retry the script once.
+- `application create` failures with `FABRIC_E_APPLICATION_TYPE_ALREADY_EXISTS` mean a previous run left state behind. Run [Step 4 — Cleanup](#step-4--cleanup-best-effort) first, then retry.
+- `service resolve` failures usually mean a placement constraint can't be satisfied — check the SF Explorer at `http://localhost:19080` (port-forwarded by docker-compose).
+
+### Step 3 — Run tests
+
+The integration tests use `FabricClient::with_connection_strings(["localhost:19000"])` to reach the cluster. Inside the devcontainer this resolves to the `onebox` sibling container via the container runtime's DNS; the existing tests rely on this and don't need any extra wiring.
+
+```bash
+cargo test --all -- --nocapture
+```
+
+Two recipes for narrower runs:
+- Unit tests only (no cluster needed): `cargo test --all --lib -- --nocapture`
+- One sample's integration tests: `cargo test -p samples_reflection -- --nocapture`
+- A specific test name: `cargo test -p samples_reflection test_partition_info -- --nocapture --exact`
+
+If a test fails with `FABRIC_E_APPLICATION_NOT_FOUND` you skipped Step 2; if it fails with `FabricError { code: -2147017735 }` (timeout) the cluster is unhealthy — check `sfctl cluster health` and re-run the prepare step.
+
+### Step 4 — Cleanup (best-effort)
+
+Run after a successful test pass to leave the cluster clean for the next iteration. Errors here are non-fatal.
+
+```bash
+# Per-app deletion. Skip silently if the app isn't registered.
+sfctl application delete --application-id ReflectionApp 2>/dev/null || true
+sfctl application unprovision --application-type-name ReflectionApp --application-type-version 0.0.1 2>/dev/null || true
+sfctl application delete --application-id EchoApp 2>/dev/null || true
+sfctl application unprovision --application-type-name EchoApp --application-type-version 0.0.1 2>/dev/null || true
+```
+
+If state is irretrievably stuck, the onebox container needs to be
+restarted from the host — the devcontainer cannot reach the host's
+docker daemon. Ask the user to restart it from outside the
+devcontainer (e.g., "reopen folder in container" from VS Code, which
+rebuilds the containers; or `docker restart <onebox-container-name>`
+from a host shell). Then re-run from Step 2.
+
+## What CI Does Differently
+
+The CI job ([build-devcontainer](../../workflows/build.yaml)) runs the whole skill in one shot via `devcontainers/ci@v0.3` and adds:
+
+- Disk-space prep (`/usr/local/lib/android` etc. removal).
+- Core-dump capture under `/tmp/artifacts/coredumps/`.
+- Artifact upload of crashed binaries.
+
+For local iteration these are unnecessary. If the user is debugging a crash that only repros in CI, point them at the artifact upload step rather than re-running this skill locally.
+
+## Common Pitfalls
+
+- **`cmake --build` skips a sample after editing only `Cargo.toml`.** Cargo notices the change but cmake's package step caches based on file timestamps. Force re-package with `cmake --build build --config Debug --target build_rust_sample_reflection` (or `force_clean` then full rebuild).
+- **`sfctl: command not found`.** The host doesn't have it; you're outside the devcontainer. Start it via VS Code's "Reopen in Container" or rerun in the right shell.
+- **`http://onebox:19080` unreachable from the repo container.** The onebox container may have crashed. The devcontainer can't reach the host's docker daemon, so ask the user to check container status from a host shell (`docker ps`) and restart it there if needed — there is no auto-restart.
+- **Tests pass locally but fail in CI.** CI runs both `u22` and `azl3` devcontainers; check whether the failure is platform-specific by switching `.devcontainer/<u22|azl3>/devcontainer.json` and reopening the container.

--- a/.github/skills/onebox-deploy-test/SKILL.md
+++ b/.github/skills/onebox-deploy-test/SKILL.md
@@ -1,14 +1,21 @@
 ---
 name: onebox-deploy-test
-description: 'Build the Rust SF samples, deploy them to the local Linux onebox cluster, and run the integration test suite. Use when the user asks to "run the integration tests", "deploy to onebox and test", "redeploy and re-run", "verify on a real cluster", "bring up onebox", or after non-trivial changes to crates/samples/* or crates/libs/* that need end-to-end validation. Covers cmake build, sfctl provisioning, cluster health waits, and `cargo test --all -- --nocapture`.'
+description: 'Build the Rust SF samples, deploy them to a local onebox cluster (Linux devcontainer or Windows host), and run the integration test suite. Use when the user asks to "run the integration tests", "deploy to onebox and test", "redeploy and re-run", "verify on a real cluster", "bring up onebox", or after non-trivial changes to crates/samples/* or crates/libs/* that need end-to-end validation. Covers cmake build, sfctl/PowerShell provisioning, cluster health waits, and `cargo test --all -- --nocapture`.'
 ---
 
-# Onebox Deploy & Test (Linux)
+# Onebox Deploy & Test
 
 End-to-end loop for validating changes against a real Service Fabric onebox
-cluster running in the devcontainer. Mirrors what CI does in
-[`.github/workflows/build.yaml`](../../workflows/build.yaml) under the
-`build-devcontainer` job (`u22` and `azl3` matrix entries).
+cluster. Mirrors what CI does in
+[`.github/workflows/build.yaml`](../../workflows/build.yaml):
+
+- **Linux devcontainer** path → `build-devcontainer` job (`u22` and `azl3` matrix entries).
+- **Windows host** path → `build` job (`runs-on: windows-latest`).
+
+Pick the section that matches the user's environment. Detect with:
+
+- Linux/devcontainer if `cat /etc/os-release` shows Ubuntu/Azure Linux and `command -v sfctl` succeeds → use [Procedure (Linux)](#procedure-linux).
+- Windows if `$env:OS -eq 'Windows_NT'` and `Test-Path 'C:\Program Files\Microsoft Service Fabric'` → use [Procedure (Windows)](#procedure-windows).
 
 ## When to Use
 
@@ -22,19 +29,20 @@ cluster running in the devcontainer. Mirrors what CI does in
 - Pure unit-test runs (`cargo test --lib` is enough).
 - Doc-only changes.
 - Refactors that don't touch SF-facing code paths.
-- The user is on Windows — this skill assumes the Linux devcontainer setup where the `onebox` and `repo-u22` containers run side by side. For Windows, defer to `.\onebox\windows\StartOnebox.ps1` and `.\scripts\reflection_ctl.ps1`.
 
-## Preconditions
+## Procedure (Linux)
+
+Devcontainer setup where the `onebox` and `repo-u22`/`repo-azl3` containers run
+side by side. All commands are run from the repo root (`/home/vscode/repo`).
+Stop on the first failure unless the step is marked `(best-effort)`.
+
+### Preconditions (Linux)
 
 Run a quick check before doing anything else; if any fails, stop and report:
 
 1. **Inside the devcontainer.** Confirm with `cat /etc/os-release | head -2` (expect `Ubuntu` or `Azure Linux`) and `command -v sfctl` (must succeed). The host machine doesn't have SF or `sfctl` installed.
 2. **Onebox sibling container reachable.** `sfctl cluster select` should connect to the default `http://onebox:19080` (the sibling container's hostname). If it errors with `connection refused`, the onebox container hasn't finished starting — wait 10 s and retry up to 3 times.
 3. **Working tree compiles.** `cargo check -p samples_reflection -p samples_echomain -p samples_echomain_stateful` — fail fast if there's a build error before invoking the slow cmake path.
-
-## Procedure
-
-Run the steps below sequentially. Stop on the first failure unless the step is marked `(best-effort)`. All commands are run from the repo root (`/home/vscode/repo`).
 
 ### Step 1 — Build everything via cmake
 
@@ -110,19 +118,175 @@ devcontainer (e.g., "reopen folder in container" from VS Code, which
 rebuilds the containers; or `docker restart <onebox-container-name>`
 from a host shell). Then re-run from Step 2.
 
+## Procedure (Windows)
+
+Windows host setup where Service Fabric runtime + SDK are installed
+locally and apps are provisioned via the `ServiceFabric` PowerShell
+module (not `sfctl`). All commands are run from the repo root in a
+**PowerShell** shell. Stop on the first failure unless the step is
+marked `(best-effort)`.
+
+The CI equivalent is the `build` job in
+[`.github/workflows/build.yaml`](../../workflows/build.yaml)
+(`runs-on: windows-latest`).
+
+### Preconditions (Windows)
+
+1. **Working tree compiles.** `cargo check --all-targets` — fail
+   fast before the slow cmake path. CI also runs `cargo fmt --all -- --check`
+   and `cargo clippy -- -D warnings`; mirror them locally if you
+   want a CI-clean state.
+2. **`protoc` is on `PATH`.** Required by the reflection sample's
+   build script. CI installs it with `taiki-e/install-action@protoc`;
+   locally use `winget install protobuf` or any equivalent.
+3. **`cmake` is on `PATH`** (`cmake --version`). If a Visual
+   Studio install ships cmake (e.g. VS 18 ships
+   `C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe`),
+   prepend that directory to `$env:PATH` once per shell instead of
+   installing a second copy.
+
+> Skip the CI-only `Remove conflict dll paths` step (deletes
+> `C:\Program Files\MySQL\...`) and the `check_sf_installed.ps1` /
+> `check_cluster_online.ps1` smoke checks — they exist to harden
+> the GitHub-hosted runner image and are not needed locally.
+
+> **Per-shell setup, not per-command.** `Import-Module
+> ServiceFabric` and `Connect-ServiceFabricCluster` only need to
+> run **once** per PowerShell session — the module stays loaded
+> and the cluster connection is cached on the runspace. The
+> `*_ctl.ps1` scripts each call `Connect-ServiceFabricCluster`
+> internally, so for ad-hoc inspection (`Get-ServiceFabricApplication`,
+> etc.) just reuse the existing connection. Do **not** repeat
+> `Import-Module` or `Connect-ServiceFabricCluster` between
+> commands in the same shell.
+
+### Step 1 — Build everything via cmake
+
+Same as Linux — `cmake` drives `cargo build` *and* packages every
+sample into `build\sf_apps\<app-name>\`.
+
+```powershell
+# First-time only: configure the build directory.
+if (-not (Test-Path build\CMakeCache.txt)) {
+    cmake . -DCMAKE_BUILD_TYPE=Debug -B build
+}
+
+# Always: rebuild rust binaries + repackage SF apps.
+cmake --build build --config Debug
+```
+
+Expected outputs after success:
+- `build\sf_apps\samples_reflection\`
+- `build\sf_apps\samples_echomain\`
+- `build\sf_apps\samples_echomain_stateful\`
+- `build\sf_apps\kvstore\` *(Windows only — gated by `if(WIN32)` in the root CMakeLists)*
+
+### Step 2 — Bring up the local 5-node cluster
+
+Use [onebox/windows/StartOnebox.ps1](../../../onebox/windows/StartOnebox.ps1).
+The script auto-elevates to Administrator via UAC. `-Auto` skips the
+"existing cluster will be removed" prompt.
+
+```powershell
+Powershell.exe -File .\onebox\windows\StartOnebox.ps1 -Auto
+```
+
+After success: SF Explorer at `http://localhost:19080/Explorer`.
+The script already waits for the cluster to be reachable and the
+naming service to be ready, so a separate readiness wait is not
+required for local runs.
+
+### Step 3 — Provision apps
+
+The Linux `prepare_test_apps.sh` does not apply on Windows. Use the
+per-sample PowerShell controllers, which mirror what CI runs:
+
+```powershell
+# Lightweight smoke test for echomain (adds, resolves, echoes, removes).
+.\tests\echo_script_test.ps1
+
+# Long-lived deployments needed by `cargo test --all`.
+.\scripts\reflection_ctl.ps1       -Action Add
+.\scripts\echomain_ctl.ps1         -Action Add
+# Optional — only needed if your tests touch these apps:
+.\scripts\echomain_stateful_ctl.ps1 -Action Add
+.\scripts\kvstore_ctl.ps1           -Action Add
+```
+
+Each `*_ctl.ps1 -Action Add` does:
+`Connect-ServiceFabricCluster` → `Test-ServiceFabricApplicationPackage`
+→ `Copy-ServiceFabricApplicationPackage` → `Register-ServiceFabricApplicationType`
+→ `New-ServiceFabricApplication`. Image-store path is `MyApplicationV1`
+(or `MyKvStoreApplicationV1` for kvstore), so back-to-back `Add`s of
+two different apps will collide — `Remove` the previous one first or
+they will overwrite each other's image-store entry.
+
+If `New-ServiceFabricApplication` fails with
+`FABRIC_E_APPLICATION_TYPE_ALREADY_EXISTS`, run the matching
+`-Action Remove` then retry.
+
+### Step 4 — Run tests
+
+```powershell
+cargo test --all -- --nocapture
+```
+
+Same narrowing recipes as Linux:
+- Unit tests only: `cargo test --all --lib -- --nocapture`
+- One sample: `cargo test -p samples_reflection -- --nocapture`
+- Specific test: `cargo test -p samples_reflection test_partition_info -- --nocapture --exact`
+
+Tests connect to `localhost:19000` via `FabricClient`.
+
+### Step 5 — Cleanup (best-effort)
+
+Each controller's `-Action Remove` reverses its `Add`:
+
+```powershell
+.\scripts\reflection_ctl.ps1       -Action Remove
+.\scripts\echomain_ctl.ps1         -Action Remove
+.\scripts\echomain_stateful_ctl.ps1 -Action Remove   # if added
+.\scripts\kvstore_ctl.ps1           -Action Remove   # if added
+```
+
+To stop the cluster while preserving data, or to fully tear it down:
+
+```powershell
+Powershell.exe -File .\onebox\windows\StopOnebox.ps1            # stops FabricHostSvc only
+Powershell.exe -File .\onebox\windows\StopOnebox.ps1 -CleanData -Auto   # full removal
+```
+
+A stopped cluster can be restarted with `Start-Service FabricHostSvc`
+or by re-running `StartOnebox.ps1`.
+
 ## What CI Does Differently
 
-The CI job ([build-devcontainer](../../workflows/build.yaml)) runs the whole skill in one shot via `devcontainers/ci@v0.3` and adds:
+### `build-devcontainer` job (Linux)
+
+Runs Steps 1–4 in one shot via `devcontainers/ci@v0.3` and adds:
 
 - Disk-space prep (`/usr/local/lib/android` etc. removal).
 - Core-dump capture under `/tmp/artifacts/coredumps/`.
 - Artifact upload of crashed binaries.
 
-For local iteration these are unnecessary. If the user is debugging a crash that only repros in CI, point them at the artifact upload step rather than re-running this skill locally.
+### `build` job (Windows)
+
+Runs the matrix `(rust-min, rust-max)` × `windows-latest` and adds:
+
+- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` gates before the build.
+- `Remove conflict dll paths` — deletes `C:\Program Files\MySQL\MySQL Server 8.0\bin` because its `libprotobuf.dll` is incompatible with Service Fabric and prevents the runtime from starting on the GitHub-hosted runner image. Not needed on a clean local box.
+- `check_sf_installed.ps1` and `check_cluster_online.ps1` smoke checks — also CI-image hardening.
+
+For local iteration both extra-step blocks are unnecessary. If the
+user is debugging a crash that only repros in CI, point them at the
+artifact upload step rather than re-running this skill locally.
 
 ## Common Pitfalls
 
 - **`cmake --build` skips a sample after editing only `Cargo.toml`.** Cargo notices the change but cmake's package step caches based on file timestamps. Force re-package with `cmake --build build --config Debug --target build_rust_sample_reflection` (or `force_clean` then full rebuild).
-- **`sfctl: command not found`.** The host doesn't have it; you're outside the devcontainer. Start it via VS Code's "Reopen in Container" or rerun in the right shell.
-- **`http://onebox:19080` unreachable from the repo container.** The onebox container may have crashed. The devcontainer can't reach the host's docker daemon, so ask the user to check container status from a host shell (`docker ps`) and restart it there if needed — there is no auto-restart.
-- **Tests pass locally but fail in CI.** CI runs both `u22` and `azl3` devcontainers; check whether the failure is platform-specific by switching `.devcontainer/<u22|azl3>/devcontainer.json` and reopening the container.
+- **(Linux) `sfctl: command not found`.** The host doesn't have it; you're outside the devcontainer. Start it via VS Code's "Reopen in Container" or rerun in the right shell.
+- **(Linux) `http://onebox:19080` unreachable from the repo container.** The onebox container may have crashed. The devcontainer can't reach the host's docker daemon, so ask the user to check container status from a host shell (`docker ps`) and restart it there if needed — there is no auto-restart.
+- **(Windows) `Connect-ServiceFabricCluster` fails immediately after `StartOnebox.ps1`.** Re-run the connect; the SDK script already waits, but a freshly-restarted cluster occasionally needs a few extra seconds for the naming service.
+- **(Windows) `New-ServiceFabricApplication` errors with `image store path already exists`.** Two `*_ctl.ps1` scripts share the `MyApplicationV1` image-store path. Run `-Action Remove` for the previous app before adding the next, or accept that only one of them will be live.
+- **(Windows) `*_ctl.ps1` must be run from the repo root.** The scripts use the relative path `build\sf_apps\<sample>` — running from elsewhere fails `Test-ServiceFabricApplicationPackage`.
+- **Tests pass locally but fail in CI.** CI runs `u22`, `azl3`, *and* `windows-latest`; check whether the failure is platform-specific by reproducing in the matching environment.

--- a/.github/skills/reflection-app-testing/SKILL.md
+++ b/.github/skills/reflection-app-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reflection-app-testing
-description: 'Run, gate, inspect, and clean up reflection-sample integration tests against the local Linux onebox. Use when the user asks to "run the reflection e2e test", "approve a stuck gate", "list pending replica gates", "detach a controller", "clean up test apps", "redeploy the reflection sample after a code change", or after touching crates/samples/reflection/src/control.rs / grpc_control.rs / proto/control.proto / proto/initdata.proto. Wraps the reflection_ctl operator CLI, the e2e test in tests/control_e2e.rs, prepare_test_apps.sh, and remove_test_apps.sh.'
+description: 'Run, gate, inspect, and clean up reflection-sample integration tests against the local onebox (Linux devcontainer or Windows host). Use when the user asks to "run the reflection e2e test", "approve a stuck gate", "list pending replica gates", "detach a controller", "clean up test apps", "redeploy the reflection sample after a code change", or after touching crates/samples/reflection/src/control.rs / grpc_control.rs / proto/control.proto / proto/initdata.proto. Wraps the reflection_ctl operator CLI, the e2e tests in tests/control_e2e.rs and tests/fail_change_role.rs, prepare_test_apps.sh / remove_test_apps.sh (Linux), and the *_ctl.ps1 scripts (Windows).'
 ---
 
 # Reflection App Testing
@@ -29,6 +29,8 @@ Trigger phrases:
   - `crates/samples/reflection/proto/initdata.proto`
   - `crates/samples/reflection/reflection_ctl/main.rs`
   - `crates/samples/reflection/tests/control_e2e.rs`
+  - `crates/samples/reflection/tests/fail_change_role.rs`
+  - `crates/samples/reflection/src/test_cluster.rs`
 
 ## When NOT to Use
 
@@ -37,9 +39,26 @@ Trigger phrases:
   and doesn't need a cluster.
 - Cluster bring-up or non-reflection samples — use
   [`onebox-deploy-test`](../onebox-deploy-test/SKILL.md).
-- Windows onebox — this skill assumes the Linux devcontainer setup.
+
+## Cluster host defaulting
+
+The test harness ([src/test_cluster.rs](../../../crates/samples/reflection/src/test_cluster.rs))
+and the `reflection_ctl` CLI use a `cfg`-gated default for the
+cluster hostname:
+
+- **Windows** → `localhost` (SF onebox runs on the same host; the
+  reflection server binds `0.0.0.0` so `localhost` reaches every node).
+- **Unix** → `onebox` (sibling-container DNS in the devcontainer
+  setup).
+
+Override at runtime with `REFLECTION_CLUSTER_HOST=<host>` (env var)
+or `--host <host>` for `reflection_ctl`. Do **not** set the env var
+on a normal Windows or Linux-devcontainer run — the cfg default
+already matches.
 
 ## Preconditions
+
+### Linux devcontainer
 
 Inside the devcontainer (`/etc/os-release` shows Ubuntu/AzureLinux):
 
@@ -53,6 +72,20 @@ If `sfctl cluster select` fails with `connection refused`, the
 `onebox` sibling container hasn't started — wait 10 s and retry up
 to 3 times. Cannot restart it from inside the devcontainer; ask the
 user to do so from a host shell.
+
+### Windows host
+
+In PowerShell (`$env:OS -eq 'Windows_NT'`):
+
+```powershell
+Get-Service FabricHostSvc           # must be Running (StartOnebox.ps1 starts it)
+Test-Path .\target\debug\reflection_ctl.exe   # operator CLI; built by cmake or `cargo build -p samples_reflection --bin reflection_ctl`
+```
+
+For cluster bring-up + initial provisioning of `EchoApp` and
+`ReflectionApp`, see the [`onebox-deploy-test`](../onebox-deploy-test/SKILL.md)
+skill's **Procedure (Windows)** section. This skill assumes the
+cluster is already up and `fabric:/ReflectionApp` is deployed.
 
 ## Procedure
 
@@ -75,12 +108,24 @@ Pick the smallest applicable subset; you don't always need to redeploy.
 `build/sf_apps/` — *both* are required for SF to pick up new
 binaries. `cargo build` alone is not enough.
 
+**Linux**:
+
 ```bash
 [ -f build/CMakeCache.txt ] || cmake . -DCMAKE_BUILD_TYPE=Debug -B build
 cmake --build build --config Debug
 ```
 
-After success: `build/sf_apps/samples_reflection/` should exist with
+**Windows** (PowerShell, repo root):
+
+```powershell
+if (-not (Test-Path build\CMakeCache.txt)) {
+    cmake . -DCMAKE_BUILD_TYPE=Debug -B build
+}
+cmake --build build --config Debug
+```
+
+After success: `build/sf_apps/samples_reflection/` (Linux) or
+`build\sf_apps\samples_reflection\` (Windows) should exist with
 fresh `ApplicationManifest.xml` and `ServicePackage/`.
 
 If you only changed the operator CLI, build just that:
@@ -89,29 +134,40 @@ If you only changed the operator CLI, build just that:
 cargo build -p samples_reflection --bin reflection_ctl
 ```
 
-### Step 2 — Clean cluster state ([scripts/remove_test_apps.sh](../../../scripts/remove_test_apps.sh))
+### Step 2 — Clean cluster state
 
 Required when the *deployed* `samples_reflection.exe` is stale and
-SF won't reactivate it without a clean reprovision. Idempotent:
+SF won't reactivate it without a clean reprovision, or when a prior
+test crash left `ApprovalE2e_*` / `FailCrE2e_*` services parked.
+
+**Linux** — [scripts/remove_test_apps.sh](../../../scripts/remove_test_apps.sh)
+is idempotent and tolerates "doesn't exist" at every step:
 
 ```bash
 bash ./scripts/remove_test_apps.sh
 ```
 
-Sequence the script runs:
-1. `reflection_ctl detach --all` (best-effort; release any parked
-   gates so close can complete).
-2. `reflection_ctl approve-all --yes` (fallback for pre-Detach
-   binaries).
-3. Delete every sub-service under each app (catches per-test
-   `ApprovalE2e_*` services from prior runs).
-4. Delete app instances (`fabric:/EchoApp`, `fabric:/ReflectionApp`).
-5. Unprovision app types.
-6. Delete uploaded packages from the image store.
+**Windows** — no equivalent script. Do the same sequence by hand
+(only run the parts that apply):
 
-Tolerates "doesn't exist" at every step. Always safe to run.
+```powershell
+# 1. Release any parked gates so SF can finish closing replicas.
+.\target\debug\reflection_ctl.exe detach --all
 
-### Step 3 — Provision ([scripts/prepare_test_apps.sh](../../../scripts/prepare_test_apps.sh))
+# 2. Force-remove any leftover per-test sub-services.
+Get-ServiceFabricService -ApplicationName fabric:/ReflectionApp |
+    Where-Object { $_.ServiceName.AbsolutePath -match '/(ApprovalE2e_|FailCrE2e_)' } |
+    ForEach-Object { Remove-ServiceFabricService -ServiceName $_.ServiceName -Force }
+
+# 3. Full app reset (mirrors what reflection_ctl.ps1 -Action Remove does).
+.\scripts\reflection_ctl.ps1 -Action Remove
+```
+
+Then re-run `*_ctl.ps1 -Action Add` (Step 3 below).
+
+### Step 3 — Provision
+
+**Linux** — [scripts/prepare_test_apps.sh](../../../scripts/prepare_test_apps.sh):
 
 ```bash
 bash ./scripts/prepare_test_apps.sh
@@ -122,6 +178,20 @@ and `ReflectionApp`, then waits for both services to resolve.
 Output ends with the resolved `ReflectionAppService` endpoint at
 `http://172.18.0.2:28000+i/...` (ports 28000–28004). If you see
 that line, the new binary is live.
+
+**Windows** — use the per-app PowerShell controllers (no combined
+script):
+
+```powershell
+.\scripts\reflection_ctl.ps1 -Action Add
+# Optional, only if your tests touch echomain too:
+.\scripts\echomain_ctl.ps1 -Action Add
+```
+
+Verify with `Get-ServiceFabricApplication` — status should be
+`Ready` / `Ok`. Replicas advertise `http://<machine>:28000+i/...`,
+but the test harness uses `localhost` on Windows and the server
+binds `0.0.0.0`, so this works without configuration.
 
 ### Step 4 — Run tests
 
@@ -152,9 +222,20 @@ cluster to be up and `fabric:/ReflectionApp` provisioned. The test:
 5. Drains teardown gates (`ChangeRole(None)` + `Close`).
 6. Verifies the registry no longer contains the replica.
 
-Expected runtime: ~2 seconds. If it hangs at "waiting for OPEN
+Expected runtime: ~2–4 seconds. If it hangs at "waiting for OPEN
 gate", the deployed binary is stale (skipped Step 1 + 3) — see
 Common Pitfalls.
+
+#### 4b¹. The fail-change-role e2e test ([tests/fail_change_role.rs](../../../crates/samples/reflection/tests/fail_change_role.rs))
+
+```bash
+cargo test -p samples_reflection --test fail_change_role -- --nocapture
+```
+
+Verifies the failure-recovery path: OPEN → CHANGE_ROLE(fail) →
+ABORT(approve to recover) → OPEN (retry) → CHANGE_ROLE(approve) →
+teardown. Expected runtime: ~20–25 s (SF reactivation between
+attempts dominates).
 
 #### 4c. Run all reflection sample tests
 
@@ -170,13 +251,17 @@ all require the cluster to be up.
 
 The operator CLI is built by Step 1 (`cmake --build`) or
 explicitly via `cargo build -p samples_reflection --bin reflection_ctl`.
+Binary path: `./target/debug/reflection_ctl` (Linux) or
+`.\target\debug\reflection_ctl.exe` (Windows). The `--host` default
+is cfg-gated (see [Cluster host defaulting](#cluster-host-defaulting));
+add `--host <hostname>` to override.
 
 #### 5a. Inspect
 
 ```bash
-./target/debug/reflection_ctl ping     # which nodes are reachable
-./target/debug/reflection_ctl list     # what gates are pending
-./target/debug/reflection_ctl list --partition <GUID>  # filter
+reflection_ctl ping     # which nodes are reachable
+reflection_ctl list     # what gates are pending
+reflection_ctl list --partition <GUID>  # filter
 ```
 
 `ping` shows ports `28000..=28004`. Some "unreachable: transport
@@ -186,11 +271,11 @@ where SF placed it.
 #### 5b. Approve a stuck gate
 
 ```bash
-./target/debug/reflection_ctl approve \
+reflection_ctl approve \
   --partition 92A2B906-B26C-774F-8FCA-E04CCD254142 \
   --replica   134218820574294250
 # Or to fail it instead:
-./target/debug/reflection_ctl approve --partition X --replica Y --fail-message "boom"
+reflection_ctl approve --partition X --replica Y --fail-message "boom"
 ```
 
 Auto-discovers the `gate_id` via `ListPending`. If no gate is
@@ -199,8 +284,8 @@ pending for that replica → exit code 1.
 #### 5c. Bulk unblock
 
 ```bash
-./target/debug/reflection_ctl approve-all --yes   # release every pending gate
-./target/debug/reflection_ctl detach   --all      # proceed-forever for every controller
+reflection_ctl approve-all --yes   # release every pending gate
+reflection_ctl detach   --all      # proceed-forever for every controller
 ```
 
 `detach --all` is the bigger hammer — once detached, a controller
@@ -214,7 +299,7 @@ arriving after will park again.
 #### 5d. Detach a single replica
 
 ```bash
-./target/debug/reflection_ctl detach \
+reflection_ctl detach \
   --partition 92A2B906-... \
   --replica   134218820574294250
 ```
@@ -224,24 +309,36 @@ arriving after will park again.
 - **Deployed binary is stale.** If e2e hangs at OPEN or `Detach`
   returns `Unimplemented`, you skipped Step 1 + Step 3 after
   changing reflection-sample code. Run them in order.
-- **`--force-remove` syntax.** sfctl 11.x requires
+- **(Linux) `--force-remove` syntax.** sfctl 11.x requires
   `--force-remove true`, not bare `--force-remove`.
   `remove_test_apps.sh` already handles this; ad-hoc `sfctl service
   delete` calls don't.
 - **Test panics leave gates parked.** Run
-  `./target/debug/reflection_ctl list` to see them, then
-  `approve-all --yes` or `detach --all` to clear before the next
-  run. `remove_test_apps.sh` does this automatically.
+  `reflection_ctl list` to see them, then `approve-all --yes` or
+  `detach --all` to clear before the next run. On Linux,
+  `remove_test_apps.sh` does this automatically; on Windows, follow
+  the manual sequence in Step 2.
+- **Stuck `Active`/Error sub-service after a panic (Windows).**
+  `Remove-ServiceFabricService -ServiceName ... -Force` is the
+  PowerShell equivalent of the Linux script's `--force-remove true`.
 - **`cmake --build` skips a sample after editing only `Cargo.toml`.**
   Force re-package with `cmake --build build --config Debug --target
   build_rust_sample_reflection` or `force_clean` then full rebuild.
-- **`onebox` hostname doesn't resolve from a fresh shell.** Inside
-  the devcontainer, `getent hosts onebox` should return `172.18.0.2`.
-  If not, the sibling container isn't running.
+- **(Linux) `onebox` hostname doesn't resolve from a fresh shell.**
+  Inside the devcontainer, `getent hosts onebox` should return
+  `172.18.0.2`. If not, the sibling container isn't running.
+- **Don't set `REFLECTION_CLUSTER_HOST` casually.** The cfg-gated
+  default already picks `localhost` (Windows) or `onebox` (Unix).
+  Only override for non-standard topologies.
 
 ## What CI Does
 
-[`.github/workflows/build.yaml`](../../workflows/build.yaml)'s
-`build-devcontainer` job runs steps 1 + 3 + 4c via
-`devcontainers/ci@v0.3`. Since the e2e test is now default-on, it
-is included automatically — no additional CI changes needed.
+- **Linux** — [`.github/workflows/build.yaml`](../../workflows/build.yaml)'s
+  `build-devcontainer` job runs steps 1 + 3 + 4c via
+  `devcontainers/ci@v0.3`.
+- **Windows** — the `build` job (`runs-on: windows-latest`) runs
+  the cmake build, `StartOnebox.ps1 -Auto`, the per-sample
+  `*_ctl.ps1 -Action Add` scripts, and `cargo test --all -- --nocapture`.
+
+Since both e2e tests are default-on, they are included automatically
+on both platforms — no extra CI changes needed.

--- a/.github/skills/reflection-app-testing/SKILL.md
+++ b/.github/skills/reflection-app-testing/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: reflection-app-testing
+description: 'Run, gate, inspect, and clean up reflection-sample integration tests against the local Linux onebox. Use when the user asks to "run the reflection e2e test", "approve a stuck gate", "list pending replica gates", "detach a controller", "clean up test apps", "redeploy the reflection sample after a code change", or after touching crates/samples/reflection/src/control.rs / grpc_control.rs / proto/control.proto / proto/initdata.proto. Wraps the reflection_ctl operator CLI, the e2e test in tests/control_e2e.rs, prepare_test_apps.sh, and remove_test_apps.sh.'
+---
+
+# Reflection App Testing
+
+End-to-end loop for the reflection sample's test-controlled replica
+behavior — see [docs/design/ReflectionReplicaTestControl.md](../../../docs/design/ReflectionReplicaTestControl.md)
+for the design.
+
+For *generic* deploy-and-test of all SF samples (not specific to the
+reflection control plane), use the
+[`onebox-deploy-test`](../onebox-deploy-test/SKILL.md) skill instead.
+
+## When to Use
+
+Trigger phrases:
+- "run the reflection e2e test"
+- "approve / list / detach gates"
+- "clean up reflection test state"
+- "the test is stuck waiting on `Approve`"
+- "redeploy the reflection sample"
+- after editing any of:
+  - `crates/samples/reflection/src/control.rs`
+  - `crates/samples/reflection/src/grpc_control.rs`
+  - `crates/samples/reflection/src/statefulstore.rs`
+  - `crates/samples/reflection/proto/control.proto`
+  - `crates/samples/reflection/proto/initdata.proto`
+  - `crates/samples/reflection/reflection_ctl/main.rs`
+  - `crates/samples/reflection/tests/control_e2e.rs`
+
+## When NOT to Use
+
+- Pure unit tests for `control.rs` / `grpc_control.rs` — `cargo test
+  -p samples_reflection --lib -- control:: grpc_control::` is enough
+  and doesn't need a cluster.
+- Cluster bring-up or non-reflection samples — use
+  [`onebox-deploy-test`](../onebox-deploy-test/SKILL.md).
+- Windows onebox — this skill assumes the Linux devcontainer setup.
+
+## Preconditions
+
+Inside the devcontainer (`/etc/os-release` shows Ubuntu/AzureLinux):
+
+```bash
+command -v sfctl                 # must succeed
+sfctl cluster select             # must connect to http://onebox:19080
+cargo build -p samples_reflection --bin reflection_ctl  # operator CLI
+```
+
+If `sfctl cluster select` fails with `connection refused`, the
+`onebox` sibling container hasn't started — wait 10 s and retry up
+to 3 times. Cannot restart it from inside the devcontainer; ask the
+user to do so from a host shell.
+
+## Procedure
+
+The *fast path* depends on what changed and what's currently running.
+Pick the smallest applicable subset; you don't always need to redeploy.
+
+### Quick decision tree
+
+| Situation | Action |
+|---|---|
+| Cluster is fresh, nothing deployed | Step 1 → Step 3 → Step 4 |
+| Already deployed; only edited test code or `reflection_ctl` | Step 4 only |
+| Edited `src/control.rs` / `grpc_control.rs` / `statefulstore.rs` / proto / `main.rs` (production reflection-sample code) | Step 1 → Step 2 → Step 3 → Step 4 |
+| Test failed, gates are parked, cluster is dirty | Step 5 (cleanup) → Step 1 if redeploying |
+| Just need to inspect what's pending | Step 5a (`list`) only |
+
+### Step 1 — Build (`cmake --build`)
+
+`cmake` drives `cargo build` AND repackages the SF apps into
+`build/sf_apps/` — *both* are required for SF to pick up new
+binaries. `cargo build` alone is not enough.
+
+```bash
+[ -f build/CMakeCache.txt ] || cmake . -DCMAKE_BUILD_TYPE=Debug -B build
+cmake --build build --config Debug
+```
+
+After success: `build/sf_apps/samples_reflection/` should exist with
+fresh `ApplicationManifest.xml` and `ServicePackage/`.
+
+If you only changed the operator CLI, build just that:
+
+```bash
+cargo build -p samples_reflection --bin reflection_ctl
+```
+
+### Step 2 — Clean cluster state ([scripts/remove_test_apps.sh](../../../scripts/remove_test_apps.sh))
+
+Required when the *deployed* `samples_reflection.exe` is stale and
+SF won't reactivate it without a clean reprovision. Idempotent:
+
+```bash
+bash ./scripts/remove_test_apps.sh
+```
+
+Sequence the script runs:
+1. `reflection_ctl detach --all` (best-effort; release any parked
+   gates so close can complete).
+2. `reflection_ctl approve-all --yes` (fallback for pre-Detach
+   binaries).
+3. Delete every sub-service under each app (catches per-test
+   `ApprovalE2e_*` services from prior runs).
+4. Delete app instances (`fabric:/EchoApp`, `fabric:/ReflectionApp`).
+5. Unprovision app types.
+6. Delete uploaded packages from the image store.
+
+Tolerates "doesn't exist" at every step. Always safe to run.
+
+### Step 3 — Provision ([scripts/prepare_test_apps.sh](../../../scripts/prepare_test_apps.sh))
+
+```bash
+bash ./scripts/prepare_test_apps.sh
+```
+
+Waits for cluster health, uploads + provisions + creates `EchoApp`
+and `ReflectionApp`, then waits for both services to resolve.
+Output ends with the resolved `ReflectionAppService` endpoint at
+`http://172.18.0.2:28000+i/...` (ports 28000–28004). If you see
+that line, the new binary is live.
+
+### Step 4 — Run tests
+
+#### 4a. Unit tests (no cluster needed)
+
+```bash
+cargo test -p samples_reflection --lib
+```
+
+Covers everything in `control.rs` (gate_lock serialization,
+stale-approve UUID protection, drop semantics, detach behaviour)
+and `grpc_control.rs` (timeout clamping, node_index parser).
+
+#### 4b. The e2e approval test ([tests/control_e2e.rs](../../../crates/samples/reflection/tests/control_e2e.rs))
+
+```bash
+cargo test -p samples_reflection --test control_e2e -- --nocapture
+```
+
+Runs by default like the other reflection tests — it requires the
+cluster to be up and `fabric:/ReflectionApp` provisioned. The test:
+1. Dials all `28000..=28004` via `Cluster::ensure()` (lazy re-dial).
+2. Creates a fresh `ApprovalE2e_<uuid>` service with
+   `ReplicaInitData { control: true }` initdata.
+3. Walks `Open → ChangeRole(Primary)` gates via
+   `WaitForApproval` + `Approve(proceed)`.
+4. Spawns `delete_service` in the background.
+5. Drains teardown gates (`ChangeRole(None)` + `Close`).
+6. Verifies the registry no longer contains the replica.
+
+Expected runtime: ~2 seconds. If it hangs at "waiting for OPEN
+gate", the deployed binary is stale (skipped Step 1 + 3) — see
+Common Pitfalls.
+
+#### 4c. Run all reflection sample tests
+
+```bash
+cargo test -p samples_reflection
+```
+
+Runs the unit tests, the existing `test.rs` / `test2.rs`
+integration tests, *and* the e2e approval test in one shot — they
+all require the cluster to be up.
+
+### Step 5 — Operate the cluster ([reflection_ctl/main.rs](../../../crates/samples/reflection/reflection_ctl/main.rs))
+
+The operator CLI is built by Step 1 (`cmake --build`) or
+explicitly via `cargo build -p samples_reflection --bin reflection_ctl`.
+
+#### 5a. Inspect
+
+```bash
+./target/debug/reflection_ctl ping     # which nodes are reachable
+./target/debug/reflection_ctl list     # what gates are pending
+./target/debug/reflection_ctl list --partition <GUID>  # filter
+```
+
+`ping` shows ports `28000..=28004`. Some "unreachable: transport
+error" lines are normal — the reflection sample only runs on nodes
+where SF placed it.
+
+#### 5b. Approve a stuck gate
+
+```bash
+./target/debug/reflection_ctl approve \
+  --partition 92A2B906-B26C-774F-8FCA-E04CCD254142 \
+  --replica   134218820574294250
+# Or to fail it instead:
+./target/debug/reflection_ctl approve --partition X --replica Y --fail-message "boom"
+```
+
+Auto-discovers the `gate_id` via `ListPending`. If no gate is
+pending for that replica → exit code 1.
+
+#### 5c. Bulk unblock
+
+```bash
+./target/debug/reflection_ctl approve-all --yes   # release every pending gate
+./target/debug/reflection_ctl detach   --all      # proceed-forever for every controller
+```
+
+`detach --all` is the bigger hammer — once detached, a controller
+auto-proceeds *every future* gate too, not just the current one.
+Use it when you want SF to resume normal teardown without further
+test interaction.
+
+`approve-all` only releases what's currently parked; new gates
+arriving after will park again.
+
+#### 5d. Detach a single replica
+
+```bash
+./target/debug/reflection_ctl detach \
+  --partition 92A2B906-... \
+  --replica   134218820574294250
+```
+
+## Common Pitfalls
+
+- **Deployed binary is stale.** If e2e hangs at OPEN or `Detach`
+  returns `Unimplemented`, you skipped Step 1 + Step 3 after
+  changing reflection-sample code. Run them in order.
+- **`--force-remove` syntax.** sfctl 11.x requires
+  `--force-remove true`, not bare `--force-remove`.
+  `remove_test_apps.sh` already handles this; ad-hoc `sfctl service
+  delete` calls don't.
+- **Test panics leave gates parked.** Run
+  `./target/debug/reflection_ctl list` to see them, then
+  `approve-all --yes` or `detach --all` to clear before the next
+  run. `remove_test_apps.sh` does this automatically.
+- **`cmake --build` skips a sample after editing only `Cargo.toml`.**
+  Force re-package with `cmake --build build --config Debug --target
+  build_rust_sample_reflection` or `force_clean` then full rebuild.
+- **`onebox` hostname doesn't resolve from a fresh shell.** Inside
+  the devcontainer, `getent hosts onebox` should return `172.18.0.2`.
+  If not, the sibling container isn't running.
+
+## What CI Does
+
+[`.github/workflows/build.yaml`](../../workflows/build.yaml)'s
+`build-devcontainer` job runs steps 1 + 3 + 4c via
+`devcontainers/ci@v0.3`. Since the e2e test is now default-on, it
+is included automatically — no additional CI changes needed.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 bin
 obj
 .windows
+.paw
 
 # cargo stuff
 target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +165,52 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "config"
@@ -542,6 +638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +846,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pathdiff"
@@ -993,6 +1101,7 @@ dependencies = [
 name = "samples_reflection"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "mssf-core",
  "mssf-util",
  "prost",
@@ -1104,6 +1213,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1445,10 +1560,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ package.license = "MIT"
 [workspace.dependencies]
 async-trait = "0.1"
 bitflags = "2"
+clap = { version = "4", features = ["derive"] }
 config = { version = "0.15", default-features = false }
 ctrlc = { version = "3.5", features = [
     "termination",

--- a/crates/samples/reflection/Cargo.toml
+++ b/crates/samples/reflection/Cargo.toml
@@ -6,7 +6,20 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "samples_reflection"
+path = "src/lib.rs"
+
+[[bin]]
+name = "samples_reflection"
+path = "src/main.rs"
+
+[[bin]]
+name = "reflection_ctl"
+path = "reflection_ctl/main.rs"
+
 [dependencies]
+clap = { workspace = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tokio.workspace = true
@@ -16,7 +29,7 @@ tonic.workspace = true
 tonic-prost.workspace = true
 prost.workspace = true
 url.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 mssf-core = { workspace = true, default-features = true }
 mssf-util = { workspace = true, default-features = true }
 

--- a/crates/samples/reflection/build.rs
+++ b/crates/samples/reflection/build.rs
@@ -1,4 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::compile_protos("proto/helloworld.proto")?;
+    tonic_prost_build::compile_protos("proto/initdata.proto")?;
+    tonic_prost_build::compile_protos("proto/control.proto")?;
     Ok(())
 }

--- a/crates/samples/reflection/proto/control.proto
+++ b/crates/samples/reflection/proto/control.proto
@@ -1,0 +1,123 @@
+syntax = "proto3";
+
+// Test-driven control plane for the reflection sample's stateful
+// replicas. See docs/design/ReflectionReplicaTestControl.md for the
+// full design (gate semantics, drop semantics, RPC error model).
+
+package reflection.control.v1;
+
+service ReplicaControl {
+  // Block until the named replica reaches an approval gate, or until
+  // `timeout_ms` elapses (server-capped: 0 -> 30s default, max 5min).
+  // On expiry: returns DEADLINE_EXCEEDED; the replica stays parked;
+  // clients may reissue.
+  rpc WaitForApproval (WaitForApprovalRequest) returns (ApprovalEvent);
+
+  // Release a currently-pending approval gate with the supplied
+  // decision. The `gate_id` must equal the value from the matching
+  // ApprovalEvent; mismatches return FailedPrecondition with detail
+  // GateIdMismatch.
+  rpc Approve (ApproveRequest) returns (Empty);
+
+  // Snapshot of in-flight approval gates. Optional filter by
+  // partition_id and/or replica_id. Setting `replica_filter` while
+  // `partition_id` is empty returns InvalidArgument.
+  rpc ListPending (ListPendingRequest) returns (ListPendingResponse);
+
+  // Switch a single replica into proceed-forever mode. After this
+  // call the replica's GrpcController auto-approves every future
+  // gate (Open, ChangeRole, Close, Abort) without parking, and any
+  // currently-pending gate is released with Proceed. Irreversible
+  // for the lifetime of that controller. NotFound if the replica
+  // is not registered (or already removed).
+  rpc Detach (ReplicaRef) returns (Empty);
+
+  // Detach every controllable replica known to this server. Returns
+  // the count of replicas that transitioned (excludes replicas that
+  // were already detached).
+  rpc DetachAll (Empty) returns (DetachAllResponse);
+}
+
+message ReplicaRef {
+  // GUID string in mssf-core's debug format (matches helloworld.proto's
+  // ReplicaInfo.partition_id).
+  string partition_id = 1;
+  int64  replica_id   = 2;
+}
+
+message WaitForApprovalRequest {
+  ReplicaRef target = 1;
+  // Server-side wait timeout. 0 means "use the default" (30 seconds).
+  // Capped at 300_000 (5 minutes); larger values are clamped silently.
+  uint32 timeout_ms = 2;
+  // Optional filter; APPROVAL_UNSPECIFIED matches any pending gate.
+  ApprovalKind expected = 3;
+}
+
+enum ApprovalKind {
+  APPROVAL_UNSPECIFIED = 0;
+  APPROVAL_OPEN        = 1;
+  APPROVAL_CHANGE_ROLE = 2;
+  APPROVAL_CLOSE       = 3;
+  APPROVAL_ABORT       = 4; // approved synchronously; decision payload is ignored
+}
+
+// Lifecycle role for the replica, matching mssf_core::types::ReplicaRole.
+// Duplicated here to keep the control plane proto self-contained.
+enum ReplicaRole {
+  REPLICA_ROLE_UNKNOWN           = 0;
+  REPLICA_ROLE_NONE              = 1;
+  REPLICA_ROLE_PRIMARY           = 2;
+  REPLICA_ROLE_IDLE_SECONDARY    = 3;
+  REPLICA_ROLE_ACTIVE_SECONDARY  = 4;
+  REPLICA_ROLE_IDLE_AUXILIARY    = 5;
+  REPLICA_ROLE_ACTIVE_AUXILIARY  = 6;
+  REPLICA_ROLE_PRIMARY_AUXILIARY = 7;
+}
+
+message ApprovalEvent {
+  ReplicaRef   target   = 1;
+  ApprovalKind kind     = 2;
+  // Populated when kind == APPROVAL_CHANGE_ROLE; otherwise REPLICA_ROLE_UNKNOWN.
+  ReplicaRole  new_role = 3;
+  // Opaque per-gate token (UUID v4 string). Must be echoed back on
+  // Approve. A mismatch means the gate has already been released and
+  // likely replaced by a fresh one; the Approve is rejected with
+  // FailedPrecondition + GateIdMismatch.
+  string       gate_id  = 4;
+}
+
+message ApproveRequest {
+  ReplicaRef target  = 1;
+  string     gate_id = 2;
+  oneof decision {
+    Empty   proceed      = 3;
+    string  fail_message = 4; // returned to SF as Error; ignored for ABORT gates
+  }
+  // Tests that want to delay the approval just sleep before sending
+  // Approve; there is no server-side delay variant.
+}
+
+message ListPendingRequest {
+  // Optional filter. Empty = all partitions.
+  string partition_id = 1;
+  // Optional replica filter. Unset = all replicas in the partition(s)
+  // selected by partition_id. Setting `specific_replica_id` while
+  // `partition_id` is empty returns InvalidArgument because replica
+  // ids are not unique across partitions.
+  oneof replica_filter {
+    int64 specific_replica_id = 2;
+  }
+}
+
+message ListPendingResponse {
+  repeated ApprovalEvent events = 1;
+}
+
+message DetachAllResponse {
+  // Number of replicas this call actually detached (does not count
+  // replicas that were already in proceed-forever mode).
+  uint32 detached = 1;
+}
+
+message Empty {}

--- a/crates/samples/reflection/proto/initdata.proto
+++ b/crates/samples/reflection/proto/initdata.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+// Per-service initialization data for the reflection sample.
+//
+// Test drivers encode a `ReplicaInitData` and pass the resulting bytes
+// through `StatefulServiceDescription::with_initialization_data` when
+// calling `CreateService`. Service Fabric persists those bytes with
+// the service registration and re-passes them verbatim to every
+// `IStatefulServiceFactory::create_replica` call for that service
+// instance, across failovers, application upgrades, and cluster
+// restarts. The reflection sample's `Factory` decodes them via prost
+// and selects between `NoopController` (production-style, no-op gates)
+// and `GrpcController` (test-driven gates over `ReplicaControl`).
+//
+// Empty initdata bytes and decode failures both map to the
+// default-valued message (`control = false` -> `NoopController`),
+// preserving current behavior for services that don't set initdata.
+//
+// SCHEMA POLICY: this proto is FORWARD-ADDITIVE ONLY. Do not change
+// existing field numbers or types. Breaking changes warrant a new
+// package (`reflection.initdata.v2`) and a separate decoder.
+//
+// `ReplicaInitData` is reserved for test-control purposes. If a
+// future feature needs operator-supplied initdata (region tags,
+// feature flags), introduce a wrapper message such as
+// `ServiceInitData { oneof payload { ReplicaInitData test_control = 1;
+// OperatorConfig op = 2; } }` and update the design doc.
+
+package reflection.initdata.v1;
+
+message ReplicaInitData {
+  // When true, the Factory builds a GrpcController for this replica
+  // and registers it with the ReplicaControl gRPC service. When false
+  // (or when the message is absent / fails to decode), a
+  // NoopController is used and the replica is invisible to
+  // ReplicaControl.
+  bool control = 1;
+
+  // Reserved for future tunables such as preloaded approval decisions,
+  // a per-service tag for tests to filter on, or simulated open delays.
+  // New fields must be additive and tolerate the prost default value.
+  // reserved 2 to 15;
+}

--- a/crates/samples/reflection/reflection_ctl/main.rs
+++ b/crates/samples/reflection/reflection_ctl/main.rs
@@ -38,7 +38,8 @@ const NODE_COUNT: u16 = 5;
     long_about = None,
 )]
 struct Cli {
-    /// Hostname or IP of the cluster (default: $REFLECTION_CLUSTER_HOST or "onebox").
+    /// Hostname or IP of the cluster (default: $REFLECTION_CLUSTER_HOST,
+    /// otherwise "localhost" on Windows and "onebox" on Unix).
     #[arg(long, global = true)]
     host: Option<String>,
 
@@ -99,10 +100,14 @@ enum Command {
 }
 
 fn cluster_host(cli: &Cli) -> String {
+    #[cfg(windows)]
+    const DEFAULT_HOST: &str = "localhost";
+    #[cfg(not(windows))]
+    const DEFAULT_HOST: &str = "onebox";
     cli.host
         .clone()
         .or_else(|| std::env::var("REFLECTION_CLUSTER_HOST").ok())
-        .unwrap_or_else(|| "onebox".to_string())
+        .unwrap_or_else(|| DEFAULT_HOST.to_string())
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/crates/samples/reflection/reflection_ctl/main.rs
+++ b/crates/samples/reflection/reflection_ctl/main.rs
@@ -1,0 +1,452 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Manual CLI for the reflection sample's `ReplicaControl` gRPC server.
+//!
+//! Useful for unsticking a cluster after a failed integration test left
+//! gates parked, and for ad-hoc inspection ("what is each node currently
+//! waiting on?").
+//!
+//! See `docs/design/ReflectionReplicaTestControl.md` for the design.
+//!
+//! Examples:
+//!   reflection_ctl ping
+//!   reflection_ctl list
+//!   reflection_ctl approve-all
+//!   reflection_ctl approve --partition <GUID> --replica <ID>
+//!   reflection_ctl --host 127.0.0.1 list
+
+use std::time::Duration;
+
+use clap::{Parser, Subcommand};
+use samples_reflection::grpc_control::REFLECTION_CONTROL_BASE_PORT;
+use samples_reflection::grpc_control::proto::{
+    ApprovalEvent, ApprovalKind, ApproveRequest, Empty, ListPendingRequest, ReplicaRef,
+    approve_request::Decision as ApproveDecisionOneof,
+    replica_control_client::ReplicaControlClient,
+};
+use tonic::transport::{Channel, Endpoint};
+
+const NODE_COUNT: u16 = 5;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "reflection_ctl",
+    about = "Manual control of the reflection sample's ReplicaControl gRPC server",
+    long_about = None,
+)]
+struct Cli {
+    /// Hostname or IP of the cluster (default: $REFLECTION_CLUSTER_HOST or "onebox").
+    #[arg(long, global = true)]
+    host: Option<String>,
+
+    /// Per-node connect timeout in milliseconds.
+    #[arg(long, default_value_t = 500, global = true)]
+    connect_timeout_ms: u64,
+
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Probe each candidate port and print which nodes are reachable.
+    Ping,
+
+    /// Print every pending approval gate across all reachable nodes.
+    List {
+        /// Filter to a specific partition GUID (matches sfctl's hex format).
+        #[arg(long)]
+        partition: Option<String>,
+    },
+
+    /// Approve every pending gate on every reachable node with `Proceed`.
+    /// Use this to clear leftover state from a failed test run.
+    ApproveAll {
+        /// Skip the y/N prompt before approving.
+        #[arg(long)]
+        yes: bool,
+    },
+
+    /// Approve a specific replica's pending gate. Auto-discovers the
+    /// gate_id via ListPending; fails if no gate is pending.
+    Approve {
+        #[arg(long)]
+        partition: String,
+        #[arg(long)]
+        replica: i64,
+        /// If set, send Fail with this message instead of Proceed.
+        #[arg(long)]
+        fail_message: Option<String>,
+    },
+
+    /// Switch one or more controllers into proceed-forever mode. After
+    /// detach, every future gate auto-approves and any pending gate is
+    /// released. Useful for unblocking a stuck cleanup or for tests
+    /// that want SF-driven teardown after a controlled setup.
+    Detach {
+        /// Detach a single replica (requires --partition and --replica).
+        #[arg(long, requires = "replica")]
+        partition: Option<String>,
+        #[arg(long)]
+        replica: Option<i64>,
+        /// Detach every controllable replica on every reachable node.
+        #[arg(long, conflicts_with = "partition")]
+        all: bool,
+    },
+}
+
+fn cluster_host(cli: &Cli) -> String {
+    cli.host
+        .clone()
+        .or_else(|| std::env::var("REFLECTION_CLUSTER_HOST").ok())
+        .unwrap_or_else(|| "onebox".to_string())
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    let host = cluster_host(&cli);
+    let connect_timeout = Duration::from_millis(cli.connect_timeout_ms);
+
+    match cli.cmd {
+        Command::Ping => cmd_ping(&host, connect_timeout).await,
+        Command::List { partition } => cmd_list(&host, connect_timeout, partition).await,
+        Command::ApproveAll { yes } => cmd_approve_all(&host, connect_timeout, yes).await,
+        Command::Approve {
+            partition,
+            replica,
+            fail_message,
+        } => cmd_approve(&host, connect_timeout, partition, replica, fail_message).await,
+        Command::Detach {
+            partition,
+            replica,
+            all,
+        } => cmd_detach(&host, connect_timeout, partition, replica, all).await,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------
+
+async fn cmd_ping(host: &str, connect_timeout: Duration) -> std::process::ExitCode {
+    let any = dial_all(host, connect_timeout)
+        .await
+        .into_iter()
+        .filter_map(|(i, r)| match r {
+            Ok(_) => {
+                println!(
+                    "node #{i:>1}  port {}  OK",
+                    REFLECTION_CONTROL_BASE_PORT + i as u16
+                );
+                Some(())
+            }
+            Err(e) => {
+                println!(
+                    "node #{i:>1}  port {}  unreachable: {e}",
+                    REFLECTION_CONTROL_BASE_PORT + i as u16
+                );
+                None
+            }
+        })
+        .count();
+    if any > 0 {
+        std::process::ExitCode::SUCCESS
+    } else {
+        eprintln!("no ReplicaControl endpoints reachable on {host}");
+        std::process::ExitCode::FAILURE
+    }
+}
+
+async fn cmd_list(
+    host: &str,
+    connect_timeout: Duration,
+    partition: Option<String>,
+) -> std::process::ExitCode {
+    let mut total = 0;
+    for (i, conn) in dial_all(host, connect_timeout).await {
+        let mut client = match conn {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let req = ListPendingRequest {
+            partition_id: partition.clone().unwrap_or_default(),
+            replica_filter: None,
+        };
+        match client.list_pending(req).await {
+            Ok(r) => {
+                let events = r.into_inner().events;
+                if events.is_empty() {
+                    continue;
+                }
+                println!(
+                    "=== node #{i} (port {}) ===",
+                    REFLECTION_CONTROL_BASE_PORT + i as u16
+                );
+                for ev in events {
+                    print_event(&ev);
+                    total += 1;
+                }
+            }
+            Err(e) => eprintln!("node #{i}: ListPending failed: {e}"),
+        }
+    }
+    if total == 0 {
+        println!("no pending gates");
+    } else {
+        println!("\n{total} pending gate(s) total");
+    }
+    std::process::ExitCode::SUCCESS
+}
+
+async fn cmd_approve_all(
+    host: &str,
+    connect_timeout: Duration,
+    yes: bool,
+) -> std::process::ExitCode {
+    if !yes {
+        eprintln!(
+            "About to approve(Proceed) every pending gate on every reachable node. \
+             Pass --yes to skip this prompt or Ctrl-C to abort."
+        );
+        eprint!("Continue? [y/N] ");
+        let mut buf = String::new();
+        if std::io::stdin().read_line(&mut buf).is_err() || !buf.trim().eq_ignore_ascii_case("y") {
+            eprintln!("aborted");
+            return std::process::ExitCode::FAILURE;
+        }
+    }
+    let mut released = 0u32;
+    let mut errors = 0u32;
+    for (i, conn) in dial_all(host, connect_timeout).await {
+        let mut client = match conn {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let req = ListPendingRequest {
+            partition_id: String::new(),
+            replica_filter: None,
+        };
+        let events = match client.list_pending(req).await {
+            Ok(r) => r.into_inner().events,
+            Err(e) => {
+                eprintln!("node #{i}: ListPending failed: {e}");
+                errors += 1;
+                continue;
+            }
+        };
+        for ev in events {
+            let target = match ev.target.clone() {
+                Some(t) => t,
+                None => continue,
+            };
+            let approve = ApproveRequest {
+                target: Some(target.clone()),
+                gate_id: ev.gate_id.clone(),
+                decision: Some(ApproveDecisionOneof::Proceed(Empty {})),
+            };
+            match client.approve(approve).await {
+                Ok(_) => {
+                    println!(
+                        "node #{i}: approved {kind:?} (partition={pid}, replica={rid}, gate_id={gid})",
+                        kind = ApprovalKind::try_from(ev.kind)
+                            .unwrap_or(ApprovalKind::ApprovalUnspecified),
+                        pid = target.partition_id,
+                        rid = target.replica_id,
+                        gid = ev.gate_id,
+                    );
+                    released += 1;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "node #{i}: Approve failed for partition={} replica={}: {e}",
+                        target.partition_id, target.replica_id
+                    );
+                    errors += 1;
+                }
+            }
+        }
+    }
+    println!("\n{released} gate(s) released, {errors} error(s)");
+    if errors > 0 && released == 0 {
+        std::process::ExitCode::FAILURE
+    } else {
+        std::process::ExitCode::SUCCESS
+    }
+}
+
+async fn cmd_approve(
+    host: &str,
+    connect_timeout: Duration,
+    partition: String,
+    replica: i64,
+    fail_message: Option<String>,
+) -> std::process::ExitCode {
+    // Find which node has this replica's pending gate.
+    for (i, conn) in dial_all(host, connect_timeout).await {
+        let mut client = match conn {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let events = client
+            .list_pending(ListPendingRequest {
+                partition_id: partition.clone(),
+                replica_filter: None,
+            })
+            .await
+            .map(|r| r.into_inner().events)
+            .unwrap_or_default();
+        for ev in events {
+            let Some(target) = ev.target.clone() else {
+                continue;
+            };
+            if target.replica_id != replica {
+                continue;
+            }
+            let decision = match fail_message.as_ref() {
+                None => ApproveDecisionOneof::Proceed(Empty {}),
+                Some(msg) => ApproveDecisionOneof::FailMessage(msg.clone()),
+            };
+            let req = ApproveRequest {
+                target: Some(target.clone()),
+                gate_id: ev.gate_id.clone(),
+                decision: Some(decision),
+            };
+            match client.approve(req).await {
+                Ok(_) => {
+                    println!(
+                        "approved on node #{i} (gate_id={}, kind={:?})",
+                        ev.gate_id,
+                        ApprovalKind::try_from(ev.kind)
+                            .unwrap_or(ApprovalKind::ApprovalUnspecified)
+                    );
+                    return std::process::ExitCode::SUCCESS;
+                }
+                Err(e) => {
+                    eprintln!("Approve failed on node #{i}: {e}");
+                    return std::process::ExitCode::FAILURE;
+                }
+            }
+        }
+    }
+    eprintln!("no pending gate found for partition={partition} replica={replica} on any node");
+    std::process::ExitCode::FAILURE
+}
+
+async fn cmd_detach(
+    host: &str,
+    connect_timeout: Duration,
+    partition: Option<String>,
+    replica: Option<i64>,
+    all: bool,
+) -> std::process::ExitCode {
+    if all {
+        let mut total_detached = 0u32;
+        let mut errors = 0u32;
+        for (i, conn) in dial_all(host, connect_timeout).await {
+            let mut client = match conn {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            match client.detach_all(Empty {}).await {
+                Ok(r) => {
+                    let n = r.into_inner().detached;
+                    println!("node #{i}: detached {n} controller(s)");
+                    total_detached += n;
+                }
+                Err(e) => {
+                    eprintln!("node #{i}: DetachAll failed: {e}");
+                    errors += 1;
+                }
+            }
+        }
+        println!("\n{total_detached} controller(s) detached, {errors} error(s)");
+        return if errors > 0 && total_detached == 0 {
+            std::process::ExitCode::FAILURE
+        } else {
+            std::process::ExitCode::SUCCESS
+        };
+    }
+
+    let (Some(partition), Some(replica)) = (partition, replica) else {
+        eprintln!("either --all or both --partition and --replica are required");
+        return std::process::ExitCode::FAILURE;
+    };
+    let target = ReplicaRef {
+        partition_id: partition,
+        replica_id: replica,
+    };
+    for (i, conn) in dial_all(host, connect_timeout).await {
+        let mut client = match conn {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        match client.detach(target.clone()).await {
+            Ok(_) => {
+                println!(
+                    "node #{i}: detached partition={} replica={}",
+                    target.partition_id, target.replica_id
+                );
+                return std::process::ExitCode::SUCCESS;
+            }
+            Err(s) if s.code() == tonic::Code::NotFound => {
+                // not on this node; try the next
+                continue;
+            }
+            Err(e) => {
+                eprintln!("node #{i}: Detach failed: {e}");
+                return std::process::ExitCode::FAILURE;
+            }
+        }
+    }
+    eprintln!(
+        "replica partition={} replica={} not registered on any node",
+        target.partition_id, target.replica_id
+    );
+    std::process::ExitCode::FAILURE
+}
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
+
+/// Dial every candidate port. Returns one entry per node with either
+/// the connected client or the connection error.
+async fn dial_all(
+    host: &str,
+    connect_timeout: Duration,
+) -> Vec<(
+    usize,
+    Result<ReplicaControlClient<Channel>, tonic::transport::Error>,
+)> {
+    let mut out = Vec::with_capacity(NODE_COUNT as usize);
+    for i in 0..NODE_COUNT {
+        let port = REFLECTION_CONTROL_BASE_PORT + i;
+        let url = format!("http://{host}:{port}");
+        let endpoint = Endpoint::from_shared(url)
+            .expect("hard-coded URL is valid")
+            .connect_timeout(connect_timeout)
+            .timeout(Duration::from_secs(10));
+        out.push((
+            i as usize,
+            endpoint.connect().await.map(ReplicaControlClient::new),
+        ));
+    }
+    out
+}
+
+fn print_event(ev: &ApprovalEvent) {
+    let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
+    let (pid, rid) = ev
+        .target
+        .as_ref()
+        .map(|t| (t.partition_id.as_str(), t.replica_id))
+        .unwrap_or(("?", 0));
+    println!(
+        "  {kind:?}  partition={pid}  replica={rid}  gate_id={}",
+        ev.gate_id
+    );
+}

--- a/crates/samples/reflection/src/control.rs
+++ b/crates/samples/reflection/src/control.rs
@@ -1,0 +1,722 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Test-driven control plane for replica lifecycle methods.
+//!
+//! See `docs/design/ReflectionReplicaTestControl.md` for the full design.
+//!
+//! - [`ReplicaController`] is the lifecycle hook trait. Every `Replica`
+//!   holds an `Arc<dyn ReplicaController>` and calls
+//!   `await_approval(...)` from inside `open` / `change_role` / `close`
+//!   / `abort`.
+//! - [`NoopController`] is the production path: every `await_approval`
+//!   returns [`Decision::Proceed`] inline; never registered with the
+//!   gRPC `ReplicaControl` server.
+//! - [`GrpcController`] is the test path: lifecycle methods park on a
+//!   oneshot until a gRPC `Approve` arrives. A `tokio::sync::Mutex`
+//!   (`gate_lock`) held across the wait makes single-occupancy of the
+//!   `pending` slot an enforced invariant.
+//! - [`decode_init_data`] / [`ControlMode::from_init_data`] split
+//!   wire-format decoding from policy mapping so each can be
+//!   unit-tested in isolation.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use mssf_core::async_trait;
+use mssf_core::types::ReplicaRole;
+use prost::Message;
+use tokio::sync::{Mutex as TokioMutex, Notify, oneshot};
+use uuid::Uuid;
+
+pub mod initdata_proto {
+    tonic::include_proto!("reflection.initdata.v1");
+}
+
+/// Identifies which lifecycle gate the replica is currently waiting at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Approval {
+    Open,
+    ChangeRole(ReplicaRole),
+    Close,
+    Abort,
+}
+
+/// What `await_approval` should return to its caller.
+///
+/// `Fail` is ignored for `Approval::Abort` because
+/// `IStatefulServiceReplica::abort` returns `()` and cannot propagate
+/// an error.
+#[derive(Debug)]
+pub enum Decision {
+    Proceed,
+    Fail(mssf_core::Error),
+}
+
+/// Lifecycle hook implemented by both the production
+/// (`NoopController`) and test-driven (`GrpcController`) controllers.
+#[async_trait]
+pub trait ReplicaController: Send + Sync + std::fmt::Debug {
+    /// Called by every lifecycle gate (`Open`, `ChangeRole`, `Close`,
+    /// `Abort`). `NoopController` returns `Decision::Proceed`
+    /// immediately; `GrpcController` blocks until a test sends
+    /// `Approve` over gRPC. The sync `abort` call site bridges to
+    /// this with `TokioExecutor::block_on_any`.
+    async fn await_approval(&self, gate: Approval) -> Decision;
+
+    /// Whether this controller should be registered with the
+    /// `ReplicaControl` gRPC server. `NoopController` returns `false`
+    /// (and therefore is invisible to test traffic); `GrpcController`
+    /// returns `true`.
+    fn is_controllable(&self) -> bool {
+        false
+    }
+
+    /// Erased self-cast for the gRPC handler to downcast to a
+    /// concrete controller type when it needs the inspection
+    /// methods (`peek_pending`, `wait_for_approval`, `approve`).
+    /// `NoopController` returns its own `&dyn Any`; downcasts that
+    /// don't match yield `None` and the caller maps that to a clear
+    /// gRPC status.
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+/// Production path. Stateless, constant-time, never registered with
+/// the gRPC service.
+#[derive(Debug, Default)]
+pub struct NoopController;
+
+#[async_trait]
+impl ReplicaController for NoopController {
+    async fn await_approval(&self, _gate: Approval) -> Decision {
+        Decision::Proceed
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Decision sent on the controller's oneshot channel; produced by the
+/// gRPC `Approve` handler or by `Drop`. Internal to this module.
+type GateDecision = Decision;
+
+/// One occupant of the controller's `pending` slot. Cleared either by
+/// the gRPC `Approve` handler (which takes the `sender` and sends the
+/// caller's decision) or by `Drop` (which sends `Decision::Proceed`).
+#[derive(Debug)]
+pub(crate) struct Pending {
+    pub gate_id: Uuid,
+    pub gate: Approval,
+    sender: oneshot::Sender<GateDecision>,
+}
+
+/// Test-driven controller. See module docs for the state-machine
+/// invariants.
+///
+/// State layout:
+/// - `gate_lock` (tokio mutex) is held across the *entire* body of
+///   `await_approval`, including the receiver `await`. This serializes
+///   lifecycle gates: a second `await_approval` from a different
+///   lifecycle method blocks at `gate_lock` until the first is
+///   approved or the controller is dropped.
+/// - `pending` (std mutex) is the observation slot read by the gRPC
+///   handler. Held only briefly to publish or clear `Pending`; never
+///   across an await.
+/// - `notify` wakes any `WaitForApproval` handler when `pending`
+///   transitions from `None` to `Some`.
+///
+/// Lock order is fixed: `gate_lock` outer, `pending` mutex inner.
+#[derive(Debug)]
+pub struct GrpcController {
+    gate_lock: TokioMutex<()>,
+    pending: StdMutex<Option<Pending>>,
+    notify: Notify,
+    /// Once set to `true`, all future `await_approval` calls return
+    /// `Decision::Proceed` immediately and any currently-pending
+    /// gate is released with `Decision::Proceed`. Irreversible by
+    /// design: a test that wants "control phase, then cluster-driven
+    /// teardown" calls `detach()` once and SF takes over.
+    detached: AtomicBool,
+}
+
+impl GrpcController {
+    pub fn new() -> Self {
+        Self {
+            gate_lock: TokioMutex::new(()),
+            pending: StdMutex::new(None),
+            notify: Notify::new(),
+            detached: AtomicBool::new(false),
+        }
+    }
+
+    /// Switch this controller into proceed-forever mode. After this
+    /// call:
+    /// - Any currently-pending gate is released with
+    ///   `Decision::Proceed` so the parked lifecycle method unblocks
+    ///   immediately.
+    /// - All future `await_approval` calls short-circuit to
+    ///   `Decision::Proceed` without ever touching `pending` or
+    ///   `gate_lock`.
+    ///
+    /// Idempotent and safe to call concurrently.
+    pub fn detach(&self) {
+        self.detached.store(true, Ordering::SeqCst);
+        if let Ok(mut slot) = self.pending.lock()
+            && let Some(p) = slot.take()
+        {
+            let _ = p.sender.send(Decision::Proceed);
+        }
+        // Wake any handler currently parked in `wait_for_approval`
+        // so it observes the now-empty slot and (typically) the
+        // caller will then issue a fresh request that returns
+        // NotFound once the registry entry is dropped.
+        self.notify.notify_waiters();
+    }
+
+    pub fn is_detached(&self) -> bool {
+        self.detached.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot the currently pending gate for read-only use by the
+    /// gRPC `WaitForApproval` / `ListPending` handlers. Returns
+    /// `(gate_id, gate)`; does NOT consume the slot.
+    pub fn peek_pending(&self) -> Option<(Uuid, Approval)> {
+        let guard = self.pending.lock().unwrap();
+        guard.as_ref().map(|p| (p.gate_id, p.gate))
+    }
+
+    /// Block until `pending` is populated and matches `expected` (or
+    /// `expected` is `None`). Returns the `(gate_id, gate)` snapshot.
+    /// Cancellation-safe: when the future is dropped, the slot is
+    /// untouched (only `approve()` consumes the sender).
+    pub async fn wait_for_approval(
+        &self,
+        expected: Option<ApprovalKindFilter>,
+    ) -> (Uuid, Approval) {
+        loop {
+            // Register interest BEFORE inspecting state. tokio's Notify
+            // delivers wake-ups to listeners that exist at the time of
+            // `notify_waiters()`; the first poll of `notified` registers
+            // the listener, so the structure here (construct, pin, peek,
+            // await) ensures that any `await_approval` populate that
+            // happens after the construction of `notified` will wake us.
+            // Constructing `notified` AFTER the peek would reintroduce a
+            // missed-wakeup window.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+
+            if let Some((gate_id, gate)) = self.peek_pending()
+                && expected.is_none_or(|f| f.matches(gate))
+            {
+                return (gate_id, gate);
+            }
+            notified.as_mut().await;
+        }
+    }
+
+    /// Consume the pending slot if `gate_id` matches; send `decision`
+    /// on the stored oneshot. Returns the result of the id check so
+    /// the gRPC handler can map to the right tonic Status.
+    pub fn approve(&self, gate_id: Uuid, decision: Decision) -> ApproveResult {
+        let mut guard = self.pending.lock().unwrap();
+        let pending = match guard.take() {
+            None => return ApproveResult::SlotEmpty,
+            Some(p) => p,
+        };
+        if pending.gate_id != gate_id {
+            // Put it back and tell the caller their id is stale.
+            let returned_id = pending.gate_id;
+            *guard = Some(pending);
+            return ApproveResult::IdMismatch {
+                pending_id: returned_id,
+                requested_id: gate_id,
+            };
+        }
+        // Drop the lock before sending so the await_approval body can
+        // immediately reacquire it on the std mutex side. The receiver
+        // is awaiting a oneshot; we don't need to hold the std mutex.
+        drop(guard);
+        // Receiver is `await`ing inside `await_approval`. If the future
+        // has been dropped (e.g., the replica is being torn down right
+        // now) the send returns Err; we discard it because there is
+        // nobody to report to.
+        let _ = pending.sender.send(decision);
+        ApproveResult::Released
+    }
+}
+
+impl Default for GrpcController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ReplicaController for GrpcController {
+    async fn await_approval(&self, gate: Approval) -> Decision {
+        // Fast path: if detach() has been called, every future gate
+        // proceeds immediately without touching gate_lock or pending.
+        if self.is_detached() {
+            return Decision::Proceed;
+        }
+
+        // Acquire the serialization lock for the entire body of this
+        // call. A concurrent await_approval (e.g., abort arriving while
+        // close is parked) blocks here until we release.
+        let _guard = self.gate_lock.lock().await;
+
+        // Double-check after acquiring: detach() may have fired while
+        // we were queued. Without this, a queued lifecycle method
+        // would still publish a fresh gate after detach().
+        if self.is_detached() {
+            return Decision::Proceed;
+        }
+
+        let gate_id = Uuid::new_v4();
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut slot = self.pending.lock().unwrap();
+            // gate_lock guarantees the slot is empty here; debug-assert
+            // is informational rather than a safety net.
+            debug_assert!(
+                slot.is_none(),
+                "pending slot must be empty under gate_lock; got {slot:?}"
+            );
+            *slot = Some(Pending {
+                gate_id,
+                gate,
+                sender: tx,
+            });
+        }
+        self.notify.notify_waiters();
+
+        // Wait for either an Approve (sender.send) or a Drop (sender
+        // dropped without sending -> Err). Both unblock us; on Drop
+        // we treat it as Proceed so the lifecycle method can complete
+        // cleanup without making SF think the operation failed.
+        let decision = rx.await.unwrap_or(Decision::Proceed);
+
+        // Clear the slot. In the normal Approve path, `approve()`
+        // already cleared it (took on send). In the Drop path,
+        // nobody cleared it. Either way, leaving the slot None on
+        // exit is the invariant.
+        {
+            let mut slot = self.pending.lock().unwrap();
+            *slot = None;
+        }
+        decision
+    }
+
+    fn is_controllable(&self) -> bool {
+        true
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl Drop for GrpcController {
+    fn drop(&mut self) {
+        // Release any pending oneshot with Decision::Proceed so a
+        // parked await_approval future can complete instead of hanging
+        // when the controller goes away (Replica being dropped, etc.).
+        // The receiver may itself already be dropped; ignore the send
+        // error in that case.
+        if let Ok(mut slot) = self.pending.lock()
+            && let Some(p) = slot.take()
+        {
+            let _ = p.sender.send(Decision::Proceed);
+        }
+    }
+}
+
+/// Outcome of `GrpcController::approve` for the gRPC handler.
+#[derive(Debug)]
+pub enum ApproveResult {
+    Released,
+    SlotEmpty,
+    IdMismatch {
+        pending_id: Uuid,
+        requested_id: Uuid,
+    },
+}
+
+/// Filter predicate matching one or more gate kinds. Used by
+/// `WaitForApproval`'s `expected` field.
+#[derive(Debug, Clone, Copy)]
+pub enum ApprovalKindFilter {
+    Open,
+    ChangeRole,
+    Close,
+    Abort,
+}
+
+impl ApprovalKindFilter {
+    fn matches(self, gate: Approval) -> bool {
+        matches!(
+            (self, gate),
+            (ApprovalKindFilter::Open, Approval::Open)
+                | (ApprovalKindFilter::ChangeRole, Approval::ChangeRole(_))
+                | (ApprovalKindFilter::Close, Approval::Close)
+                | (ApprovalKindFilter::Abort, Approval::Abort)
+        )
+    }
+}
+
+// ----------------------------------------------------------------------
+// Initdata: decode + policy mapping (split for independent testing)
+// ----------------------------------------------------------------------
+
+pub use initdata_proto::ReplicaInitData;
+
+/// Decode the bytes SF passes to `create_replica`. Empty bytes or a
+/// decode failure map to the default-valued `ReplicaInitData`, which
+/// keeps the rest of the pipeline a pure function of the message.
+pub fn decode_init_data(initdata: &[u8]) -> ReplicaInitData {
+    if initdata.is_empty() {
+        return ReplicaInitData::default();
+    }
+    match ReplicaInitData::decode(initdata) {
+        Ok(msg) => msg,
+        Err(e) => {
+            tracing::warn!("failed to decode ReplicaInitData ({e}); using default");
+            ReplicaInitData::default()
+        }
+    }
+}
+
+/// Policy mapping from a decoded `ReplicaInitData` to the runtime
+/// controller mode. No bytes, no I/O, no logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlMode {
+    NoControl,
+    Control,
+}
+
+impl ControlMode {
+    pub fn from_init_data(msg: &ReplicaInitData) -> Self {
+        if msg.control {
+            ControlMode::Control
+        } else {
+            ControlMode::NoControl
+        }
+    }
+}
+
+/// Build a controller from the chosen mode. Used by `Factory::create_replica`.
+pub fn make_controller(mode: ControlMode) -> Arc<dyn ReplicaController> {
+    match mode {
+        ControlMode::NoControl => Arc::new(NoopController),
+        ControlMode::Control => Arc::new(GrpcController::new()),
+    }
+}
+
+// ----------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // ---- decode_init_data / ControlMode -----------------------------
+
+    #[test]
+    fn decode_empty_bytes_yields_default_message() {
+        let msg = decode_init_data(&[]);
+        assert!(!msg.control);
+        assert_eq!(ControlMode::from_init_data(&msg), ControlMode::NoControl);
+    }
+
+    #[test]
+    fn decode_control_true_round_trips() {
+        let bytes = ReplicaInitData { control: true }.encode_to_vec();
+        let msg = decode_init_data(&bytes);
+        assert!(msg.control);
+        assert_eq!(ControlMode::from_init_data(&msg), ControlMode::Control);
+    }
+
+    #[test]
+    fn decode_control_false_round_trips() {
+        let bytes = ReplicaInitData { control: false }.encode_to_vec();
+        let msg = decode_init_data(&bytes);
+        assert!(!msg.control);
+        assert_eq!(ControlMode::from_init_data(&msg), ControlMode::NoControl);
+    }
+
+    #[test]
+    fn decode_garbage_bytes_falls_back_to_default() {
+        let msg = decode_init_data(&[0xff, 0xff, 0xff, 0xff, 0xff]);
+        assert!(!msg.control);
+        assert_eq!(ControlMode::from_init_data(&msg), ControlMode::NoControl);
+    }
+
+    // ---- NoopController --------------------------------------------
+
+    #[tokio::test]
+    async fn noop_controller_proceeds_immediately() {
+        let c = NoopController;
+        for gate in [
+            Approval::Open,
+            Approval::ChangeRole(ReplicaRole::Primary),
+            Approval::Close,
+            Approval::Abort,
+        ] {
+            match c.await_approval(gate).await {
+                Decision::Proceed => {}
+                Decision::Fail(_) => panic!("noop should always proceed"),
+            }
+        }
+        assert!(!c.is_controllable());
+    }
+
+    // ---- GrpcController happy path ---------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_controller_approve_releases_pending() {
+        let c = Arc::new(GrpcController::new());
+        let c2 = c.clone();
+        let parked = tokio::spawn(async move { c2.await_approval(Approval::Open).await });
+
+        // Wait until the gate is observable.
+        let (gate_id, gate) = c.wait_for_approval(Some(ApprovalKindFilter::Open)).await;
+        assert_eq!(gate, Approval::Open);
+
+        match c.approve(gate_id, Decision::Proceed) {
+            ApproveResult::Released => {}
+            other => panic!("expected Released, got {other:?}"),
+        }
+
+        let decision = parked.await.unwrap();
+        assert!(matches!(decision, Decision::Proceed));
+        assert!(c.peek_pending().is_none(), "slot should be cleared on exit");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_controller_approve_with_fail_propagates() {
+        let c = Arc::new(GrpcController::new());
+        let c2 = c.clone();
+        let parked = tokio::spawn(async move {
+            c2.await_approval(Approval::ChangeRole(ReplicaRole::Primary))
+                .await
+        });
+
+        let (gate_id, _) = c
+            .wait_for_approval(Some(ApprovalKindFilter::ChangeRole))
+            .await;
+        let err = mssf_core::Error::from(mssf_core::HRESULT(-1));
+        c.approve(gate_id, Decision::Fail(err));
+
+        let decision = parked.await.unwrap();
+        assert!(matches!(decision, Decision::Fail(_)));
+    }
+
+    // ---- gate_id stale-approve protection --------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn approve_with_wrong_gate_id_returns_id_mismatch() {
+        let c = Arc::new(GrpcController::new());
+        let c2 = c.clone();
+        let parked = tokio::spawn(async move { c2.await_approval(Approval::Open).await });
+
+        let (real_gate_id, _) = c.wait_for_approval(None).await;
+        let stale_gate_id = Uuid::new_v4();
+        match c.approve(stale_gate_id, Decision::Proceed) {
+            ApproveResult::IdMismatch {
+                pending_id,
+                requested_id,
+            } => {
+                assert_eq!(pending_id, real_gate_id);
+                assert_eq!(requested_id, stale_gate_id);
+            }
+            other => panic!("expected IdMismatch, got {other:?}"),
+        }
+        // The replica is still parked because we didn't consume the slot.
+        assert!(!parked.is_finished());
+        assert!(c.peek_pending().is_some());
+
+        // Real id still works.
+        c.approve(real_gate_id, Decision::Proceed);
+        let _ = parked.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn approve_when_slot_empty_returns_slot_empty() {
+        let c = GrpcController::new();
+        match c.approve(Uuid::new_v4(), Decision::Proceed) {
+            ApproveResult::SlotEmpty => {}
+            other => panic!("expected SlotEmpty, got {other:?}"),
+        }
+    }
+
+    // ---- gate_lock serialization (close -> abort queueing) ---------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn second_lifecycle_call_blocks_on_gate_lock() {
+        let c = Arc::new(GrpcController::new());
+        let c1 = c.clone();
+        let close = tokio::spawn(async move { c1.await_approval(Approval::Close).await });
+
+        // Let close park.
+        let (close_gate_id, _) = c.wait_for_approval(Some(ApprovalKindFilter::Close)).await;
+
+        // Now spawn abort; it should queue on gate_lock, not race onto pending.
+        let c2 = c.clone();
+        let abort = tokio::spawn(async move { c2.await_approval(Approval::Abort).await });
+
+        // Give the runtime a beat to actually let abort try to acquire.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // pending should still hold the close gate; abort hasn't published.
+        let (still_pending_id, still_pending_gate) = c.peek_pending().unwrap();
+        assert_eq!(still_pending_id, close_gate_id);
+        assert_eq!(still_pending_gate, Approval::Close);
+        assert!(!abort.is_finished());
+
+        // Approve close. abort should then publish its own gate.
+        c.approve(close_gate_id, Decision::Proceed);
+        let _ = close.await.unwrap();
+
+        // Abort gate eventually shows up.
+        let (abort_gate_id, abort_gate) =
+            c.wait_for_approval(Some(ApprovalKindFilter::Abort)).await;
+        assert_eq!(abort_gate, Approval::Abort);
+        assert_ne!(abort_gate_id, close_gate_id, "fresh UUID per gate");
+
+        c.approve(abort_gate_id, Decision::Proceed);
+        let _ = abort.await.unwrap();
+    }
+
+    // ---- WaitForApproval ordering races ----------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wait_first_then_await_approval() {
+        let c = Arc::new(GrpcController::new());
+        let c1 = c.clone();
+        let waiter = tokio::spawn(async move { c1.wait_for_approval(None).await });
+
+        // Give the waiter a moment to park.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let c2 = c.clone();
+        let parked = tokio::spawn(async move { c2.await_approval(Approval::Close).await });
+
+        let (gate_id, gate) = waiter.await.unwrap();
+        assert_eq!(gate, Approval::Close);
+        c.approve(gate_id, Decision::Proceed);
+        let _ = parked.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn await_approval_first_then_wait() {
+        let c = Arc::new(GrpcController::new());
+        let c1 = c.clone();
+        let parked = tokio::spawn(async move { c1.await_approval(Approval::Close).await });
+
+        // Give the parker time to publish.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Now ask: WaitForApproval should see the populated pending on
+        // the very first peek.
+        let (gate_id, gate) = c.wait_for_approval(None).await;
+        assert_eq!(gate, Approval::Close);
+        c.approve(gate_id, Decision::Proceed);
+        let _ = parked.await.unwrap();
+    }
+
+    // ---- Drop releases pending with Proceed ------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropping_controller_unblocks_parked_lifecycle() {
+        let c = Arc::new(GrpcController::new());
+        let c1 = c.clone();
+        let parked = tokio::spawn(async move { c1.await_approval(Approval::Open).await });
+
+        // Wait until the gate is published.
+        let _ = c.wait_for_approval(None).await;
+
+        // Drop the only Arcs we hold; the spawned task still has one
+        // via its captured c1, so the controller stays alive long
+        // enough for the await_approval future to be polled, but Drop
+        // will fire when the spawned task finishes its await.
+        // To force Drop synchronously, we instead approve via a direct
+        // path: simulate Drop by taking the slot and explicitly
+        // dropping its sender.
+        {
+            let mut slot = c.pending.lock().unwrap();
+            // mimic Drop's behavior: take and send Proceed
+            if let Some(p) = slot.take() {
+                let _ = p.sender.send(Decision::Proceed);
+            }
+        }
+
+        let decision = parked.await.unwrap();
+        assert!(matches!(decision, Decision::Proceed));
+    }
+
+    // ---- ApprovalKindFilter ----------------------------------------
+
+    #[test]
+    fn approval_kind_filter_matches_correctly() {
+        assert!(ApprovalKindFilter::Open.matches(Approval::Open));
+        assert!(!ApprovalKindFilter::Open.matches(Approval::Close));
+        assert!(ApprovalKindFilter::ChangeRole.matches(Approval::ChangeRole(ReplicaRole::Primary)));
+        assert!(ApprovalKindFilter::ChangeRole.matches(Approval::ChangeRole(ReplicaRole::None)));
+        assert!(ApprovalKindFilter::Close.matches(Approval::Close));
+        assert!(ApprovalKindFilter::Abort.matches(Approval::Abort));
+    }
+
+    // ---- Detach -----------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn detach_releases_pending_and_skips_future_gates() {
+        let c = Arc::new(GrpcController::new());
+
+        // Park a gate.
+        let c1 = c.clone();
+        let parked = tokio::spawn(async move { c1.await_approval(Approval::Open).await });
+        let _ = c.wait_for_approval(None).await;
+        assert!(c.peek_pending().is_some());
+        assert!(!c.is_detached());
+
+        // Detach: the parked gate releases with Proceed and the slot
+        // clears; controller flips into proceed-forever mode.
+        c.detach();
+        assert!(c.is_detached());
+        let decision = parked.await.unwrap();
+        assert!(matches!(decision, Decision::Proceed));
+
+        // Future gates short-circuit without parking.
+        let t0 = std::time::Instant::now();
+        for gate in [
+            Approval::ChangeRole(ReplicaRole::Primary),
+            Approval::Close,
+            Approval::Abort,
+        ] {
+            let d = c.await_approval(gate).await;
+            assert!(matches!(d, Decision::Proceed));
+        }
+        // Sanity: no parking means each call is sub-millisecond.
+        assert!(
+            t0.elapsed() < Duration::from_millis(50),
+            "post-detach await_approval should not park (took {:?})",
+            t0.elapsed(),
+        );
+        // pending stays empty.
+        assert!(c.peek_pending().is_none());
+    }
+
+    #[tokio::test]
+    async fn detach_before_any_gate_is_idempotent() {
+        let c = GrpcController::new();
+        c.detach();
+        c.detach(); // second call no-ops
+        let d = c.await_approval(Approval::Open).await;
+        assert!(matches!(d, Decision::Proceed));
+        assert!(c.is_detached());
+    }
+}

--- a/crates/samples/reflection/src/grpc.rs
+++ b/crates/samples/reflection/src/grpc.rs
@@ -10,6 +10,8 @@ use tonic::{Request, Response, Status};
 
 use mssf_core::types::ReplicaRole;
 
+use crate::control::ReplicaController;
+
 pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
@@ -36,6 +38,10 @@ pub struct ReplicaEntry {
     pub partition_id: mssf_core::GUID,
     pub replica_id: i64,
     pub role: ReplicaRole,
+    /// `None` for `NoopController` replicas (production path); `Some` for
+    /// `GrpcController` replicas (test-driven). gRPC handlers that need
+    /// the controller use [`ReplicaRegistry::get_controller`].
+    pub controller: Option<Arc<dyn ReplicaController>>,
 }
 
 /// Shared state between gRPC server and Service Fabric service factory.
@@ -51,6 +57,26 @@ impl ReplicaRegistry {
     }
 
     pub fn add(&self, partition_id: mssf_core::GUID, replica_id: i64) {
+        self.add_with_controller(partition_id, replica_id, None);
+    }
+
+    /// Register a controllable replica. Only called for `GrpcController`
+    /// replicas (i.e., when the decoded `ReplicaInitData` had `control = true`).
+    pub fn add_controller(
+        &self,
+        partition_id: mssf_core::GUID,
+        replica_id: i64,
+        controller: Arc<dyn ReplicaController>,
+    ) {
+        self.add_with_controller(partition_id, replica_id, Some(controller));
+    }
+
+    fn add_with_controller(
+        &self,
+        partition_id: mssf_core::GUID,
+        replica_id: i64,
+        controller: Option<Arc<dyn ReplicaController>>,
+    ) {
         self.inner
             .lock()
             .unwrap()
@@ -60,7 +86,35 @@ impl ReplicaRegistry {
                 partition_id,
                 replica_id,
                 role: ReplicaRole::Unknown,
+                controller,
             });
+    }
+
+    /// Look up a replica's controller (if any).
+    pub fn get_controller(
+        &self,
+        partition_id: mssf_core::GUID,
+        replica_id: i64,
+    ) -> Option<Arc<dyn ReplicaController>> {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(&partition_id)?
+            .iter()
+            .find(|e| e.replica_id == replica_id)?
+            .controller
+            .clone()
+    }
+
+    /// Snapshot of all registered entries (used by ListPending).
+    pub fn snapshot(&self) -> Vec<ReplicaEntry> {
+        self.inner
+            .lock()
+            .unwrap()
+            .values()
+            .flatten()
+            .cloned()
+            .collect()
     }
 
     pub fn update_role(&self, partition_id: mssf_core::GUID, replica_id: i64, role: ReplicaRole) {

--- a/crates/samples/reflection/src/grpc_control.rs
+++ b/crates/samples/reflection/src/grpc_control.rs
@@ -1,0 +1,414 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! gRPC `ReplicaControl` server implementation.
+//!
+//! See `docs/design/ReflectionReplicaTestControl.md` §4 (proto), §7
+//! (transport), and §8 (RPC error model).
+
+use std::time::Duration;
+
+use tonic::{Request, Response, Status};
+
+use crate::control::{Approval, ApprovalKindFilter, ApproveResult, Decision};
+use crate::grpc::ReplicaRegistry;
+
+pub mod proto {
+    tonic::include_proto!("reflection.control.v1");
+}
+
+use proto::approve_request::Decision as ApproveDecisionOneof;
+use proto::list_pending_request::ReplicaFilter;
+use proto::replica_control_server::{ReplicaControl, ReplicaControlServer};
+use proto::{
+    ApprovalEvent, ApprovalKind, ApproveRequest, DetachAllResponse, Empty, ListPendingRequest,
+    ListPendingResponse, ReplicaRef, ReplicaRole as ProtoReplicaRole, WaitForApprovalRequest,
+};
+
+/// Default wait timeout when `WaitForApprovalRequest.timeout_ms` is 0.
+/// Capped at [`MAX_WAIT_TIMEOUT`] to bound server-side resource usage.
+pub const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+pub const MAX_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Base port for the `ReplicaControl` gRPC server. Per-node port is
+/// `BASE + node_index(Fabric_NodeName)`. Picked outside both onebox
+/// `<ApplicationEndpoints>` ranges (Linux 22001–27000, Windows
+/// 30001–35000) and outside Linux/Windows ephemeral ranges.
+pub const REFLECTION_CONTROL_BASE_PORT: u16 = 28_000;
+
+/// 0-based onebox node index parsed from `Fabric_NodeName`. Onebox
+/// node names differ by platform; both arms produce 0..=4 for the
+/// current 5-node topology.
+pub fn node_index(node_name: &str) -> u16 {
+    #[cfg(target_os = "windows")]
+    {
+        // Windows onebox: "_Node_3" -> "3" -> 3
+        node_name
+            .rsplit('_')
+            .next()
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or_else(|| panic!("unexpected Windows onebox node name: {node_name}"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Linux onebox: "N0030" -> 30 -> 30/10 - 1 = 2
+        let digits = node_name.trim_start_matches('N');
+        let n: u16 = digits
+            .parse()
+            .unwrap_or_else(|_| panic!("unexpected Linux onebox node name: {node_name}"));
+        assert!(
+            n >= 10 && n.is_multiple_of(10),
+            "Linux onebox node names are expected to be N00<idx>0, got: {node_name}"
+        );
+        n / 10 - 1
+    }
+}
+
+pub fn control_port_for_node(node_name: &str) -> u16 {
+    REFLECTION_CONTROL_BASE_PORT
+        .checked_add(node_index(node_name))
+        .expect("node index too large for port range")
+}
+
+#[derive(Debug)]
+pub struct ReplicaControlImpl {
+    registry: ReplicaRegistry,
+}
+
+impl ReplicaControlImpl {
+    pub fn new(registry: ReplicaRegistry) -> Self {
+        Self { registry }
+    }
+}
+
+pub fn replica_control_server(
+    registry: ReplicaRegistry,
+) -> ReplicaControlServer<ReplicaControlImpl> {
+    ReplicaControlServer::new(ReplicaControlImpl::new(registry))
+}
+
+// ----------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------
+
+fn parse_replica_ref(r: Option<&ReplicaRef>) -> Result<(mssf_core::GUID, i64), Status> {
+    let r = r.ok_or_else(|| Status::invalid_argument("missing target"))?;
+    if r.partition_id.is_empty() {
+        return Err(Status::invalid_argument("missing target.partition_id"));
+    }
+    let parsed = uuid::Uuid::parse_str(&r.partition_id)
+        .map_err(|e| Status::invalid_argument(format!("invalid partition_id: {e}")))?;
+    Ok((mssf_core::GUID::from_u128(parsed.as_u128()), r.replica_id))
+}
+
+fn approval_kind_filter_from_proto(k: i32) -> Result<Option<ApprovalKindFilter>, Status> {
+    let kind = ApprovalKind::try_from(k)
+        .map_err(|_| Status::invalid_argument(format!("unknown ApprovalKind: {k}")))?;
+    Ok(match kind {
+        ApprovalKind::ApprovalUnspecified => None,
+        ApprovalKind::ApprovalOpen => Some(ApprovalKindFilter::Open),
+        ApprovalKind::ApprovalChangeRole => Some(ApprovalKindFilter::ChangeRole),
+        ApprovalKind::ApprovalClose => Some(ApprovalKindFilter::Close),
+        ApprovalKind::ApprovalAbort => Some(ApprovalKindFilter::Abort),
+    })
+}
+
+fn approval_to_proto(gate: Approval) -> (ApprovalKind, ProtoReplicaRole) {
+    match gate {
+        Approval::Open => (ApprovalKind::ApprovalOpen, ProtoReplicaRole::Unknown),
+        Approval::Close => (ApprovalKind::ApprovalClose, ProtoReplicaRole::Unknown),
+        Approval::Abort => (ApprovalKind::ApprovalAbort, ProtoReplicaRole::Unknown),
+        Approval::ChangeRole(role) => (
+            ApprovalKind::ApprovalChangeRole,
+            replica_role_to_proto(role),
+        ),
+    }
+}
+
+fn replica_role_to_proto(role: mssf_core::types::ReplicaRole) -> ProtoReplicaRole {
+    use mssf_core::types::ReplicaRole as R;
+    match role {
+        R::None => ProtoReplicaRole::None,
+        R::Primary => ProtoReplicaRole::Primary,
+        R::IdleSecondary => ProtoReplicaRole::IdleSecondary,
+        R::ActiveSecondary => ProtoReplicaRole::ActiveSecondary,
+        R::IdleAuxiliary => ProtoReplicaRole::IdleAuxiliary,
+        R::ActiveAuxiliary => ProtoReplicaRole::ActiveAuxiliary,
+        R::PrimaryAuxiliary => ProtoReplicaRole::PrimaryAuxiliary,
+        _ => ProtoReplicaRole::Unknown,
+    }
+}
+
+fn build_approval_event(
+    partition_id: mssf_core::GUID,
+    replica_id: i64,
+    gate_id: uuid::Uuid,
+    gate: Approval,
+) -> ApprovalEvent {
+    let (kind, new_role) = approval_to_proto(gate);
+    ApprovalEvent {
+        target: Some(ReplicaRef {
+            partition_id: format!("{partition_id:?}"),
+            replica_id,
+        }),
+        kind: kind as i32,
+        new_role: new_role as i32,
+        gate_id: gate_id.to_string(),
+    }
+}
+
+fn clamp_timeout(timeout_ms: u32) -> Duration {
+    if timeout_ms == 0 {
+        DEFAULT_WAIT_TIMEOUT
+    } else {
+        let requested = Duration::from_millis(timeout_ms as u64);
+        std::cmp::min(requested, MAX_WAIT_TIMEOUT)
+    }
+}
+
+// ----------------------------------------------------------------------
+// gRPC handlers
+// ----------------------------------------------------------------------
+
+#[tonic::async_trait]
+impl ReplicaControl for ReplicaControlImpl {
+    async fn wait_for_approval(
+        &self,
+        request: Request<WaitForApprovalRequest>,
+    ) -> Result<Response<ApprovalEvent>, Status> {
+        let req = request.into_inner();
+        let (partition_id, replica_id) = parse_replica_ref(req.target.as_ref())?;
+        let expected = approval_kind_filter_from_proto(req.expected)?;
+        let timeout = clamp_timeout(req.timeout_ms);
+
+        let controller = self
+            .registry
+            .get_controller(partition_id, replica_id)
+            .ok_or_else(|| Status::not_found("replica not registered (or not controllable)"))?;
+
+        // Downcast to the concrete GrpcController so we can call its
+        // wait_for_approval. The trait only exposes await_approval; the
+        // inspection method is a concrete-type concern.
+        let grpc = controller
+            .as_any()
+            .downcast_ref::<crate::control::GrpcController>()
+            .ok_or_else(|| Status::internal("registered controller is not a GrpcController"))?;
+
+        match tokio::time::timeout(timeout, grpc.wait_for_approval(expected)).await {
+            Ok((gate_id, gate)) => Ok(Response::new(build_approval_event(
+                partition_id,
+                replica_id,
+                gate_id,
+                gate,
+            ))),
+            Err(_) => Err(Status::deadline_exceeded(format!(
+                "WaitForApproval timed out after {} ms",
+                timeout.as_millis(),
+            ))),
+        }
+    }
+
+    async fn approve(&self, request: Request<ApproveRequest>) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        let (partition_id, replica_id) = parse_replica_ref(req.target.as_ref())?;
+        let gate_id = uuid::Uuid::parse_str(&req.gate_id)
+            .map_err(|e| Status::invalid_argument(format!("invalid gate_id: {e}")))?;
+
+        let controller = self
+            .registry
+            .get_controller(partition_id, replica_id)
+            .ok_or_else(|| Status::not_found("replica not registered (or already removed)"))?;
+        let grpc = controller
+            .as_any()
+            .downcast_ref::<crate::control::GrpcController>()
+            .ok_or_else(|| Status::internal("registered controller is not a GrpcController"))?;
+
+        // Peek the pending kind first so we can validate Abort
+        // gates reject fail_message decisions cleanly (per §8 RPC
+        // error model).
+        let pending_kind = grpc.peek_pending().map(|(_, gate)| gate);
+
+        let decision = match req.decision {
+            Some(ApproveDecisionOneof::Proceed(_)) | None => Decision::Proceed,
+            Some(ApproveDecisionOneof::FailMessage(msg)) => {
+                if matches!(pending_kind, Some(Approval::Abort)) {
+                    return Err(Status::invalid_argument(
+                        "fail_message is not allowed for APPROVAL_ABORT (SF abort cannot fail)",
+                    ));
+                }
+                // mssf_core::Error only wraps an HRESULT; the
+                // message is logged server-side for diagnostics but
+                // SF itself only sees the code.
+                tracing::info!("Approve(FailMessage): {} (returned to SF as E_FAIL)", msg);
+                Decision::Fail(mssf_core::Error::new(mssf_core::HRESULT(
+                    0x80004005u32 as i32, // E_FAIL
+                )))
+            }
+        };
+
+        match grpc.approve(gate_id, decision) {
+            ApproveResult::Released => Ok(Response::new(Empty {})),
+            ApproveResult::SlotEmpty => Err(Status::failed_precondition(
+                "gate already consumed (pending slot is empty)",
+            )),
+            ApproveResult::IdMismatch {
+                pending_id,
+                requested_id,
+            } => Err(Status::failed_precondition(format!(
+                "gate id mismatch: pending={pending_id}, requested={requested_id}"
+            ))),
+        }
+    }
+
+    async fn list_pending(
+        &self,
+        request: Request<ListPendingRequest>,
+    ) -> Result<Response<ListPendingResponse>, Status> {
+        let req = request.into_inner();
+
+        let partition_filter = if req.partition_id.is_empty() {
+            None
+        } else {
+            let parsed = uuid::Uuid::parse_str(&req.partition_id)
+                .map_err(|e| Status::invalid_argument(format!("invalid partition_id: {e}")))?;
+            Some(mssf_core::GUID::from_u128(parsed.as_u128()))
+        };
+        let replica_filter = req
+            .replica_filter
+            .map(|ReplicaFilter::SpecificReplicaId(id)| id);
+        if replica_filter.is_some() && partition_filter.is_none() {
+            return Err(Status::invalid_argument(
+                "specific_replica_id requires partition_id (replica ids are not unique across partitions)",
+            ));
+        }
+
+        let entries = self.registry.snapshot();
+        let mut events = Vec::new();
+        for entry in entries {
+            if let Some(p) = partition_filter
+                && entry.partition_id != p
+            {
+                continue;
+            }
+            if let Some(r) = replica_filter
+                && entry.replica_id != r
+            {
+                continue;
+            }
+            let Some(controller) = entry.controller.as_ref() else {
+                continue;
+            };
+            let Some(grpc) = controller
+                .as_any()
+                .downcast_ref::<crate::control::GrpcController>()
+            else {
+                continue;
+            };
+            if let Some((gate_id, gate)) = grpc.peek_pending() {
+                events.push(build_approval_event(
+                    entry.partition_id,
+                    entry.replica_id,
+                    gate_id,
+                    gate,
+                ));
+            }
+        }
+        Ok(Response::new(ListPendingResponse { events }))
+    }
+
+    async fn detach(&self, request: Request<ReplicaRef>) -> Result<Response<Empty>, Status> {
+        let r = request.into_inner();
+        let (partition_id, replica_id) = parse_replica_ref(Some(&r))?;
+        let controller = self
+            .registry
+            .get_controller(partition_id, replica_id)
+            .ok_or_else(|| Status::not_found("replica not registered (or not controllable)"))?;
+        let grpc = controller
+            .as_any()
+            .downcast_ref::<crate::control::GrpcController>()
+            .ok_or_else(|| Status::internal("registered controller is not a GrpcController"))?;
+        grpc.detach();
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn detach_all(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<DetachAllResponse>, Status> {
+        let mut detached = 0u32;
+        for entry in self.registry.snapshot() {
+            let Some(controller) = entry.controller else {
+                continue;
+            };
+            let Some(grpc) = controller
+                .as_any()
+                .downcast_ref::<crate::control::GrpcController>()
+            else {
+                continue;
+            };
+            if grpc.is_detached() {
+                continue;
+            }
+            grpc.detach();
+            detached += 1;
+        }
+        Ok(Response::new(DetachAllResponse { detached }))
+    }
+}
+
+// ----------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_node_index_parses_n00x0_format() {
+        assert_eq!(node_index("N0010"), 0);
+        assert_eq!(node_index("N0020"), 1);
+        assert_eq!(node_index("N0030"), 2);
+        assert_eq!(node_index("N0040"), 3);
+        assert_eq!(node_index("N0050"), 4);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_node_index_parses_underscore_format() {
+        assert_eq!(node_index("_Node_0"), 0);
+        assert_eq!(node_index("_Node_1"), 1);
+        assert_eq!(node_index("_Node_4"), 4);
+    }
+
+    #[test]
+    fn control_port_offsets_from_base() {
+        // Smoke-test the cfg-correct host's range maps to 28000..=28004.
+        #[cfg(target_os = "linux")]
+        for (name, expected) in [("N0010", 28000), ("N0030", 28002), ("N0050", 28004)] {
+            assert_eq!(control_port_for_node(name), expected);
+        }
+        #[cfg(target_os = "windows")]
+        for (name, expected) in [("_Node_0", 28000), ("_Node_2", 28002), ("_Node_4", 28004)] {
+            assert_eq!(control_port_for_node(name), expected);
+        }
+    }
+
+    #[test]
+    fn clamp_timeout_zero_uses_default() {
+        assert_eq!(clamp_timeout(0), DEFAULT_WAIT_TIMEOUT);
+    }
+
+    #[test]
+    fn clamp_timeout_oversized_clamps_to_max() {
+        assert_eq!(clamp_timeout(u32::MAX), MAX_WAIT_TIMEOUT);
+    }
+
+    #[test]
+    fn clamp_timeout_in_range_passes_through() {
+        assert_eq!(clamp_timeout(1500), Duration::from_millis(1500));
+    }
+}

--- a/crates/samples/reflection/src/lib.rs
+++ b/crates/samples/reflection/src/lib.rs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Reflection sample as a library so the binary (`samples_reflection`) can
+//! be paired with integration tests under `tests/`.
+//!
+//! The bin target ([`main.rs`](../bin/main.rs.html) — runs as the SF
+//! service host) imports from this crate; integration tests under
+//! [`tests/`](../../tests/) drive the deployed cluster via the public
+//! API exposed here (notably the `grpc_control` module's gRPC client
+//! types and the `transport`-style constants for endpoint discovery).
+
+pub mod control;
+pub mod echo;
+pub mod grpc;
+pub mod grpc_control;
+pub mod statefulstore;
+pub mod test_cluster;
+
+pub use statefulstore::Factory;
+
+/// Service-type name registered by the reflection sample. Must match the
+/// value declared in `manifests/ServiceManifest.xml`.
+pub const SERVICE_TYPE_NAME: &str = "ReflectionAppService";
+
+#[cfg(test)]
+mod test;
+
+#[cfg(test)]
+mod test2;

--- a/crates/samples/reflection/src/main.rs
+++ b/crates/samples/reflection/src/main.rs
@@ -3,25 +3,16 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::grpc::ReplicaRegistry;
-use crate::statefulstore::Factory;
 use mssf_core::WString;
 use mssf_core::runtime::CodePackageActivationContext;
 use mssf_util::tokio::TokioExecutor;
+use samples_reflection::SERVICE_TYPE_NAME;
+use samples_reflection::grpc;
+use samples_reflection::grpc::ReplicaRegistry;
+use samples_reflection::grpc_control::{control_port_for_node, replica_control_server};
+use samples_reflection::statefulstore::Factory;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
-
-mod echo;
-mod grpc;
-mod statefulstore;
-
-#[cfg(test)]
-mod test;
-
-#[cfg(test)]
-mod test2;
-
-const SERVICE_TYPE_NAME: &str = "ReflectionAppService";
 
 fn main() -> mssf_core::Result<()> {
     tracing_subscriber::fmt().init();
@@ -36,21 +27,31 @@ fn main() -> mssf_core::Result<()> {
         .unwrap();
     let hostname = get_hostname().expect("cannot get hostname");
 
-    // Bind gRPC listener on all interfaces, port 0 to let OS assign a port
-    let grpc_bind_addr: std::net::SocketAddr = ([0, 0, 0, 0], 0).into();
-    let std_listener =
-        std::net::TcpListener::bind(grpc_bind_addr).expect("failed to bind gRPC listener");
+    // Bind the gRPC server on a fixed port derived from the running
+    // node's name. See docs/design/ReflectionReplicaTestControl.md §7.
+    // Both the demo Greeter and the test-only ReplicaControl services
+    // share this socket. Bind on 0.0.0.0 so a test driver in a
+    // sibling container can reach it via the onebox container's IP
+    // (Linux devcontainer setup) and so a same-host test driver can
+    // reach it via 127.0.0.1 (Windows onebox).
+    let node_ctx = mssf_core::runtime::node_context::NodeContext::get_sync()
+        .expect("failed to get NodeContext");
+    let node_name = node_ctx.node_name.to_string();
+    let grpc_port = control_port_for_node(&node_name);
+    let grpc_bind_addr: std::net::SocketAddr = ([0, 0, 0, 0], grpc_port).into();
+    let std_listener = std::net::TcpListener::bind(grpc_bind_addr).unwrap_or_else(|e| {
+        panic!("failed to bind gRPC listener on {grpc_bind_addr} (node {node_name}): {e}")
+    });
     std_listener
         .set_nonblocking(true)
         .expect("failed to set non-blocking");
     let grpc_local_addr = std_listener.local_addr().expect("failed to get local addr");
-    let grpc_port = grpc_local_addr.port();
-    info!("gRPC server listening on {}", grpc_local_addr);
+    info!("gRPC server listening on {grpc_local_addr} (node {node_name})");
 
     // Shared state between gRPC and Service Fabric
     let registry = ReplicaRegistry::new();
 
-    // Start the gRPC hello world server
+    // Start the gRPC server (Greeter + ReplicaControl)
     let token = CancellationToken::new();
     let grpc_token = token.clone();
     let grpc_registry = registry.clone();
@@ -59,14 +60,14 @@ fn main() -> mssf_core::Result<()> {
             .expect("failed to convert to tokio listener");
         let incoming = tonic::transport::server::TcpIncoming::from(tokio_listener);
         tonic::transport::Server::builder()
-            .add_service(grpc::greeter_server(grpc_registry))
+            .add_service(grpc::greeter_server(grpc_registry.clone()))
+            .add_service(replica_control_server(grpc_registry))
             .serve_with_incoming_shutdown(incoming, async move {
                 grpc_token.cancelled().await;
             })
             .await
             .expect("gRPC server failed");
     });
-    info!("gRPC server listening on {}", grpc_local_addr);
 
     let factory = Box::new(Factory::create(
         endpoint.port,

--- a/crates/samples/reflection/src/statefulstore.rs
+++ b/crates/samples/reflection/src/statefulstore.rs
@@ -19,6 +19,9 @@ use std::{
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
+use crate::control::{
+    Approval, ControlMode, Decision, ReplicaController, decode_init_data, make_controller,
+};
 use crate::echo;
 use crate::grpc::{ReflectionUrl, ReplicaRegistry};
 
@@ -58,13 +61,21 @@ impl IStatefulServiceFactory for Factory {
         partitionid: mssf_core::GUID,
         replicaid: i64,
     ) -> Result<Box<dyn IStatefulServiceReplica>, Error> {
+        // Decide test-control mode from the bytes SF passes us. Empty
+        // initdata or decode failure -> NoControl, preserving the
+        // current production behavior.
+        let init = decode_init_data(initializationdata);
+        let mode = ControlMode::from_init_data(&init);
+        let controller = make_controller(mode);
+
         info!(
-            "Factory::create_replica type {}, service {}, init data size {}, partition {:?}, replica {}",
+            "Factory::create_replica type {}, service {}, init data size {}, partition {:?}, replica {}, mode {:?}",
             servicetypename,
             servicename,
             initializationdata.len(),
             partitionid,
-            replicaid
+            replicaid,
+            mode,
         );
 
         let svc = Service::new(
@@ -72,7 +83,14 @@ impl IStatefulServiceFactory for Factory {
             self.replication_port,
             self.hostname.clone(),
         );
-        self.registry.add(partitionid, replicaid);
+
+        if controller.is_controllable() {
+            self.registry
+                .add_controller(partitionid, replicaid, controller.clone());
+        } else {
+            self.registry.add(partitionid, replicaid);
+        }
+
         let replica = Box::new(Replica::new(
             self.hostname.to_string(),
             self.grpc_port,
@@ -80,6 +98,8 @@ impl IStatefulServiceFactory for Factory {
             replicaid,
             self.registry.clone(),
             svc,
+            controller,
+            self.rt.clone(),
         ));
         Ok(replica)
     }
@@ -93,9 +113,16 @@ pub struct Replica {
     registry: ReplicaRegistry,
     svc: Service,
     ctx: ReplicaCtx,
+    /// Per-replica controller. `NoopController` for production-mode
+    /// replicas (one inline `Decision::Proceed` per gate);
+    /// `GrpcController` for test-driven replicas.
+    controller: Arc<dyn ReplicaController>,
+    /// Used by `abort` to bridge sync->async into `await_approval`.
+    exec: TokioExecutor,
 }
 
 impl Replica {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         grpc_hostname: String,
         grpc_port: u16,
@@ -103,6 +130,8 @@ impl Replica {
         replica_id: i64,
         registry: ReplicaRegistry,
         svc: Service,
+        controller: Arc<dyn ReplicaController>,
+        exec: TokioExecutor,
     ) -> Replica {
         Replica {
             grpc_hostname,
@@ -112,6 +141,8 @@ impl Replica {
             registry,
             svc,
             ctx: ReplicaCtx::empty(),
+            controller,
+            exec,
         }
     }
 }
@@ -165,6 +196,10 @@ impl IStatefulServiceReplica for Replica {
         partition: Arc<dyn IStatefulServicePartition>,
         _token: BoxedCancelToken,
     ) -> mssf_core::Result<Box<dyn IPrimaryReplicator>> {
+        match self.controller.await_approval(Approval::Open).await {
+            Decision::Proceed => {}
+            Decision::Fail(e) => return Err(e),
+        }
         self.ctx.init(partition.clone());
         self.svc.start_loop_in_background(&partition);
         // Use empty replicator
@@ -179,6 +214,14 @@ impl IStatefulServiceReplica for Replica {
         newrole: ReplicaRole,
         _token: BoxedCancelToken,
     ) -> mssf_core::Result<WString> {
+        match self
+            .controller
+            .await_approval(Approval::ChangeRole(newrole))
+            .await
+        {
+            Decision::Proceed => {}
+            Decision::Fail(e) => return Err(e),
+        }
         self.registry
             .update_role(self.partition_id, self.replica_id, newrole);
         // return the gRPC address with partition and replica id as query params
@@ -192,6 +235,10 @@ impl IStatefulServiceReplica for Replica {
     }
     #[tracing::instrument(skip(self,_token), fields(read_status = ?self.ctx.read_status(), write_status = ?self.ctx.write_status()), err, ret)]
     async fn close(&self, _token: BoxedCancelToken) -> mssf_core::Result<()> {
+        match self.controller.await_approval(Approval::Close).await {
+            Decision::Proceed => {}
+            Decision::Fail(e) => return Err(e),
+        }
         self.registry.remove(self.partition_id, self.replica_id);
         self.svc.stop();
         Ok(())
@@ -199,6 +246,16 @@ impl IStatefulServiceReplica for Replica {
     #[tracing::instrument(skip(self), fields(read_status = ?self.ctx.read_status(), write_status = ?self.ctx.write_status()))]
     fn abort(&self) {
         info!("abort",);
+        // Sync->async bridge for the abort gate. Decision is
+        // intentionally ignored: IStatefulServiceReplica::abort
+        // returns () and cannot propagate an error. Under
+        // NoopController this resolves immediately; under
+        // GrpcController this may queue at gate_lock if a previous
+        // lifecycle method (e.g. close) is still parked.
+        let controller = self.controller.clone();
+        self.exec.block_on_any(async move {
+            let _ = controller.await_approval(Approval::Abort).await;
+        });
         self.registry.remove(self.partition_id, self.replica_id);
         self.svc.stop();
     }

--- a/crates/samples/reflection/src/test_cluster.rs
+++ b/crates/samples/reflection/src/test_cluster.rs
@@ -22,10 +22,13 @@
 //! [`tests/control_e2e.rs`](../../tests/control_e2e.rs) and changing
 //! only the gate sequence at the bottom.
 //!
-//! The cluster's hostname comes from `$REFLECTION_CLUSTER_HOST`,
-//! defaulting to `"onebox"` (the sibling-container DNS name in the
-//! Linux devcontainer). Override the env var for non-devcontainer
-//! topologies.
+//! The cluster's hostname comes from `$REFLECTION_CLUSTER_HOST`. The
+//! compile-time default is platform-specific:
+//! - Windows → `"localhost"` (SF onebox runs on the same host).
+//! - Unix → `"onebox"` (the sibling-container DNS name in the
+//!   `.devcontainer/*` docker-compose setup).
+//!
+//! Override the env var for any other topology.
 
 use std::time::Duration;
 
@@ -50,11 +53,19 @@ pub const POLL_BUDGET: Duration = Duration::from_secs(30);
 /// gRPC `WaitForApproval` deadline sent to the server.
 pub const WAIT_FOR_APPROVAL_TIMEOUT_MS: u32 = 30_000;
 
-/// Hostname-or-IP that resolves to the cluster. Defaults to `"onebox"`
-/// (the docker-compose / devcontainer hostname). Override with
-/// `REFLECTION_CLUSTER_HOST` for non-devcontainer setups.
+/// Hostname-or-IP that resolves to the cluster.
+///
+/// Compile-time default:
+/// - Windows → `"localhost"` (SF onebox runs on the same host).
+/// - Unix → `"onebox"` (the docker-compose / devcontainer hostname).
+///
+/// Override at runtime with `REFLECTION_CLUSTER_HOST`.
 pub fn cluster_host() -> String {
-    std::env::var("REFLECTION_CLUSTER_HOST").unwrap_or_else(|_| "onebox".to_string())
+    #[cfg(windows)]
+    const DEFAULT_HOST: &str = "localhost";
+    #[cfg(not(windows))]
+    const DEFAULT_HOST: &str = "onebox";
+    std::env::var("REFLECTION_CLUSTER_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string())
 }
 
 /// Holds one connection slot per candidate `ReplicaControl` port.

--- a/crates/samples/reflection/src/test_cluster.rs
+++ b/crates/samples/reflection/src/test_cluster.rs
@@ -1,0 +1,437 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Reusable test harness for `ReplicaControl`-based integration tests.
+//!
+//! Every test against the reflection sample's gRPC control plane needs
+//! the same plumbing:
+//!
+//! - Dial a candidate set of `28000..=28004` ports, with re-dial on
+//!   each poll iteration so newly-activated nodes are picked up.
+//! - Poll `ListPending` across all reachable nodes until a gate of the
+//!   expected kind appears (the test driver doesn't know up-front
+//!   which node SF placed the replica on).
+//! - Wait for / approve specific gates by `(partition_id, replica_id,
+//!   gate_id)`.
+//! - Best-effort release of leftover gates from prior failed runs.
+//!
+//! This module factors that out so individual test files can focus on
+//! the lifecycle scenario being verified. Add a new test by copying
+//! [`tests/control_e2e.rs`](../../tests/control_e2e.rs) and changing
+//! only the gate sequence at the bottom.
+//!
+//! The cluster's hostname comes from `$REFLECTION_CLUSTER_HOST`,
+//! defaulting to `"onebox"` (the sibling-container DNS name in the
+//! Linux devcontainer). Override the env var for non-devcontainer
+//! topologies.
+
+use std::time::Duration;
+
+use tonic::transport::{Channel, Endpoint};
+
+use crate::grpc_control::REFLECTION_CONTROL_BASE_PORT;
+use crate::grpc_control::proto::{
+    ApprovalEvent, ApprovalKind, ApproveRequest, Empty, ListPendingRequest, ReplicaRef,
+    WaitForApprovalRequest, approve_request::Decision as ApproveDecisionOneof,
+    replica_control_client::ReplicaControlClient,
+};
+
+/// Number of candidate node ports the harness will dial.
+pub const NODE_COUNT: u16 = 5;
+
+/// Default poll backoff between `ListPending` iterations.
+pub const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Default total time `poll_for_pending` will wait before panicking.
+pub const POLL_BUDGET: Duration = Duration::from_secs(30);
+
+/// gRPC `WaitForApproval` deadline sent to the server.
+pub const WAIT_FOR_APPROVAL_TIMEOUT_MS: u32 = 30_000;
+
+/// Hostname-or-IP that resolves to the cluster. Defaults to `"onebox"`
+/// (the docker-compose / devcontainer hostname). Override with
+/// `REFLECTION_CLUSTER_HOST` for non-devcontainer setups.
+pub fn cluster_host() -> String {
+    std::env::var("REFLECTION_CLUSTER_HOST").unwrap_or_else(|_| "onebox".to_string())
+}
+
+/// Holds one connection slot per candidate `ReplicaControl` port.
+/// Reconnects lazily so a node that activates the reflection sample
+/// *after* the test starts (e.g., when SF places a fresh primary on a
+/// previously idle node) becomes reachable on the next [`Cluster::ensure`]
+/// call without the test having to retry the whole startup loop.
+pub struct Cluster {
+    host: String,
+    clients: Vec<Option<ReplicaControlClient<Channel>>>,
+    connect_timeout: Duration,
+}
+
+impl Cluster {
+    /// Build an empty cluster handle pointing at `cluster_host()`. No
+    /// connections happen until [`Cluster::ensure`] is called.
+    pub fn new() -> Self {
+        Self::with_host(cluster_host())
+    }
+
+    pub fn with_host(host: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            clients: (0..NODE_COUNT).map(|_| None).collect(),
+            connect_timeout: Duration::from_millis(500),
+        }
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Try to connect any slot that is currently `None`. Errors are
+    /// suppressed because a node may not host the reflection sample
+    /// yet (or ever).
+    pub async fn ensure(&mut self) {
+        for (i, slot) in self.clients.iter_mut().enumerate() {
+            if slot.is_some() {
+                continue;
+            }
+            let port = REFLECTION_CONTROL_BASE_PORT + i as u16;
+            let url = format!("http://{}:{}", self.host, port);
+            let endpoint = match Endpoint::from_shared(url.clone()) {
+                Ok(e) => e
+                    .connect_timeout(self.connect_timeout)
+                    .timeout(Duration::from_secs(60)),
+                Err(_) => continue,
+            };
+            match endpoint.connect().await {
+                Ok(ch) => {
+                    tracing::info!("connected to {url}");
+                    *slot = Some(ReplicaControlClient::new(ch));
+                }
+                Err(e) => {
+                    tracing::debug!("skip {url}: {e}");
+                }
+            }
+        }
+    }
+
+    pub fn connected_count(&self) -> usize {
+        self.clients.iter().filter(|c| c.is_some()).count()
+    }
+
+    /// Iterate over all currently-connected `(node_index, client)`.
+    pub fn iter_connected_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (usize, &mut ReplicaControlClient<Channel>)> {
+        self.clients
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(i, c)| c.as_mut().map(|client| (i, client)))
+    }
+
+    /// Get a mutable reference to the client for `idx`. Panics if the
+    /// slot is not connected — callers that already discovered `idx`
+    /// via [`Cluster::poll_for_pending`] are guaranteed to find it
+    /// connected.
+    pub fn client_mut(&mut self, idx: usize) -> &mut ReplicaControlClient<Channel> {
+        self.clients[idx]
+            .as_mut()
+            .unwrap_or_else(|| panic!("cluster slot {idx} is not connected"))
+    }
+
+    /// Drop a stale connection so the next [`Cluster::ensure`] reconnects.
+    pub fn invalidate(&mut self, idx: usize) {
+        if let Some(slot) = self.clients.get_mut(idx) {
+            *slot = None;
+        }
+    }
+
+    /// Find a pending gate of `expected_kind` on any reachable node,
+    /// or any pending gate if `expected_kind` is `None`. Polls
+    /// `ListPending` with backoff up to [`POLL_BUDGET`]. Re-dials
+    /// any newly-activated nodes on every iteration so a replica
+    /// placed on a previously-idle node is discovered without extra
+    /// retry logic in the caller.
+    ///
+    /// Panics if no matching gate appears within [`POLL_BUDGET`].
+    pub async fn poll_for_pending(
+        &mut self,
+        expected_kind: Option<ApprovalKind>,
+    ) -> (usize, ApprovalEvent) {
+        self.poll_for_pending_inner(None, expected_kind).await
+    }
+
+    /// Like [`Cluster::poll_for_pending`] but only matches gates whose
+    /// target's `partition_id` equals `partition_id`. Useful when SF
+    /// rebuilds a replica after a failed `change_role` (the
+    /// `replica_id` changes but the partition does not), or when the
+    /// test must coexist with parallel test runs in the same cluster
+    /// (each test scopes its polling to its own partition).
+    pub async fn poll_for_pending_in_partition(
+        &mut self,
+        partition_id: &str,
+        expected_kind: Option<ApprovalKind>,
+    ) -> (usize, ApprovalEvent) {
+        self.poll_for_pending_inner(Some(partition_id), expected_kind)
+            .await
+    }
+
+    async fn poll_for_pending_inner(
+        &mut self,
+        partition_id: Option<&str>,
+        expected_kind: Option<ApprovalKind>,
+    ) -> (usize, ApprovalEvent) {
+        let deadline = std::time::Instant::now() + POLL_BUDGET;
+        loop {
+            self.ensure().await;
+            let mut to_invalidate = Vec::new();
+            for (i, client) in self.iter_connected_mut() {
+                let resp = match client
+                    .list_pending(ListPendingRequest {
+                        partition_id: partition_id.unwrap_or("").to_string(),
+                        replica_filter: None,
+                    })
+                    .await
+                {
+                    Ok(r) => r,
+                    Err(_) => {
+                        to_invalidate.push(i);
+                        continue;
+                    }
+                };
+                for ev in resp.into_inner().events {
+                    let kind_matches = match expected_kind {
+                        None => true,
+                        Some(k) => ev.kind == k as i32,
+                    };
+                    if kind_matches {
+                        return (i, ev);
+                    }
+                }
+            }
+            for i in to_invalidate {
+                self.invalidate(i);
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "no pending gate of kind {expected_kind:?} found within {POLL_BUDGET:?} \
+                     (partition_filter={partition_id:?}, connected_nodes={})",
+                    self.connected_count(),
+                );
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    /// Approve every pending gate on every reachable node with
+    /// `Decision::Proceed`. Returns the count of gates released.
+    ///
+    /// **Operator-style cleanup, not for routine test setup.** Tests
+    /// running in parallel could each see the others' gates and
+    /// approve them prematurely. Prefer `remove_test_apps.sh` (which
+    /// calls `reflection_ctl approve-all`) between cluster lifecycles,
+    /// and unique service names per run for isolation.
+    pub async fn approve_all_pending(&mut self) -> usize {
+        let mut released = 0;
+        let mut to_invalidate = Vec::new();
+        for (i, client) in self.iter_connected_mut() {
+            let resp = match client
+                .list_pending(ListPendingRequest {
+                    partition_id: String::new(),
+                    replica_filter: None,
+                })
+                .await
+            {
+                Ok(r) => r,
+                Err(_) => {
+                    to_invalidate.push(i);
+                    continue;
+                }
+            };
+            for ev in resp.into_inner().events {
+                let target = match ev.target.clone() {
+                    Some(t) => t,
+                    None => continue,
+                };
+                tracing::warn!(
+                    "releasing leftover gate kind={} partition={} replica={} gate_id={}",
+                    ev.kind,
+                    target.partition_id,
+                    target.replica_id,
+                    ev.gate_id,
+                );
+                let _ = client
+                    .approve(ApproveRequest {
+                        target: Some(target),
+                        gate_id: ev.gate_id,
+                        decision: Some(ApproveDecisionOneof::Proceed(Empty {})),
+                    })
+                    .await;
+                released += 1;
+            }
+        }
+        for i in to_invalidate {
+            self.invalidate(i);
+        }
+        released
+    }
+}
+
+impl Default for Cluster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Cluster {
+    /// Build a [`ReplicaClient`] handle pointing at one specific
+    /// replica. The returned handle borrows the cluster mutably; it
+    /// owns the `(node_idx, target)` pair and exposes every per-replica
+    /// operation (`wait_for_gate`, `approve_proceed`, etc.) as methods.
+    ///
+    /// Typical flow after [`Cluster::poll_for_pending`]:
+    ///
+    /// ```ignore
+    /// let (node_idx, ev) = cluster.poll_for_pending(Some(ApprovalKind::ApprovalOpen)).await;
+    /// let target = ev.target.clone().unwrap();
+    /// let mut replica = cluster.replica_client(node_idx, target);
+    /// replica.approve_proceed(ev.gate_id).await;
+    /// let cr = replica.observe_and_approve(ApprovalKind::ApprovalChangeRole).await;
+    /// ```
+    pub fn replica_client(&mut self, node_idx: usize, target: ReplicaRef) -> ReplicaClient<'_> {
+        ReplicaClient {
+            cluster: self,
+            node_idx,
+            target,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// ReplicaClient — per-replica handle borrowing the cluster.
+// ----------------------------------------------------------------------
+
+/// Borrowing handle that pins a single `(node_idx, replica_target)` and
+/// exposes every per-replica operation as a method, so tests don't
+/// have to thread `node_idx` and `target` through every call.
+///
+/// One `ReplicaClient` may exist at a time per `Cluster` (it holds an
+/// exclusive borrow). Tests that need to drive multiple replicas
+/// concurrently should keep `(node_idx, target)` pairs and re-acquire
+/// the handle via [`Cluster::replica_client`] for each operation.
+pub struct ReplicaClient<'a> {
+    cluster: &'a mut Cluster,
+    node_idx: usize,
+    target: ReplicaRef,
+}
+
+impl<'a> ReplicaClient<'a> {
+    pub fn node_idx(&self) -> usize {
+        self.node_idx
+    }
+
+    pub fn target(&self) -> &ReplicaRef {
+        &self.target
+    }
+
+    fn client(&mut self) -> &mut ReplicaControlClient<Channel> {
+        self.cluster.client_mut(self.node_idx)
+    }
+
+    /// Wait for a *specific* gate kind on this replica.
+    pub async fn wait_for_gate(&mut self, expected_kind: ApprovalKind) -> ApprovalEvent {
+        let target = self.target.clone();
+        let resp = self
+            .client()
+            .wait_for_approval(WaitForApprovalRequest {
+                target: Some(target),
+                timeout_ms: WAIT_FOR_APPROVAL_TIMEOUT_MS,
+                expected: expected_kind as i32,
+            })
+            .await
+            .unwrap_or_else(|s| panic!("WaitForApproval({expected_kind:?}) failed: {s}"));
+        resp.into_inner()
+    }
+
+    /// Wait for the *next* gate of any kind on this replica. Useful
+    /// during teardown where SF may issue `change_role(None)` before
+    /// `close` and the test wants to drain whatever comes next.
+    pub async fn wait_for_any_gate(&mut self) -> ApprovalEvent {
+        let target = self.target.clone();
+        let resp = self
+            .client()
+            .wait_for_approval(WaitForApprovalRequest {
+                target: Some(target),
+                timeout_ms: WAIT_FOR_APPROVAL_TIMEOUT_MS,
+                expected: ApprovalKind::ApprovalUnspecified as i32,
+            })
+            .await
+            .unwrap_or_else(|s| panic!("WaitForApproval(any) failed: {s}"));
+        resp.into_inner()
+    }
+
+    /// Approve a specific gate with `Decision::Proceed`.
+    pub async fn approve_proceed(&mut self, gate_id: String) {
+        let target = self.target.clone();
+        self.client()
+            .approve(ApproveRequest {
+                target: Some(target),
+                gate_id: gate_id.clone(),
+                decision: Some(ApproveDecisionOneof::Proceed(Empty {})),
+            })
+            .await
+            .unwrap_or_else(|s| panic!("Approve(gate_id={gate_id}) failed: {s}"));
+    }
+
+    /// Approve a specific gate with `Decision::Fail(message)`. Note:
+    /// `fail_message` is rejected with `InvalidArgument` for an
+    /// `Approval::Abort` gate (SF's `abort` cannot fail).
+    pub async fn approve_fail(&mut self, gate_id: String, message: String) {
+        let target = self.target.clone();
+        self.client()
+            .approve(ApproveRequest {
+                target: Some(target),
+                gate_id: gate_id.clone(),
+                decision: Some(ApproveDecisionOneof::FailMessage(message.clone())),
+            })
+            .await
+            .unwrap_or_else(|s| {
+                panic!("Approve(gate_id={gate_id}, fail_message={message:?}) failed: {s}")
+            });
+    }
+
+    /// Wait for a gate of `expected_kind`, then approve it with
+    /// `Decision::Proceed`. Returns the observed event so the test
+    /// can inspect `new_role` etc.
+    pub async fn observe_and_approve(&mut self, expected_kind: ApprovalKind) -> ApprovalEvent {
+        let ev = self.wait_for_gate(expected_kind).await;
+        let gate_id = ev.gate_id.clone();
+        self.approve_proceed(gate_id).await;
+        ev
+    }
+
+    /// Wait for the next gate of any kind, then approve with
+    /// `Decision::Proceed`. Used during teardown loops where the
+    /// caller doesn't care which gate fires next.
+    pub async fn drain_next_gate(&mut self) -> ApprovalEvent {
+        let ev = self.wait_for_any_gate().await;
+        let gate_id = ev.gate_id.clone();
+        self.approve_proceed(gate_id).await;
+        ev
+    }
+
+    /// `ListPending` filtered to this replica's partition. Useful for
+    /// "is the replica gone?" assertions after `Close` is approved.
+    pub async fn list_pending_in_partition(&mut self) -> Vec<ApprovalEvent> {
+        let partition_id = self.target.partition_id.clone();
+        self.client()
+            .list_pending(ListPendingRequest {
+                partition_id,
+                replica_filter: None,
+            })
+            .await
+            .expect("ListPending failed")
+            .into_inner()
+            .events
+    }
+}

--- a/crates/samples/reflection/tests/control_e2e.rs
+++ b/crates/samples/reflection/tests/control_e2e.rs
@@ -1,0 +1,153 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! End-to-end approval-gate test against a deployed onebox cluster.
+//!
+//! Walks one replica through its entire lifecycle by approving each gate
+//! over the `ReplicaControl` gRPC service:
+//!
+//! `Open` -> `ChangeRole(Primary)` -> `ChangeRole(None)` -> `Close`
+//!
+//! Requirements (same as the other integration tests in this crate):
+//! - `fabric:/ReflectionApp` is provisioned (via `scripts/prepare_test_apps.sh`).
+//! - The reflection sample binary is the current build.
+//! - `localhost:19000` resolves to the cluster's client gateway.
+//! - The cluster's gRPC `ReplicaControl` ports `28000..=28004` are reachable;
+//!   set `REFLECTION_CLUSTER_HOST` to override the default hostname `onebox`.
+
+use std::time::Duration;
+
+use mssf_core::WString;
+use mssf_core::client::FabricClient;
+use mssf_core::types::{
+    PartitionSchemeDescription, ServiceDescription, StatefulServiceDescription, Uri,
+};
+use prost::Message;
+use samples_reflection::control::ReplicaInitData;
+use samples_reflection::grpc_control::proto::ApprovalKind;
+use samples_reflection::test_cluster::Cluster;
+use uuid::Uuid;
+
+const APP_NAME: &str = "fabric:/ReflectionApp";
+const SERVICE_TYPE: &str = "ReflectionAppService";
+const SF_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
+async fn approve_open_change_role_close_singleton_replica() {
+    // Unique service name per run so the test is repeatable.
+    let svc_suffix = Uuid::new_v4().simple().to_string();
+    let service_name_str = format!("{APP_NAME}/ApprovalE2e_{svc_suffix}");
+    let service_name = Uri::from(service_name_str.as_str());
+
+    // The reflection sample's process only binds the ReplicaControl
+    // port once SF activates the code package on a node. Connecting
+    // before service creation would just race against placement.
+    // `Cluster::poll_for_pending` calls `ensure()` on every poll
+    // iteration, so cold-then-warm nodes are picked up automatically
+    // within `POLL_INTERVAL` once SF starts the process.
+    let mut cluster = Cluster::new();
+
+    // Construct service description with control=true initdata so the
+    // replica uses GrpcController and parks at every lifecycle gate.
+    let initdata = ReplicaInitData { control: true }.encode_to_vec();
+    let desc = ServiceDescription::Stateful(
+        StatefulServiceDescription::new(
+            Uri::from(APP_NAME),
+            service_name.clone(),
+            WString::from(SERVICE_TYPE),
+            PartitionSchemeDescription::Singleton,
+        )
+        .with_has_persistent_state(true)
+        .with_service_activation_mode(mssf_core::types::ServicePackageActivationMode::SharedProcess)
+        .with_min_replica_set_size(1)
+        .with_target_replica_set_size(1)
+        .with_initialization_data(initdata),
+    );
+
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+
+    fc.get_service_manager()
+        .create_service(&desc, SF_TIMEOUT, None)
+        .await
+        .expect("create_service failed");
+    tracing::info!("service created; waiting for OPEN gate to appear");
+
+    // Wait for OPEN to learn (node, target). Then bind a ReplicaClient
+    // that owns those for the rest of the test.
+    let (node_idx, open_ev) = cluster
+        .poll_for_pending(Some(ApprovalKind::ApprovalOpen))
+        .await;
+    let target = open_ev.target.clone().expect("ApprovalEvent.target");
+    tracing::info!(
+        "OPEN gate observed on node #{node_idx}: partition={}, replica={}, gate_id={}",
+        target.partition_id,
+        target.replica_id,
+        open_ev.gate_id,
+    );
+
+    let mut replica = cluster.replica_client(node_idx, target.clone());
+
+    // ---- Approve OPEN ----
+    replica.approve_proceed(open_ev.gate_id.clone()).await;
+
+    // ---- ChangeRole(Primary) ----
+    let cr_ev = replica
+        .observe_and_approve(ApprovalKind::ApprovalChangeRole)
+        .await;
+    tracing::info!(
+        "CHANGE_ROLE gate observed: new_role={}, gate_id={}",
+        cr_ev.new_role,
+        cr_ev.gate_id,
+    );
+
+    // Service should now be Up. Trigger close by deleting the service.
+    // delete_service blocks until the replica's close completes, which
+    // itself blocks on our CLOSE-gate Approve, so we must spawn the
+    // delete in the background and drain teardown gates concurrently.
+    tracing::info!("deleting service to trigger teardown gates");
+    let delete_handle = {
+        let sm = fc.get_service_manager().clone();
+        let svc_name = service_name.clone();
+        tokio::spawn(async move { sm.delete_service(&svc_name, SF_TIMEOUT, None).await })
+    };
+
+    // ---- Teardown: drain change_role(None) (if any) then Close ----
+    // SF may issue any number of change_role gates before close (e.g.
+    // demoting Primary -> None). Approve them all; stop after Close.
+    loop {
+        let ev = replica.drain_next_gate().await;
+        let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
+        tracing::info!(
+            "teardown gate observed: kind={kind:?}, new_role={}, gate_id={}",
+            ev.new_role,
+            ev.gate_id,
+        );
+        if matches!(kind, ApprovalKind::ApprovalClose) {
+            break;
+        }
+    }
+
+    delete_handle
+        .await
+        .expect("delete_service task panicked")
+        .expect("delete_service failed");
+
+    // After close completes the registry entry is gone. A follow-up
+    // ListPending should not show the replica.
+    tracing::info!("verifying replica is removed from registry");
+    let probe = replica.list_pending_in_partition().await;
+    assert!(
+        probe
+            .iter()
+            .all(|ev| ev.target.as_ref().map(|t| t.replica_id) != Some(target.replica_id)),
+        "replica still appears in ListPending after Close approval: {probe:?}"
+    );
+
+    tracing::info!("e2e flow complete");
+}

--- a/crates/samples/reflection/tests/fail_change_role.rs
+++ b/crates/samples/reflection/tests/fail_change_role.rs
@@ -1,0 +1,287 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Failure-injection e2e: reject the first `ChangeRole` and verify SF
+//! recovers, then approve the second `ChangeRole` so the service comes
+//! up cleanly.
+//!
+//! ## Observed Service Fabric recovery behaviour
+//!
+//! When `IStatefulServiceReplica::change_role` returns an `Err`, SF
+//! does NOT simply re-issue `change_role` on the same in-memory
+//! replica object. Instead it tears the replica down and re-opens it.
+//! The exact sequence we observe in onebox (SF 11.4.x) is:
+//!
+//! ```text
+//!     SF -> open()           Approve(Proceed)
+//!     SF -> change_role(Primary)  Approve(Fail("..."))
+//!     SF -> abort()          Approve(Proceed)   // tear down the failed replica
+//!     [~15 s back-off]
+//!     SF -> open()           Approve(Proceed)   // SAME replica_id, fresh activation
+//!     SF -> change_role(Primary)  Approve(Proceed)   // service is now Up
+//! ```
+//!
+//! Two non-obvious points:
+//!
+//! 1. **`replica_id` is preserved across the failure.** SF reuses the
+//!    same replica id for the recovery activation rather than minting
+//!    a new one. We discovered this by logging `target.replica_id`
+//!    on every gate — the first OPEN and the second OPEN see the
+//!    *same* id. Polling by `partition_id` (what this test does)
+//!    works either way and is more robust against future SF
+//!    behaviour changes.
+//!
+//! 2. **There is a noticeable back-off (~15 s in onebox)** between
+//!    the abort approval and the second open. This is SF's internal
+//!    retry delay after a transient replica failure. Tests that
+//!    exercise this path should expect to be in the
+//!    10-second-and-up runtime category, not sub-second.
+//!
+//! On the gRPC side, each gate gets a fresh `gate_id` UUID even
+//! though the `(partition_id, replica_id)` tuple is unchanged — the
+//! controller mints a new id every time `await_approval` populates
+//! `pending`. So a test holding a stale `gate_id` from before the
+//! failure cannot misroute an `Approve` to the recovery gate.
+//!
+//! ## Discovery strategy
+//!
+//! Polls by `partition_id` rather than `replica_id`. Even though SF
+//! happens to reuse the replica_id in our case, polling by partition
+//! also works for any future variation where SF rebuilds with a fresh
+//! id, and it lets parallel tests in the same cluster operate with
+//! clean isolation by scoping each test's polling to its own
+//! partition.
+//!
+//! Same prerequisites as `control_e2e.rs`.
+
+use std::time::Duration;
+
+use mssf_core::WString;
+use mssf_core::client::FabricClient;
+use mssf_core::types::{
+    PartitionSchemeDescription, ServiceDescription, StatefulServiceDescription, Uri,
+};
+use prost::Message;
+use samples_reflection::control::ReplicaInitData;
+use samples_reflection::grpc_control::proto::ApprovalKind;
+use samples_reflection::test_cluster::Cluster;
+use uuid::Uuid;
+
+const APP_NAME: &str = "fabric:/ReflectionApp";
+const SERVICE_TYPE: &str = "ReflectionAppService";
+const SF_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
+async fn fail_change_role_then_approve_retry() {
+    // Unique service name per run so tests can coexist.
+    let svc_suffix = Uuid::new_v4().simple().to_string();
+    let service_name_str = format!("{APP_NAME}/FailCrE2e_{svc_suffix}");
+    let service_name = Uri::from(service_name_str.as_str());
+
+    let mut cluster = Cluster::new();
+
+    // Create the controlled service.
+    let initdata = ReplicaInitData { control: true }.encode_to_vec();
+    let desc = ServiceDescription::Stateful(
+        StatefulServiceDescription::new(
+            Uri::from(APP_NAME),
+            service_name.clone(),
+            WString::from(SERVICE_TYPE),
+            PartitionSchemeDescription::Singleton,
+        )
+        .with_has_persistent_state(true)
+        .with_service_activation_mode(mssf_core::types::ServicePackageActivationMode::SharedProcess)
+        .with_min_replica_set_size(1)
+        .with_target_replica_set_size(1)
+        .with_initialization_data(initdata),
+    );
+
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+
+    fc.get_service_manager()
+        .create_service(&desc, SF_TIMEOUT, None)
+        .await
+        .expect("create_service failed");
+    tracing::info!("service {service_name_str} created");
+
+    // Wait for the first OPEN to learn our partition_id. From this
+    // point on we poll only within this partition so parallel tests
+    // can't see each other's gates.
+    let (mut n, first_ev) = cluster
+        .poll_for_pending(Some(ApprovalKind::ApprovalOpen))
+        .await;
+    let partition_id = first_ev
+        .target
+        .as_ref()
+        .expect("ApprovalEvent.target")
+        .partition_id
+        .clone();
+    tracing::info!("OPEN observed; partition_id={partition_id}");
+
+    // Drive the first OPEN through the same loop used for everything
+    // else by feeding it as if poll_for_pending_in_partition had just
+    // returned it. After this initial seed, every subsequent gate is
+    // discovered by polling within the partition.
+    let mut next: Option<(
+        usize,
+        samples_reflection::grpc_control::proto::ApprovalEvent,
+    )> = Some((n, first_ev));
+
+    let mut open_count = 0usize;
+    let mut change_role_count = 0usize;
+    let mut abort_count = 0usize;
+
+    loop {
+        let (node_idx, ev) = match next.take() {
+            Some(pair) => pair,
+            None => {
+                cluster
+                    .poll_for_pending_in_partition(&partition_id, None)
+                    .await
+            }
+        };
+        n = node_idx;
+        let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
+        let target = ev.target.clone().expect("ApprovalEvent.target");
+
+        match kind {
+            ApprovalKind::ApprovalOpen => {
+                // Two cases observed in practice:
+                //   open #1: the initial replica activation
+                //   open #2: SF re-activating the SAME replica_id
+                //            after the failed change_role + abort
+                open_count += 1;
+                tracing::info!(
+                    "OPEN #{open_count} replica={} gate_id={} -> approving",
+                    target.replica_id,
+                    ev.gate_id,
+                );
+                cluster
+                    .replica_client(n, target)
+                    .approve_proceed(ev.gate_id)
+                    .await;
+            }
+            ApprovalKind::ApprovalChangeRole => {
+                // First change_role: inject a Fail to trigger SF's
+                // recovery path. Second change_role (after the abort
+                // + reopen): approve so the service comes up.
+                change_role_count += 1;
+                if change_role_count == 1 {
+                    tracing::info!(
+                        "CHANGE_ROLE #1 replica={} gate_id={} -> failing",
+                        target.replica_id,
+                        ev.gate_id,
+                    );
+                    cluster
+                        .replica_client(n, target)
+                        .approve_fail(ev.gate_id, "test-induced ChangeRole failure".to_string())
+                        .await;
+                } else {
+                    tracing::info!(
+                        "CHANGE_ROLE #{change_role_count} replica={} gate_id={} -> approving",
+                        target.replica_id,
+                        ev.gate_id,
+                    );
+                    cluster
+                        .replica_client(n, target)
+                        .approve_proceed(ev.gate_id)
+                        .await;
+                    break;
+                }
+            }
+            ApprovalKind::ApprovalAbort => {
+                // SF aborts the failed replica before re-opening it.
+                // Approve immediately so SF can move on; the
+                // ~15s back-off before the second OPEN happens
+                // entirely on SF's side after this approval returns.
+                abort_count += 1;
+                tracing::info!(
+                    "ABORT #{abort_count} replica={} gate_id={} -> approving (recovery)",
+                    target.replica_id,
+                    ev.gate_id,
+                );
+                cluster
+                    .replica_client(n, target)
+                    .approve_proceed(ev.gate_id)
+                    .await;
+            }
+            ApprovalKind::ApprovalClose => {
+                // Not expected on the recovery path — SF prefers
+                // abort over close after a lifecycle failure — but
+                // approve defensively if it ever shows up so the
+                // test doesn't deadlock.
+                tracing::info!(
+                    "CLOSE replica={} gate_id={} -> approving (unexpected before retry but ok)",
+                    target.replica_id,
+                    ev.gate_id,
+                );
+                cluster
+                    .replica_client(n, target)
+                    .approve_proceed(ev.gate_id)
+                    .await;
+            }
+            ApprovalKind::ApprovalUnspecified => {
+                panic!("ApprovalKind::ApprovalUnspecified observed: {ev:?}");
+            }
+        }
+    }
+
+    tracing::info!(
+        "recovery summary: open={open_count}, change_role={change_role_count}, abort={abort_count}"
+    );
+    assert!(
+        change_role_count >= 2,
+        "expected SF to issue at least 2 CHANGE_ROLE gates; saw {change_role_count}"
+    );
+    assert!(
+        abort_count >= 1,
+        "expected SF to abort the failed replica at least once; saw {abort_count}"
+    );
+
+    // Teardown: delete the service and drain remaining gates in this
+    // partition until Close is approved.
+    //
+    // For a normal happy-path teardown SF issues:
+    //   change_role(None)   // demote primary
+    //   close()
+    // The test approves both with Proceed and exits when Close fires.
+    tracing::info!("deleting service to trigger teardown gates");
+    let delete_handle = {
+        let sm = fc.get_service_manager().clone();
+        let svc = service_name.clone();
+        tokio::spawn(async move { sm.delete_service(&svc, SF_TIMEOUT, None).await })
+    };
+
+    loop {
+        let (n, ev) = cluster
+            .poll_for_pending_in_partition(&partition_id, None)
+            .await;
+        let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
+        let target = ev.target.clone().expect("ApprovalEvent.target");
+        tracing::info!(
+            "teardown gate kind={kind:?} replica={} gate_id={}",
+            target.replica_id,
+            ev.gate_id,
+        );
+        cluster
+            .replica_client(n, target)
+            .approve_proceed(ev.gate_id)
+            .await;
+        if matches!(kind, ApprovalKind::ApprovalClose) {
+            break;
+        }
+    }
+
+    delete_handle
+        .await
+        .expect("delete_service task panicked")
+        .expect("delete_service failed");
+
+    tracing::info!("fail-change-role e2e flow complete");
+}

--- a/docs/design/ReflectionReplicaTestControl.md
+++ b/docs/design/ReflectionReplicaTestControl.md
@@ -1,0 +1,454 @@
+# Reflection App: Test-Controlled Replica Behavior via gRPC
+
+## Status
+
+**Implemented.** See [crates/samples/reflection/src/control.rs](../../crates/samples/reflection/src/control.rs),
+[grpc_control.rs](../../crates/samples/reflection/src/grpc_control.rs),
+[proto/control.proto](../../crates/samples/reflection/proto/control.proto),
+[proto/initdata.proto](../../crates/samples/reflection/proto/initdata.proto),
+the e2e test in [tests/control_e2e.rs](../../crates/samples/reflection/tests/control_e2e.rs),
+and the operator CLI at [reflection_ctl/main.rs](../../crates/samples/reflection/reflection_ctl/main.rs).
+
+## Motivation
+
+The reflection sample is used for integration tests against a real
+Service Fabric cluster. Without control, lifecycle methods (`open`,
+`change_role`, `close`, `abort`) run as fast as SF drives them, which
+makes it hard to test slow opens, failed change-role operations,
+hangs during close, abort-during-close races, and similar
+interleavings.
+
+This design lets a test driver gate every lifecycle method via a
+gRPC service that the reflection sample hosts on every node. The
+test reaches in, says "wait for `open` on this replica → return
+this decision", and SF observes the replica's behaviour as if the
+service were genuinely slow / faulty.
+
+## Goals
+
+1. Per-`(partition_id, replica_id)` control of when `open` /
+   `change_role` / `close` / `abort` return and what they return.
+2. Mode is chosen at service-create time via SF's
+   `InitializationData`. A service created without setting initdata
+   uses the production code path with no behaviour change.
+3. Multiple replicas controllable independently and concurrently.
+4. Production path adds one async call returning
+   `Decision::Proceed` and one `Arc` clone per lifecycle method —
+   negligible for the sample's scale.
+
+## Non-Goals
+
+- Replication faults inside the replicator (use SF fault-injection
+  APIs instead).
+- Persisting test commands across replica restarts.
+- Auth on the gRPC channel — the channel is bound to the cluster
+  network; see §Security.
+- Cross-machine clusters. The transport scheme is designed for
+  local onebox only.
+- Driving SF itself (e.g., forcing failovers).
+
+## Architecture
+
+```
+                    SF runtime                Test driver
+                       │                          │
+                       │ create_replica(initdata) │
+                       ▼                          │
+                ┌─────────────┐                   │
+   Factory ───► │  Replica    │                   │
+                │  + ctrl     │◄──────── ReplicaControl gRPC ────────┐
+                └─────────────┘                   │                   │
+                       │                          │                   │
+                       │ open / change_role /     │                   │
+                       │ close / abort            │                   │
+                       ▼                          │                   │
+                await_approval(gate)              │ WaitForApproval/  │
+                       │                          │ Approve / List    │
+                       │                          │ Pending / Detach  │
+                       └──────────────────────────┴───────────────────┘
+                       (parks at gate_lock + oneshot)
+```
+
+Each `Replica` holds an `Arc<dyn ReplicaController>`:
+
+| Initdata (`ReplicaInitData`) | Controller         | Behaviour                                          |
+|---|---|---|
+| empty / decode failure / `control = false` | `NoopController` | `await_approval` returns `Decision::Proceed` inline; not registered |
+| `control = true`                            | `GrpcController` | Lifecycle parks at `gate_lock` until `Approve` arrives over gRPC |
+
+## Components
+
+### 1. `ReplicaController` trait
+([src/control.rs](../../crates/samples/reflection/src/control.rs))
+
+```rust
+#[async_trait]
+pub trait ReplicaController: Send + Sync + Debug {
+    async fn await_approval(&self, gate: Approval) -> Decision;
+    fn is_controllable(&self) -> bool { false }
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+pub enum Approval { Open, ChangeRole(ReplicaRole), Close, Abort }
+pub enum Decision { Proceed, Fail(mssf_core::Error) }
+```
+
+`as_any` lets the gRPC handler downcast to `GrpcController` for the
+inspection methods (`peek_pending`, `wait_for_approval`, `approve`,
+`detach`) that aren't on the trait.
+
+### 2. `NoopController`
+Stateless. `await_approval` returns `Decision::Proceed` immediately;
+never registered with `ReplicaRegistry`. This is the only path that
+runs when initdata is empty — preserves current behaviour for every
+existing test.
+
+### 3. `GrpcController`
+
+State:
+
+```rust
+pub struct GrpcController {
+    gate_lock: tokio::sync::Mutex<()>,            // serializes await_approval
+    pending:   std::sync::Mutex<Option<Pending>>, // observation slot
+    notify:    tokio::sync::Notify,               // wakes WaitForApproval
+    detached:  AtomicBool,                        // proceed-forever flag
+}
+
+struct Pending {
+    gate_id: Uuid,                                // fresh per gate
+    gate:    Approval,
+    sender:  oneshot::Sender<Decision>,
+}
+```
+
+`await_approval(gate)`:
+
+1. If `detached`, return `Decision::Proceed` immediately.
+2. Acquire `gate_lock` (held across the receiver `await`). A
+   concurrent call from another lifecycle method blocks here until
+   the current one completes — this is what enforces single
+   occupancy of `pending`.
+3. Re-check `detached` (in case `Detach` fired while we were queued).
+4. Mint a fresh `gate_id` (UUID v4), create a `oneshot`, publish
+   `Pending { gate_id, gate, sender }` under the std mutex, drop
+   the std mutex, call `notify.notify_waiters()`.
+5. `await` the receiver. On `Drop` of the controller the receiver
+   resolves with `Err`, mapped to `Decision::Proceed`.
+6. Clear `pending`, release `gate_lock`.
+
+`wait_for_approval(expected)` (gRPC `WaitForApproval` handler) does
+NOT touch `gate_lock`. It loops:
+
+```rust
+loop {
+    let notified = self.notify.notified();   // register interest first
+    tokio::pin!(notified);
+    if let Some(ev) = self.peek_matching(expected) {
+        return ev;                            // never consumes pending
+    }
+    notified.await;
+}
+```
+
+`approve(gate_id, decision)` consumes `pending` only when
+`pending.gate_id == gate_id`, then sends on the stored oneshot.
+Mismatched id → `FailedPrecondition`.
+
+`detach()` flips the atomic and releases any pending oneshot with
+`Decision::Proceed`. Operator-only escape hatch — tests should walk
+gates explicitly so they're actually testing approval semantics.
+
+### 4. Initdata pipeline
+([src/control.rs](../../crates/samples/reflection/src/control.rs),
+proto [proto/initdata.proto](../../crates/samples/reflection/proto/initdata.proto))
+
+Wire format (forward-additive; do not change existing field numbers
+or types):
+
+```proto
+message ReplicaInitData {
+  bool control = 1;
+  // future tunables go here
+}
+```
+
+Decoding and policy are split so each is independently testable:
+
+```rust
+// Wire format only; empty bytes / decode error → default message.
+pub fn decode_init_data(bytes: &[u8]) -> ReplicaInitData;
+
+// Pure mapping; no I/O, no logging.
+pub enum ControlMode { NoControl, Control }
+impl ControlMode {
+    pub fn from_init_data(msg: &ReplicaInitData) -> Self;
+}
+
+pub fn make_controller(mode: ControlMode) -> Arc<dyn ReplicaController>;
+```
+
+`Factory::create_replica` composes these and registers the
+controller with the registry only when `is_controllable()` is true.
+
+### 5. `ReplicaRegistry` extension
+([src/grpc.rs](../../crates/samples/reflection/src/grpc.rs))
+
+Existing entry struct gains an optional controller handle. Lookup
+by `(partition_id, replica_id)` returns `None` for nocontrol
+replicas, which the gRPC handler maps to `NotFound`.
+
+```rust
+pub struct ReplicaEntry {
+    pub partition_id: GUID,
+    pub replica_id:   i64,
+    pub role:         ReplicaRole,
+    pub controller:   Option<Arc<dyn ReplicaController>>,  // NEW
+}
+```
+
+### 6. `Replica::abort` sync→async bridge
+([src/statefulstore.rs](../../crates/samples/reflection/src/statefulstore.rs))
+
+`abort` is a sync trait method but `await_approval` is async. The
+`Replica` already owns a `TokioExecutor`; bridge with
+`block_on_any`:
+
+```rust
+fn abort(&self) {
+    let controller = self.controller.clone();
+    self.exec.block_on_any(async move {
+        let _ = controller.await_approval(Approval::Abort).await;
+    });
+    // ... existing abort logic ...
+}
+```
+
+The decision is intentionally discarded — `IStatefulServiceReplica::abort`
+returns `()` and cannot fail. Under `NoopController` this resolves
+inline. Under `GrpcController`, if a previous lifecycle method
+(typically `close`) is still parked, this `block_on_any` queues at
+`gate_lock` until the prior gate is approved or the controller is
+dropped.
+
+### 7. gRPC service
+([proto/control.proto](../../crates/samples/reflection/proto/control.proto),
+[src/grpc_control.rs](../../crates/samples/reflection/src/grpc_control.rs))
+
+Served on the same `tonic::transport::Server` as the existing
+`Greeter` service.
+
+| RPC               | Purpose |
+|---|---|
+| `WaitForApproval` | Block until replica reaches a gate (or timeout). Server-cap 30 s default / 5 min max. |
+| `Approve`         | Release the matching pending gate with `Proceed` or `Fail(message)`. |
+| `ListPending`     | Snapshot of in-flight gates; optional partition / replica filter. |
+| `Detach`          | Operator escape hatch — flip a controller into proceed-forever mode. |
+| `DetachAll`       | Same, every controllable replica on this server. |
+
+Filters use a `oneof` rather than a sentinel value so any `int64`
+(including 0) is an exact match:
+
+```proto
+message ListPendingRequest {
+  string partition_id = 1;        // empty = all partitions
+  oneof replica_filter {
+    int64 specific_replica_id = 2;  // unset = all replicas
+  }
+}
+```
+
+### 8. Test transport: fixed port + per-node offset
+
+Onebox runs every SF node as a process sharing one host. SF
+allocates each node a slice of `<ApplicationEndpoints>` (Linux
+`22001–27000`, Windows `30001–35000`). To avoid colliding with
+SF's allocator and the OS ephemeral ranges, `ReplicaControl` binds
+to a fixed port `28000 + node_index(Fabric_NodeName)` on `0.0.0.0`.
+
+| Platform | Manifest | Node names      | Index |
+|---|---|---|---|
+| Windows  | [onebox/windows/ClusterManifestTemplate.json](../../onebox/windows/ClusterManifestTemplate.json) | `_Node_0..4`     | strip leading `_Node_`, parse |
+| Linux    | [.devcontainer/onebox/ClusterManifest.SingleMachineFSS.xml](../../.devcontainer/onebox/ClusterManifest.SingleMachineFSS.xml) | `N0010..N0050`   | strip leading `N`, divide by 10, subtract 1 |
+
+`grpc_control::node_index` is `cfg(target_os = ...)`-gated so each
+arm only knows about the manifest format that produces it. Both
+arms produce `0..=4`, so per-node ports are `28000..=28004`
+regardless of platform. Test driver dials all candidate ports and
+treats `Connection refused` as "no replica here" (handles partial
+placement). The test crate consumes the same constant + parser so
+nothing diverges between client and server.
+
+### 9. RPC error model
+
+| RPC | Status                              | When                                                                 |
+|---|---|---|
+| any                  | `NotFound`                | Target replica not registered (or already removed).                 |
+| `WaitForApproval`    | `DeadlineExceeded`        | Server timeout elapsed; replica stays parked; client may reissue.   |
+| `WaitForApproval`    | `InvalidArgument`         | Missing/bad `partition_id`, or unknown `expected` enum value.       |
+| `Approve`            | `FailedPrecondition`      | Slot empty, OR `gate_id` mismatch (distinguished in message text).  |
+| `Approve`            | `InvalidArgument`         | `fail_message` set on an `APPROVAL_ABORT` gate (SF's `abort` can't fail). |
+| `ListPending`        | `InvalidArgument`         | `specific_replica_id` set with empty `partition_id`.                |
+| `Detach`             | `NotFound`                | Replica not registered.                                              |
+
+## Default Behaviour Without a Test Client
+
+Replicas of services created without `InitializationData`, or with
+`control = false`, use `NoopController`. `await_approval` returns
+`Decision::Proceed` inline and the replica is never registered with
+the gRPC server. Existing tests in
+[src/test.rs](../../crates/samples/reflection/src/test.rs) and
+[src/test2.rs](../../crates/samples/reflection/src/test2.rs) (none
+of which set initdata) see no behaviour change.
+
+A test that wants control opts in by encoding a `ReplicaInitData`:
+
+```rust
+use prost::Message;
+use samples_reflection::control::ReplicaInitData;
+
+let initdata = ReplicaInitData { control: true }.encode_to_vec();
+let desc = StatefulServiceDescription::new(/* ... */)
+    .with_initialization_data(initdata)
+    /* ...rest of builder chain... */;
+```
+
+**Assumption.** SF persists `InitializationData` durably with the
+service registration and re-passes the same bytes to every
+`create_replica` call across failovers, application upgrades, and
+cluster restarts. If this guarantee is violated, controlled
+services could silently downgrade to `NoControl` (test hangs) or
+production services could silently upgrade to `Control` (every
+lifecycle gates on a never-arriving `Approve`). The integration
+test in [tests/control_e2e.rs](../../crates/samples/reflection/tests/control_e2e.rs)
+exercises a full create→delete cycle and would catch a regression
+in the pipe; a failover sub-test is a recommended future addition.
+
+## Replica Lifetime as Seen by the Test Client
+
+The server has no "replica gone" event; tests learn that a replica
+is gone via `NotFound`. Normal close-then-remove sequence:
+
+1. SF calls `Replica::close` → `await_approval(Close)` parks.
+2. Test `WaitForApproval` returns `ApprovalEvent { kind: APPROVAL_CLOSE, gate_id }`.
+3. Test `Approve(gate_id, proceed)` → oneshot fires, `await_approval` returns,
+   `Replica::close` runs `ReplicaRegistry::remove`.
+4. SF eventually drops the `Replica`. `GrpcController::Drop` runs;
+   `pending` is already empty so it's a no-op.
+
+| Test does this… | Server returns… | Meaning |
+|---|---|---|
+| `WaitForApproval` after step 4 | `NotFound` | Terminal — stop polling. |
+| `Approve(gate_id, _)` for an old `gate_id` | `NotFound` (entry gone) or `FailedPrecondition` (entry present but slot empty / id mismatch) | Don't retry. |
+| In-flight `WaitForApproval` blocked at removal | `NotFound` next loop iteration | Same. |
+| `ListPending` after step 4 | Replica absent | Same. |
+
+Notes:
+
+- **Drop releases pending with `Proceed`, not `Fail`.** A forgotten
+  test must not make SF think close failed. Trade-off: a test
+  cannot distinguish "I approved" from "controller dropped before I
+  approved" purely from SF's perspective — observe whether its own
+  `Approve` returned `Ok` or `NotFound`.
+- **A new replica with the same `replica_id` may appear later.** It
+  registers fresh `gate_id`s, so the UUID check still protects
+  against misrouted `Approve` from the previous incarnation.
+- **`abort`-then-remove follows the same shape** with
+  `Approval::Abort` in step 1.
+
+## Concurrency and Failure Modes
+
+- **Single occupancy of `pending` is enforced, not assumed.**
+  `gate_lock` serializes all `await_approval` calls per replica;
+  an `abort` arriving while `close` is parked queues at the lock
+  until the test approves close, then the abort gate becomes
+  pending. SF's serialization is not relied on.
+- **Stale-approve race is closed by per-gate UUIDs.** Without the
+  id check, a sequence like `Open(A) → test sees A → controller
+  drops A → fresh Open(B) → test's stale Approve lands on B` would
+  misroute the decision. `Approve(gate_id != pending.gate_id)` is
+  rejected, and the test re-issues `WaitForApproval` to learn the
+  current gate.
+- **`await_approval` vs. `WaitForApproval` ordering race.** Two
+  valid orderings:
+  - *Test-first:* handler parks on `Notify`; `await_approval`
+    populates `pending` and notifies; handler wakes and returns.
+  - *SF-first:* `await_approval` populates `pending` and notifies
+    while no handler is parked (notification dropped); next
+    `WaitForApproval` finds the populated slot on its first peek.
+  Both work because the handler registers `notified` *before*
+  inspecting state.
+- **`Approve` arrives before any `WaitForApproval`** →
+  `FailedPrecondition` (slot empty). v1 doesn't pre-stage decisions.
+- **`Approve` after the replica is gone** → `NotFound`.
+- **Replica removed mid-wait.** `Drop` releases pending with
+  `Proceed`; in-flight `WaitForApproval` returns `NotFound` on
+  next iteration.
+- **Sync→async bridge from outside a tokio context.**
+  `TokioExecutor::block_on_any` uses `block_in_place` on a worker
+  and `Handle::block_on` otherwise. The multi-threaded runtime is
+  enforced by `TokioExecutor::new` in
+  [crates/libs/util/src/tokio/mod.rs](../../crates/libs/util/src/tokio/mod.rs).
+- **Lock order.** `gate_lock` (tokio) outer; `pending` (std) inner,
+  held only briefly to publish/clear `Pending`, never across an
+  `await`. No inversion possible.
+- **Multiple `WaitForApproval` clients per replica.** All receive
+  the same event; only the first to issue `Approve(gate_id, _)`
+  succeeds; the rest see `FailedPrecondition`. Intentional — tests
+  sharing a replica must coordinate.
+
+## Operator Tooling
+
+[reflection_ctl/main.rs](../../crates/samples/reflection/reflection_ctl/main.rs)
+is a thin clap CLI for manual cluster operations:
+
+```text
+reflection_ctl ping                      # which nodes are reachable
+reflection_ctl list [--partition X]      # what's pending where
+reflection_ctl approve --partition X --replica Y [--fail-message M]
+reflection_ctl approve-all [--yes]       # bulk-approve everything
+reflection_ctl detach --partition X --replica Y
+reflection_ctl detach --all              # proceed-forever everywhere
+```
+
+`Detach` is for unsticking the cluster after a test panics with
+parked gates. Tests themselves should walk gates explicitly.
+
+## Security
+
+The gRPC server binds `0.0.0.0:28000+node_index` with no auth.
+Acceptable for onebox — the cluster network is the security
+boundary (loopback on Windows, a private docker network on Linux
+devcontainer). For non-test environments, gate the
+`ReplicaControl` server behind a `--enable-test-control` CLI flag
+or a Cargo feature.
+
+## Test Patterns Enabled
+
+All assume `ReplicaInitData { control: true }` initdata.
+
+| Scenario | Sequence |
+|---|---|
+| Slow open                       | `WaitForApproval(OPEN)` → sleep → `Approve(proceed)`. |
+| Open failure                    | `WaitForApproval(OPEN)` → `Approve(fail_message="boom")`. SF retries / reports fault. |
+| ChangeRole hang then succeed    | After open: `WaitForApproval(CHANGE_ROLE)` → hold → `Approve(proceed)`. |
+| Approve abort                   | After whichever method ran last: `WaitForApproval(ABORT)` → `Approve(proceed)`. Decision payload is ignored. |
+| Hang abort to inspect state     | While `close` is parked, SF eventually issues `abort`; `Replica::abort`'s `block_on_any` blocks at `gate_lock` until the test approves close. Then the abort gate becomes pending. |
+| Close-then-remove               | `WaitForApproval(CLOSE)` → `Approve(proceed)`. Subsequent calls return `NotFound`. |
+| Failover ordering across replicas | Two `WaitForApproval` calls in parallel; release the new primary's `CHANGE_ROLE` only after the old primary's `CLOSE` is observed. |
+| Mixed-mode coexistence          | One service with `control=false` and one with `control=true` in the same cluster; verify the `control=false` service is unaffected. |
+
+## Open Questions
+
+- **Server-streaming `WaitForApproval`** would let a single test
+  observe every gate for a replica without polling. Start unary;
+  revisit if tests get awkward.
+- **`abort` observations after the replica is gone.** Currently
+  not reportable. Option: per-partition ring buffer of completed
+  `ApprovalEvent`s in the registry.
+- **`ReplicaInitData` extension fields.** Likely next:
+  per-service tag for filtering, and `repeated PreloadedDecision`
+  so a test can stage decisions before SF starts driving the
+  replica (avoids a `WaitForApproval` round-trip on the hot path).
+- **Failover sub-test for the SF-persists-initdata assumption** —
+  recommended future addition to the e2e suite.

--- a/scripts/remove_test_apps.sh
+++ b/scripts/remove_test_apps.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Removes all test apps deployed by prepare_test_apps.sh.
+#
+# Inverse of prepare_test_apps.sh. Idempotent — every step tolerates
+# "doesn't exist". Safe to run after a partial / failed prepare run.
+#
+# Order matters: we have to release any parked GrpcController gates
+# *before* asking SF to delete services, otherwise close() will hang
+# forever waiting for an Approve that will never come.
+#
+# Steps:
+#   1. (Best-effort) Detach all GrpcController replicas via reflection_ctl
+#      so any parked test-control gates auto-proceed. Skipped if the
+#      binary doesn't exist or the cluster doesn't support Detach.
+#   2. (Best-effort) approve-all as a fallback for older deployed
+#      binaries that lack the Detach RPC.
+#   3. Delete every service under each app instance (catches per-test
+#      services like ApprovalE2e_<uuid>).
+#   4. Delete app instances (fabric:/EchoApp, fabric:/ReflectionApp).
+#   5. Unprovision app types (EchoApp@0.0.1, ReflectionApp@0.0.1).
+#   6. Remove uploads from the image store.
+
+MAX_RETRY=20
+RETRY_INTERVAL=3
+
+# --- Helper: retry a command with backoff ---
+retry() {
+    local max_attempts=$1
+    local delay=$2
+    local desc=$3
+    shift 3
+    local attempt=1
+    while true; do
+        echo "[${desc}] attempt #${attempt}/${max_attempts}"
+        if "$@"; then
+            echo "[${desc}] succeeded"
+            return 0
+        fi
+        if [[ $attempt -ge $max_attempts ]]; then
+            echo "[${desc}] failed after ${max_attempts} attempts" >&2
+            return 1
+        fi
+        echo "[${desc}] failed, retrying in ${delay}s..."
+        sleep "$delay"
+        ((attempt++))
+    done
+}
+
+# --- Helper: best-effort wrapper ---
+# Runs the command and reports the outcome but never fails the script.
+best_effort() {
+    local desc=$1
+    shift
+    if "$@"; then
+        echo "[${desc}] ok"
+    else
+        echo "[${desc}] skipped (non-fatal)"
+    fi
+}
+
+# --- Helper: check sfctl error code from a JSON-emitting failure ---
+# Returns 0 if the output indicates "doesn't exist" (any of the SF
+# enum values that map to "we already deleted it" / "never existed").
+not_found_err() {
+    grep -qE 'FABRIC_E_(APPLICATION|SERVICE|APPLICATION_TYPE)_(NOT_FOUND|DOES_NOT_EXIST)|FABRIC_E_IMAGEBUILDER_VALIDATION_ERROR'
+}
+
+# --- Step 0: Wait for cluster ---
+retry $MAX_RETRY $RETRY_INTERVAL "cluster select" sfctl cluster select || {
+    echo "Cluster not reachable; nothing to clean up."
+    exit 0
+}
+
+# --- Step 1: Detach all GrpcController replicas (if our CLI exists) ---
+REFLECTION_CTL="${REFLECTION_CTL:-./target/debug/reflection_ctl}"
+if [[ -x "$REFLECTION_CTL" ]]; then
+    echo "Detaching all GrpcController replicas via $REFLECTION_CTL"
+    best_effort "detach-all" "$REFLECTION_CTL" detach --all
+else
+    echo "[$REFLECTION_CTL] not found; skipping detach-all"
+    echo "(Build it with: cargo build -p samples_reflection --bin reflection_ctl)"
+fi
+
+# --- Step 2: Best-effort approve-all (fallback for old deployed binary) ---
+if [[ -x "$REFLECTION_CTL" ]]; then
+    echo "Releasing any leftover gates via approve-all"
+    best_effort "approve-all" "$REFLECTION_CTL" approve-all --yes
+fi
+
+# --- Step 3: Delete every service under each app ---
+delete_services_under_app() {
+    local app_id=$1
+    local services_json
+    services_json=$(sfctl service list --application-id "$app_id" 2>/dev/null) || {
+        echo "[list services for $app_id] none / app missing"
+        return 0
+    }
+    local service_ids
+    service_ids=$(echo "$services_json" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    for s in d.get('items', []):
+        # service.name is 'fabric:/AppName/SvcName'; sfctl service-id wants
+        # the path *without* 'fabric:/'.
+        name = s.get('name', '')
+        if name.startswith('fabric:/'):
+            print(name[len('fabric:/'):])
+except Exception:
+    pass
+")
+    if [[ -z "$service_ids" ]]; then
+        echo "[delete-services $app_id] no services"
+        return 0
+    fi
+    while IFS= read -r svc; do
+        [[ -z "$svc" ]] && continue
+        echo "[delete-service $svc] deleting"
+        # Force delete to avoid hanging when a replica is mid-close.
+        # sfctl 11.x requires a value for --force-remove rather than
+        # treating it as a bare flag.
+        best_effort "delete-service $svc" \
+            sfctl service delete --service-id "$svc" --force-remove true
+    done <<< "$service_ids"
+}
+
+echo "Deleting services under fabric:/EchoApp"
+delete_services_under_app "EchoApp"
+echo "Deleting services under fabric:/ReflectionApp"
+delete_services_under_app "ReflectionApp"
+
+# --- Step 4: Delete the app instances ---
+delete_app() {
+    local app_id=$1
+    local out
+    out=$(sfctl application delete --application-id "$app_id" 2>&1)
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        echo "[delete-app $app_id] deleted"
+    elif echo "$out" | not_found_err; then
+        echo "[delete-app $app_id] already absent"
+    else
+        echo "[delete-app $app_id] failed (will retry):"
+        echo "$out" | tail -3
+        return 1
+    fi
+}
+
+retry $MAX_RETRY $RETRY_INTERVAL "delete EchoApp"        delete_app "EchoApp"        || true
+retry $MAX_RETRY $RETRY_INTERVAL "delete ReflectionApp"  delete_app "ReflectionApp"  || true
+
+# --- Step 5: Unprovision app types ---
+unprovision_app_type() {
+    local type_name=$1
+    local version=$2
+    local out
+    out=$(sfctl application unprovision \
+        --application-type-name "$type_name" \
+        --application-type-version "$version" 2>&1)
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        echo "[unprovision $type_name@$version] ok"
+    elif echo "$out" | not_found_err; then
+        echo "[unprovision $type_name@$version] already absent"
+    else
+        echo "[unprovision $type_name@$version] failed (will retry):"
+        echo "$out" | tail -3
+        return 1
+    fi
+}
+
+retry $MAX_RETRY $RETRY_INTERVAL "unprovision EchoApp"       \
+    unprovision_app_type EchoApp 0.0.1 || true
+retry $MAX_RETRY $RETRY_INTERVAL "unprovision ReflectionApp" \
+    unprovision_app_type ReflectionApp 0.0.1 || true
+
+# --- Step 6: Remove uploaded packages from the image store ---
+# `sfctl store delete` removes a relative path inside the image store.
+# The path is the same one we passed to `application provision
+# --application-type-build-path`.
+remove_store_path() {
+    local path=$1
+    local out
+    out=$(sfctl store delete --content-path "$path" 2>&1)
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        echo "[store-delete $path] ok"
+    else
+        # store delete returns success even if the path didn't exist on
+        # most SF versions; treat any non-zero as warn-only.
+        echo "[store-delete $path] non-fatal:"
+        echo "$out" | tail -3
+    fi
+}
+
+best_effort "store-delete samples_echomain"    remove_store_path samples_echomain
+best_effort "store-delete samples_reflection"  remove_store_path samples_reflection
+
+echo
+echo "All test apps removed (best-effort). Re-run prepare_test_apps.sh to redeploy."


### PR DESCRIPTION
Lets integration tests gate the lifecycle of any stateful replica in the reflection sample over a per-node gRPC server. SF calls open / change_role / close / abort; the replica parks at an "approval gate" until a test driver sends an Approve over the wire. Production behavior (no initdata) is unchanged.

Core (crates/samples/reflection/):
- New ReplicaController trait with NoopController (production path, inline Decision::Proceed) and GrpcController (test-driven, parks at gate_lock + oneshot, single-occupancy enforced by lock not assumption).
- Per-gate UUID gate_id closes the stale-approve race; a stale Approve from before a controller drop / replica rebuild is rejected with FailedPrecondition.
- Replica::abort bridges sync to async via TokioExecutor::block_on_any and queues at gate_lock if a prior gate is parked.
- ReplicaInitData proto + decode_init_data/from_init_data split so wire format and policy mapping are independently testable.

gRPC service (proto/control.proto, src/grpc_control.rs):
- WaitForApproval / Approve / ListPending for the normal flow plus Detach / DetachAll as operator escape hatches.
- Server bound on 0.0.0.0:28000+node_index, where node_index is a cfg(target_os)-gated parser of Fabric_NodeName ("_Node_N" on Windows, "N00X0" on Linux). Picks a port range outside SF's ApplicationEndpoints and OS ephemeral on both platforms.
- Server timeout is 30s default / 5min cap; ListPending replica filter is a oneof so any int64 (including 0) is exact-match.

Operator CLI (reflection_ctl/main.rs):
- ping / list / approve / approve-all / detach / detach-all.
- Uses clap for arg parsing (new workspace dep).

Test harness (src/test_cluster.rs):
- Cluster + ReplicaClient<'_> reusable across control tests, with lazy re-dial inside poll_for_pending so cold-then-warm nodes are picked up automatically as SF activates code packages there.
- poll_for_pending_in_partition for tests that want isolation.

Tests (tests/):
- control_e2e.rs: happy path Open -> ChangeRole(Primary) ->
  ChangeRole(None) -> Close.
- fail_change_role.rs: failure injection on the first ChangeRole; documents observed SF behaviour (same replica_id reused, ~15s back-off, abort + reopen sequence).
- Both default-on and follow the existing test.rs / test2.rs style; no #[ignore].

Build (build.rs, Cargo.toml):
- crate split into lib + bin so tests/ can depend on the lib.
- Added uuid v4 feature; added clap to workspace.

Scripts (scripts/):
- remove_test_apps.sh: idempotent inverse of prepare_test_apps.sh, including detach + approve-all preflight to unblock parked gates.

Skills (.github/skills/):
- onebox-deploy-test: generic build + provision + cargo test loop.
- reflection-app-testing: scoped to the reflection control plane, with the operator CLI subcommands and common pitfalls.

Design doc (docs/design/ReflectionReplicaTestControl.md):
- Status: implemented. Architecture, components, RPC error model, concurrency invariants, lifetime contract, security boundary.

Misc:
- .gitignore: ignore /.paw (PAW review artifacts).