### PR TITLE
mssf_util::tonic — failover-aware tonic Channel for Service Fabric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,12 +226,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -230,6 +254,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -260,9 +290,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -686,13 +720,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mssf-tests"
+version = "0.0.0"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mssf-util",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tower",
+]
+
+[[package]]
 name = "mssf-util"
 version = "0.7.0"
 dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
  "mssf-com",
  "mssf-core",
  "tokio",
  "tokio-util",
+ "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "trait-variant",
@@ -951,6 +1013,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "samples_client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/libs/core",
     "crates/libs/pal",
     "crates/libs/util",
+    "tests/mssf-tests",
 ]
 package.edition = "2024"
 package.authors = [ "youyuanwu@outlook.com" ]
@@ -47,6 +48,15 @@ tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 prost = "0.14"
 trait-variant = "0.1"
+arc-swap = "1"
+futures = { version = "0.3", default-features = false, features = ["std"] }
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
+hyper = "1"
+hyper-util = { version = "0.1", default-features = false, features = ["tokio"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
+bytes = "1"
 url = "2"
 uuid = { version = "1", default-features = false }
 windows = { version = "0.62", default-features = false }
@@ -57,4 +67,4 @@ windows-core = "0.62"
 mssf-com = { version = "0.6", path = "./crates/libs/com", default-features = false }
 mssf-core = { version = "0.7", path = "./crates/libs/core", default-features = false }
 mssf-pal = { version = "0.5", path = "./crates/libs/pal", default-features = true }
-mssf-util = { version = "0.7", path = "./crates/libs/util", default-features = true }
+mssf-util = { version = "0.7", path = "./crates/libs/util", default-features = true, features = ["tonic"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,4 @@ windows-core = "0.62"
 mssf-com = { version = "0.6", path = "./crates/libs/com", default-features = false }
 mssf-core = { version = "0.7", path = "./crates/libs/core", default-features = false }
 mssf-pal = { version = "0.5", path = "./crates/libs/pal", default-features = true }
-mssf-util = { version = "0.7", path = "./crates/libs/util", default-features = true, features = ["tonic"] }
+mssf-util = { version = "0.7", path = "./crates/libs/util", default-features = true }

--- a/crates/libs/util/Cargo.toml
+++ b/crates/libs/util/Cargo.toml
@@ -14,6 +14,18 @@ description = "mssf utilites and extensions for tokio and more"
 default = ["tokio", "tracing"]
 tokio = ["dep:tokio", "dep:tokio-util"]
 tracing = ["dep:tracing"]
+tonic = [
+    "tokio",
+    "dep:tonic",
+    "dep:tower",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:http",
+    "dep:http-body",
+    "dep:arc-swap",
+    "dep:futures",
+    "dep:bytes",
+]
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "signal"], optional = true, default-features = false }
@@ -22,6 +34,18 @@ tracing = { workspace = true, optional = true }
 mssf-core = { workspace = true, default-features = false }
 mssf-com = { workspace = true }
 
+# `tonic` feature deps
+tonic = { workspace = true, optional = true }
+tower = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true }
+hyper-util = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
+http-body = { workspace = true, optional = true }
+arc-swap = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+
 [dev-dependencies]
 trait-variant.workspace = true
 tracing-subscriber.workspace = true
+tokio = { workspace = true, features = ["rt", "signal", "macros", "rt-multi-thread", "io-util", "net", "time"], default-features = false }

--- a/crates/libs/util/src/lib.rs
+++ b/crates/libs/util/src/lib.rs
@@ -21,3 +21,6 @@ pub mod monitoring;
 pub mod data;
 
 pub mod mock;
+
+#[cfg(feature = "tonic")]
+pub mod tonic;

--- a/crates/libs/util/src/tonic/channel/builder.rs
+++ b/crates/libs/util/src/tonic/channel/builder.rs
@@ -5,14 +5,11 @@
 
 use std::sync::Arc;
 
-use hyper_util::rt::TokioIo;
-use tokio::net::TcpStream;
 use tonic::transport::Endpoint;
-use tower::Service;
 
-use crate::tonic::connector::{TargetConnector, TargetConnectorBuilder};
+use crate::tonic::connector::TargetConnectorBuilder;
 use crate::tonic::middleware::ResolveStatusMiddleware;
-use crate::tonic::naming::{BoxError, TargetResolver};
+use crate::tonic::naming::TargetResolver;
 
 use super::swap::SwapChannel;
 
@@ -22,17 +19,20 @@ use super::swap::SwapChannel;
 /// generated tonic clients.
 pub type TargetChannel = ResolveStatusMiddleware<SwapChannel>;
 
-type TlsWrapper = Box<dyn FnOnce(TargetConnector, Endpoint) -> SwapChannel + Send>;
-
 /// Builder for [`TargetChannel`].
 ///
 /// The resolver embeds the target selector; the channel builder
 /// has no selector setter of its own.
+///
+/// **TLS is not yet supported.** v1 ships plain TCP only via
+/// [`TargetConnector`]. The TLS recipe sketched in the design
+/// doc requires generalizing `SwapChannel` over its inner IO
+/// type (today fixed at `TokioIo<TcpStream>`); see Future work
+/// in `docs/design/TonicConnectorDesign.md`.
 pub struct TargetChannelBuilder {
     resolver: Option<Arc<dyn TargetResolver>>,
     endpoint_template: Option<Endpoint>,
     trailer_header: Option<http::HeaderName>,
-    tls: Option<TlsWrapper>,
 }
 
 impl TargetChannelBuilder {
@@ -41,7 +41,6 @@ impl TargetChannelBuilder {
             resolver: None,
             endpoint_template: None,
             trailer_header: None,
-            tls: None,
         }
     }
 
@@ -72,31 +71,6 @@ impl TargetChannelBuilder {
         self
     }
 
-    /// Wrap the connector with a user-supplied TLS layer before
-    /// building the inner `tonic::Channel`. The closure receives
-    /// the [`TargetConnector`] and must return a `Service<Uri>`
-    /// that performs TLS on top of it (typical:
-    /// `tonic_tls::*::TlsConnector::new`). The returned service's
-    /// bounds match [`SwapChannel::with_connector`].
-    pub fn with_tls<F, T>(mut self, f: F) -> Self
-    where
-        F: FnOnce(TargetConnector) -> T + Send + 'static,
-        T: Service<http::Uri, Response = TokioIo<TcpStream>, Error = BoxError>
-            + Clone
-            + Send
-            + Sync
-            + 'static,
-        T::Future: Send + 'static,
-    {
-        // Deferred so the user can call `endpoint_template(...)`
-        // either before or after `with_tls(...)`.
-        self.tls = Some(Box::new(move |conn: TargetConnector, ep: Endpoint| {
-            let tls = f(conn);
-            SwapChannel::with_connector(ep, tls)
-        }));
-        self
-    }
-
     /// Build a ready-to-use service. Sync; no IO until the first
     /// request.
     pub fn build(self) -> TargetChannel {
@@ -108,10 +82,7 @@ impl TargetChannelBuilder {
             .expect("TargetChannelBuilder::trailer_header is required");
         let connector = TargetConnectorBuilder::new().resolver(resolver).build();
         let ep = self.endpoint_template.unwrap_or_else(default_endpoint);
-        let swap = match self.tls {
-            Some(wrapper) => wrapper(connector, ep),
-            None => SwapChannel::new(ep, connector),
-        };
+        let swap = SwapChannel::new(ep, connector);
         ResolveStatusMiddleware::new(swap.clone(), trailer_header, move || swap.rebuild())
     }
 }

--- a/crates/libs/util/src/tonic/channel/builder.rs
+++ b/crates/libs/util/src/tonic/channel/builder.rs
@@ -1,0 +1,127 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::sync::Arc;
+
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
+use tonic::transport::Endpoint;
+use tower::Service;
+
+use crate::tonic::connector::{TargetConnector, TargetConnectorBuilder};
+use crate::tonic::middleware::ResolveStatusMiddleware;
+use crate::tonic::naming::{BoxError, TargetResolver};
+
+use super::swap::SwapChannel;
+
+/// Convenience composed channel: trailer middleware on top of a
+/// hot-swappable `tonic::Channel`. Implements
+/// `Service<Request<tonic::body::Body>>` so it can go straight into
+/// generated tonic clients.
+pub type TargetChannel = ResolveStatusMiddleware<SwapChannel>;
+
+type TlsWrapper = Box<dyn FnOnce(TargetConnector, Endpoint) -> SwapChannel + Send>;
+
+/// Builder for [`TargetChannel`].
+///
+/// The resolver embeds the target selector; the channel builder
+/// has no selector setter of its own.
+pub struct TargetChannelBuilder {
+    resolver: Option<Arc<dyn TargetResolver>>,
+    endpoint_template: Option<Endpoint>,
+    trailer_header: Option<http::HeaderName>,
+    tls: Option<TlsWrapper>,
+}
+
+impl TargetChannelBuilder {
+    pub fn new() -> Self {
+        Self {
+            resolver: None,
+            endpoint_template: None,
+            trailer_header: None,
+            tls: None,
+        }
+    }
+
+    /// Required. Same trait object as
+    /// [`TargetConnectorBuilder::resolver`].
+    pub fn resolver(mut self, r: Arc<dyn TargetResolver>) -> Self {
+        self.resolver = Some(r);
+        self
+    }
+
+    /// **Required.** Trailer header name the middleware will
+    /// inspect for rebuild signals. Pass `"mssf-status"` for the
+    /// SF Rust SDK convention. Panics at `build()` time if not a
+    /// valid HTTP header name.
+    pub fn trailer_header(mut self, name: impl AsRef<str>) -> Self {
+        let parsed = http::HeaderName::try_from(name.as_ref())
+            .expect("TargetChannelBuilder::trailer_header: invalid header name");
+        self.trailer_header = Some(parsed);
+        self
+    }
+
+    /// Endpoint template applied to every generation of the inner
+    /// `tonic::Channel`. The URI is a placeholder; the connector
+    /// ignores it. Defaults to
+    /// `Endpoint::from_static("http://fabric.invalid")`.
+    pub fn endpoint_template(mut self, ep: Endpoint) -> Self {
+        self.endpoint_template = Some(ep);
+        self
+    }
+
+    /// Wrap the connector with a user-supplied TLS layer before
+    /// building the inner `tonic::Channel`. The closure receives
+    /// the [`TargetConnector`] and must return a `Service<Uri>`
+    /// that performs TLS on top of it (typical:
+    /// `tonic_tls::*::TlsConnector::new`). The returned service's
+    /// bounds match [`SwapChannel::with_connector`].
+    pub fn with_tls<F, T>(mut self, f: F) -> Self
+    where
+        F: FnOnce(TargetConnector) -> T + Send + 'static,
+        T: Service<http::Uri, Response = TokioIo<TcpStream>, Error = BoxError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        T::Future: Send + 'static,
+    {
+        // Deferred so the user can call `endpoint_template(...)`
+        // either before or after `with_tls(...)`.
+        self.tls = Some(Box::new(move |conn: TargetConnector, ep: Endpoint| {
+            let tls = f(conn);
+            SwapChannel::with_connector(ep, tls)
+        }));
+        self
+    }
+
+    /// Build a ready-to-use service. Sync; no IO until the first
+    /// request.
+    pub fn build(self) -> TargetChannel {
+        let resolver = self
+            .resolver
+            .expect("TargetChannelBuilder::resolver is required");
+        let trailer_header = self
+            .trailer_header
+            .expect("TargetChannelBuilder::trailer_header is required");
+        let connector = TargetConnectorBuilder::new().resolver(resolver).build();
+        let ep = self.endpoint_template.unwrap_or_else(default_endpoint);
+        let swap = match self.tls {
+            Some(wrapper) => wrapper(connector, ep),
+            None => SwapChannel::new(ep, connector),
+        };
+        ResolveStatusMiddleware::new(swap.clone(), trailer_header, move || swap.rebuild())
+    }
+}
+
+impl Default for TargetChannelBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn default_endpoint() -> Endpoint {
+    Endpoint::from_static("http://fabric.invalid")
+}

--- a/crates/libs/util/src/tonic/channel/mod.rs
+++ b/crates/libs/util/src/tonic/channel/mod.rs
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Channel composition: [`SwapChannel`] (atomic Channel hot-swap)
+//! plus the [`TargetChannel`] convenience alias / builder.
+
+mod builder;
+mod swap;
+
+pub use self::builder::{TargetChannel, TargetChannelBuilder};
+pub use self::swap::SwapChannel;

--- a/crates/libs/util/src/tonic/channel/swap.rs
+++ b/crates/libs/util/src/tonic/channel/swap.rs
@@ -27,10 +27,15 @@ type ErasedConnector = BoxCloneSyncService<http::Uri, TokioIo<TcpStream>, BoxErr
 ///
 /// `SwapChannel` is **type-erased over the inner connector**: it
 /// stores a `BoxCloneSyncService<Uri, TokioIo<TcpStream>, BoxError>`
-/// internally, so the same `SwapChannel` type can hold a plain
-/// [`TargetConnector`] or any other user-supplied `Service<Uri>`
-/// (e.g. tonic-tls). The cost is one `Box::pin` per dial — minor
-/// against TCP connect + TLS handshake.
+/// internally. The cost is one `Box::pin` per dial — negligible
+/// against TCP connect.
+///
+/// **The IO type is fixed at `TokioIo<TcpStream>`**, so any
+/// connector other than [`TargetConnector`] must also produce
+/// `TokioIo<TcpStream>` (i.e. plain TCP). TLS-wrapped connectors
+/// (which return `TokioIo<TlsStream<...>>`) do not fit. Generalizing
+/// the IO bound to support TLS is Future Work — see
+/// `docs/design/TonicConnectorDesign.md`.
 ///
 /// Readiness is driven inside the response future rather than
 /// across separate `poll_ready` / `call` invocations, so cloning
@@ -64,9 +69,12 @@ impl SwapChannel {
     }
 
     /// Build a `SwapChannel` from any `Service<Uri>` that produces
-    /// a hyper-compatible IO. Used for TLS composition: pass the
-    /// `tonic_tls::*::TlsConnector<TargetConnector>` returned by
-    /// `TlsConnector::new(...)`.
+    /// a plain `TokioIo<TcpStream>`. Useful for tests with a mock
+    /// connector or for users who want to wrap [`TargetConnector`]
+    /// in additional non-TLS tower middleware.
+    ///
+    /// **Does not support TLS** — see the type-level note on
+    /// [`SwapChannel`].
     pub fn with_connector<S>(endpoint_template: Endpoint, connector: S) -> Self
     where
         S: Service<http::Uri, Response = TokioIo<TcpStream>, Error = BoxError>

--- a/crates/libs/util/src/tonic/channel/swap.rs
+++ b/crates/libs/util/src/tonic/channel/swap.rs
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arc_swap::ArcSwap;
+use futures::future::BoxFuture;
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
+use tonic::body::Body;
+use tonic::transport::{Channel, Endpoint};
+use tower::util::BoxCloneSyncService;
+use tower::{Service, ServiceExt as _};
+
+use crate::tonic::connector::TargetConnector;
+use crate::tonic::naming::BoxError;
+
+/// Type-erased connector slot stored inside [`SwapChannel`].
+type ErasedConnector = BoxCloneSyncService<http::Uri, TokioIo<TcpStream>, BoxError>;
+
+/// Wraps a [`Channel`] behind an `ArcSwap` so the inner Channel
+/// can be replaced atomically without invalidating the user-facing
+/// handle.
+///
+/// `SwapChannel` is **type-erased over the inner connector**: it
+/// stores a `BoxCloneSyncService<Uri, TokioIo<TcpStream>, BoxError>`
+/// internally, so the same `SwapChannel` type can hold a plain
+/// [`TargetConnector`] or any other user-supplied `Service<Uri>`
+/// (e.g. tonic-tls). The cost is one `Box::pin` per dial — minor
+/// against TCP connect + TLS handshake.
+///
+/// Readiness is driven inside the response future rather than
+/// across separate `poll_ready` / `call` invocations, so cloning
+/// `SwapChannel` (e.g. inside layered tower stacks) doesn't risk
+/// leaking a stale readied snapshot from before a `rebuild()`.
+#[derive(Clone)]
+pub struct SwapChannel {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    /// Current Channel; replaced atomically by `rebuild()`.
+    channel: ArcSwap<Channel>,
+    /// Type-erased connector; cloned on every rebuild.
+    connector: ErasedConnector,
+    /// Endpoint template (timeouts, keepalive, HTTP/2 windows,
+    /// ...). The URI inside is a placeholder; the connector
+    /// ignores it.
+    endpoint_template: Endpoint,
+}
+
+impl SwapChannel {
+    /// Build a `SwapChannel` from a plain [`TargetConnector`].
+    /// Equivalent to
+    /// `with_connector(template, BoxCloneSyncService::new(connector))`.
+    /// The first inner Channel is built lazily via
+    /// `Endpoint::connect_with_connector_lazy`, so this performs
+    /// no IO.
+    pub fn new(endpoint_template: Endpoint, connector: TargetConnector) -> Self {
+        Self::with_connector(endpoint_template, connector)
+    }
+
+    /// Build a `SwapChannel` from any `Service<Uri>` that produces
+    /// a hyper-compatible IO. Used for TLS composition: pass the
+    /// `tonic_tls::*::TlsConnector<TargetConnector>` returned by
+    /// `TlsConnector::new(...)`.
+    pub fn with_connector<S>(endpoint_template: Endpoint, connector: S) -> Self
+    where
+        S: Service<http::Uri, Response = TokioIo<TcpStream>, Error = BoxError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        let erased: ErasedConnector = BoxCloneSyncService::new(connector);
+        let initial = endpoint_template.connect_with_connector_lazy(erased.clone());
+        Self {
+            inner: Arc::new(Inner {
+                channel: ArcSwap::from_pointee(initial),
+                connector: erased,
+                endpoint_template,
+            }),
+        }
+    }
+
+    /// Trigger a rebuild of the inner Channel. Non-blocking; this
+    /// schedules a `connect_with_connector_lazy(...)` (which itself
+    /// does no IO) and atomically swaps the result in.
+    ///
+    /// Storm dedup happens **above** this layer in
+    /// [`super::super::ResolveStatusMiddleware`].
+    ///
+    /// Does not affect in-flight requests: they hold clones of the
+    /// previous Channel and run to completion on it.
+    pub fn rebuild(&self) {
+        let new_channel = self
+            .inner
+            .endpoint_template
+            .connect_with_connector_lazy(self.inner.connector.clone());
+        self.inner.channel.store(Arc::new(new_channel));
+    }
+}
+
+impl Service<http::Request<Body>> for SwapChannel {
+    type Response = http::Response<Body>;
+    type Error = tonic::transport::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Always advertise ready. The actual `Channel` (which is
+        // a buffered tonic service requiring `poll_ready` to be
+        // paired with `call` on the same instance) is readied
+        // inside the future returned by `call`. This avoids
+        // cross-clone state leaks: tower wrappers above us may
+        // clone `SwapChannel` between `poll_ready` and `call`,
+        // and they may also outlive a `rebuild()` that swaps in
+        // a different inner `Channel` generation.
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+        // Snapshot the current Channel; ready it; dispatch.
+        // The returned future holds its own clone of that
+        // Channel internally (tonic's future captures the
+        // buffer sender), so a concurrent `rebuild()` does not
+        // affect this in-flight call.
+        let mut ch = (**self.inner.channel.load()).clone();
+        Box::pin(async move {
+            let svc = ch.ready().await?;
+            svc.call(req).await
+        })
+    }
+}

--- a/crates/libs/util/src/tonic/connector/mod.rs
+++ b/crates/libs/util/src/tonic/connector/mod.rs
@@ -1,0 +1,11 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Hyper-compatible `Service<http::Uri>` connector that delegates
+//! the "what to dial" decision to a [`TargetResolver`].
+
+mod service;
+
+pub use self::service::{TargetConnector, TargetConnectorBuilder};

--- a/crates/libs/util/src/tonic/connector/service.rs
+++ b/crates/libs/util/src/tonic/connector/service.rs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
+use tower::Service;
+
+use crate::tonic::naming::{BoxError, TargetResolver};
+
+/// Hyper-compatible connector. Implements `tower::Service<http::Uri>`
+/// returning a connected IO. Suitable for
+/// [`tonic::transport::Endpoint::connect_with_connector_lazy`].
+///
+/// The connector is **pure** transport: ask the resolver for a
+/// `DialTarget`, open a TCP connection. It has no knowledge of
+/// channels, retries, or trailers. Channel-level invalidation
+/// lives one layer up, in `SwapChannel`.
+#[derive(Clone)]
+pub struct TargetConnector {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    resolver: Arc<dyn TargetResolver>,
+}
+
+impl TargetConnector {
+    /// Construct directly from a resolver, bypassing the builder.
+    pub fn new(resolver: Arc<dyn TargetResolver>) -> Self {
+        Self {
+            inner: Arc::new(Inner { resolver }),
+        }
+    }
+}
+
+impl Service<http::Uri> for TargetConnector {
+    /// Concrete IO type returned to hyper. Plain TCP wrapped in
+    /// hyper-util's `TokioIo` adapter for the hyper IO traits.
+    /// For TLS, the user composes a TLS connector on top via
+    /// [`super::super::SwapChannel::with_connector`].
+    type Response = TokioIo<TcpStream>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _placeholder_uri: http::Uri) -> Self::Future {
+        // The placeholder URI is hyper's pool key, NOT our SF Fabric
+        // URI. We ignore it.
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let target = inner.resolver.resolve().await?;
+            let stream = TcpStream::connect((target.host.as_str(), target.port))
+                .await
+                .map_err(|e| Box::new(e) as BoxError)?;
+            Ok(TokioIo::new(stream))
+        })
+    }
+}
+
+/// Builder for [`TargetConnector`].
+pub struct TargetConnectorBuilder {
+    resolver: Option<Arc<dyn TargetResolver>>,
+}
+
+impl TargetConnectorBuilder {
+    pub fn new() -> Self {
+        Self { resolver: None }
+    }
+
+    /// Required. The SF naming abstraction. Use
+    /// [`super::super::FabricTargetResolverBuilder`] for the
+    /// production impl, or any custom [`TargetResolver`].
+    pub fn resolver(mut self, r: Arc<dyn TargetResolver>) -> Self {
+        self.resolver = Some(r);
+        self
+    }
+
+    /// Panics if `resolver` was not set. Sync; no IO until first
+    /// dial.
+    pub fn build(self) -> TargetConnector {
+        let resolver = self
+            .resolver
+            .expect("TargetConnectorBuilder::resolver is required");
+        TargetConnector::new(resolver)
+    }
+}
+
+impl Default for TargetConnectorBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/libs/util/src/tonic/middleware.rs
+++ b/crates/libs/util/src/tonic/middleware.rs
@@ -11,10 +11,9 @@
 //! `docs/design/TonicConnectorDesign.md` ("Rebuild dedup").
 
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
-use arc_swap::ArcSwapOption;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use http_body::Frame;
@@ -25,16 +24,25 @@ use tower::Service;
 /// header triggers a non-blocking rebuild of the inner Channel
 /// via the supplied rebuild handle.
 ///
-/// Stateful for dedup: tracks the last trailer value observed and
-/// only triggers `rebuild()` when the value differs (with two
-/// special signals — absent trailer resets state, empty value
-/// always rebuilds without affecting state).
+/// Stateful for dedup: tracks the last trailer value observed
+/// and only triggers `rebuild()` when the value differs (with
+/// two special signals — absent trailer resets state, empty
+/// value always rebuilds without affecting state).
+///
+/// **Concurrency.** The dedup decision
+/// (load → classify → store) is serialized under a
+/// `std::sync::Mutex`, so concurrent in-flight RPCs that
+/// complete with the **same** trailer value collapse to one
+/// `rebuild()` call. Distinct values still produce one rebuild
+/// each. The mutex is held only across the decision; the
+/// rebuild closure runs outside the lock so back-to-back
+/// `connect_with_connector_lazy` calls don't serialize.
 #[derive(Clone)]
 pub struct ResolveStatusMiddleware<S> {
     inner: S,
     rebuild: Arc<dyn Fn() + Send + Sync>,
     header_name: http::HeaderName,
-    last_seen: Arc<ArcSwapOption<String>>,
+    last_seen: Arc<Mutex<Option<String>>>,
 }
 
 impl<S> ResolveStatusMiddleware<S> {
@@ -50,7 +58,7 @@ impl<S> ResolveStatusMiddleware<S> {
             inner,
             rebuild: Arc::new(rebuild),
             header_name,
-            last_seen: Arc::new(ArcSwapOption::empty()),
+            last_seen: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -137,14 +145,14 @@ where
 struct TrailerObserver {
     inner: Body,
     header: http::HeaderName,
-    last_seen: Arc<ArcSwapOption<String>>,
+    last_seen: Arc<Mutex<Option<String>>>,
     rebuild: Arc<dyn Fn() + Send + Sync>,
     /// Set once we observe a trailer frame; if the body ends
     /// without one we apply the "no trailer" branch.
     saw_trailers: bool,
     /// Set once we've applied the dedup decision (either via a
     /// trailer frame or via the end-of-stream reset). Prevents
-    /// double-firing.
+    /// double-firing within a single response body.
     fired: bool,
 }
 
@@ -152,7 +160,7 @@ impl TrailerObserver {
     fn new(
         inner: Body,
         header: http::HeaderName,
-        last_seen: Arc<ArcSwapOption<String>>,
+        last_seen: Arc<Mutex<Option<String>>>,
         rebuild: Arc<dyn Fn() + Send + Sync>,
     ) -> Self {
         Self {
@@ -170,21 +178,33 @@ impl TrailerObserver {
             return;
         }
         self.fired = true;
-        let prev = self.last_seen.load_full();
-        let prev_str: Option<&str> = prev.as_deref().map(|s| s.as_str());
-        let action = classify(observed, prev_str);
-        match action {
-            DedupAction::None => {}
-            DedupAction::Reset => {
-                self.last_seen.store(None);
+
+        // Hold the lock across load + classify + store so
+        // concurrent observers of the same value collapse to a
+        // single decision. Drop the guard *before* invoking the
+        // rebuild closure: rebuild does its own lazy work
+        // (connect_with_connector_lazy + ArcSwap::store) and
+        // doesn't need to be serialized; we only need the
+        // decision step itself to be atomic.
+        let should_rebuild = {
+            let mut guard = self.last_seen.lock().expect("middleware mutex poisoned");
+            let prev_str: Option<&str> = guard.as_deref();
+            let action = classify(observed, prev_str);
+            match action {
+                DedupAction::None => false,
+                DedupAction::Reset => {
+                    *guard = None;
+                    false
+                }
+                DedupAction::RebuildKeepLast => true,
+                DedupAction::StoreAndRebuild(v) => {
+                    *guard = Some(v);
+                    true
+                }
             }
-            DedupAction::RebuildKeepLast => {
-                (self.rebuild)();
-            }
-            DedupAction::StoreAndRebuild(v) => {
-                self.last_seen.store(Some(Arc::new(v)));
-                (self.rebuild)();
-            }
+        };
+        if should_rebuild {
+            (self.rebuild)();
         }
     }
 }

--- a/crates/libs/util/src/tonic/middleware.rs
+++ b/crates/libs/util/src/tonic/middleware.rs
@@ -1,0 +1,272 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Trailer-aware middleware: inspects gRPC response trailers and
+//! triggers a non-blocking rebuild on the configured header.
+//!
+//! Lives **above** `SwapChannel` in the tower stack. The dedup
+//! state machine is documented in
+//! `docs/design/TonicConnectorDesign.md` ("Rebuild dedup").
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arc_swap::ArcSwapOption;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use http_body::Frame;
+use tonic::body::Body;
+use tower::Service;
+
+/// Inspects gRPC response trailers; on the configured trailer
+/// header triggers a non-blocking rebuild of the inner Channel
+/// via the supplied rebuild handle.
+///
+/// Stateful for dedup: tracks the last trailer value observed and
+/// only triggers `rebuild()` when the value differs (with two
+/// special signals — absent trailer resets state, empty value
+/// always rebuilds without affecting state).
+#[derive(Clone)]
+pub struct ResolveStatusMiddleware<S> {
+    inner: S,
+    rebuild: Arc<dyn Fn() + Send + Sync>,
+    header_name: http::HeaderName,
+    last_seen: Arc<ArcSwapOption<String>>,
+}
+
+impl<S> ResolveStatusMiddleware<S> {
+    /// Construct from any rebuild trigger. Useful for tests with
+    /// a mock and for users who want to plug a different
+    /// invalidation mechanism behind the same trailer-detection
+    /// logic.
+    pub fn new<F>(inner: S, header_name: http::HeaderName, rebuild: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        Self {
+            inner,
+            rebuild: Arc::new(rebuild),
+            header_name,
+            last_seen: Arc::new(ArcSwapOption::empty()),
+        }
+    }
+}
+
+/// Decision applied by the dedup state machine after observing a
+/// response. Extracted as an enum to make the middleware unit
+/// tests trivial.
+#[derive(Debug, PartialEq, Eq)]
+enum DedupAction {
+    /// No-op; trailer absent and `last_seen` already `None`, or
+    /// trailer matched `last_seen`.
+    None,
+    /// Trailer present (non-empty) with a value differing from
+    /// `last_seen`; store it and rebuild.
+    StoreAndRebuild(String),
+    /// Trailer present with empty value; rebuild without
+    /// touching `last_seen`.
+    RebuildKeepLast,
+    /// No trailer on the response; reset `last_seen` to `None`,
+    /// no rebuild.
+    Reset,
+}
+
+/// Apply the dedup rule documented in
+/// `TonicConnectorDesign.md#rebuild-dedup`.
+fn classify(observed: Option<&str>, last_seen: Option<&str>) -> DedupAction {
+    match observed {
+        None => {
+            if last_seen.is_none() {
+                DedupAction::None
+            } else {
+                DedupAction::Reset
+            }
+        }
+        Some("") => DedupAction::RebuildKeepLast,
+        Some(v) => match last_seen {
+            Some(prev) if prev == v => DedupAction::None,
+            _ => DedupAction::StoreAndRebuild(v.to_string()),
+        },
+    }
+}
+
+impl<S> Service<http::Request<Body>> for ResolveStatusMiddleware<S>
+where
+    S: Service<
+            http::Request<Body>,
+            Response = http::Response<Body>,
+            Error = tonic::transport::Error,
+        > + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = http::Response<Body>;
+    type Error = tonic::transport::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+        // Use the readied service clone; re-arm `self.inner` with
+        // a fresh clone for next call (standard tower idiom).
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut inner, &mut self.inner);
+        let header = self.header_name.clone();
+        let rebuild = self.rebuild.clone();
+        let last_seen = self.last_seen.clone();
+        Box::pin(async move {
+            let resp = inner.call(req).await?;
+            let (parts, body) = resp.into_parts();
+            let observer = TrailerObserver::new(body, header, last_seen, rebuild);
+            let wrapped = Body::new(observer);
+            Ok(http::Response::from_parts(parts, wrapped))
+        })
+    }
+}
+
+/// Body wrapper that delegates `poll_frame` and inspects the
+/// final trailer frame. Apply the dedup rule before forwarding
+/// the frame downstream so the caller observes trailers
+/// unchanged.
+struct TrailerObserver {
+    inner: Body,
+    header: http::HeaderName,
+    last_seen: Arc<ArcSwapOption<String>>,
+    rebuild: Arc<dyn Fn() + Send + Sync>,
+    /// Set once we observe a trailer frame; if the body ends
+    /// without one we apply the "no trailer" branch.
+    saw_trailers: bool,
+    /// Set once we've applied the dedup decision (either via a
+    /// trailer frame or via the end-of-stream reset). Prevents
+    /// double-firing.
+    fired: bool,
+}
+
+impl TrailerObserver {
+    fn new(
+        inner: Body,
+        header: http::HeaderName,
+        last_seen: Arc<ArcSwapOption<String>>,
+        rebuild: Arc<dyn Fn() + Send + Sync>,
+    ) -> Self {
+        Self {
+            inner,
+            header,
+            last_seen,
+            rebuild,
+            saw_trailers: false,
+            fired: false,
+        }
+    }
+
+    fn fire(&mut self, observed: Option<&str>) {
+        if self.fired {
+            return;
+        }
+        self.fired = true;
+        let prev = self.last_seen.load_full();
+        let prev_str: Option<&str> = prev.as_deref().map(|s| s.as_str());
+        let action = classify(observed, prev_str);
+        match action {
+            DedupAction::None => {}
+            DedupAction::Reset => {
+                self.last_seen.store(None);
+            }
+            DedupAction::RebuildKeepLast => {
+                (self.rebuild)();
+            }
+            DedupAction::StoreAndRebuild(v) => {
+                self.last_seen.store(Some(Arc::new(v)));
+                (self.rebuild)();
+            }
+        }
+    }
+}
+
+impl http_body::Body for TrailerObserver {
+    type Data = Bytes;
+    type Error = tonic::Status;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.as_mut().get_mut();
+        let polled = Pin::new(&mut this.inner).poll_frame(cx);
+        match &polled {
+            // Trailers frame: extract the configured header value
+            // (if any) and run the dedup decision before
+            // forwarding the frame to the caller.
+            Poll::Ready(Some(Ok(frame))) if frame.is_trailers() => {
+                if let Some(map) = frame.trailers_ref() {
+                    let observed = map.get(&this.header).and_then(|v| v.to_str().ok());
+                    this.saw_trailers = true;
+                    this.fire(observed);
+                }
+            }
+            // End-of-stream without ever seeing a trailers frame:
+            // apply the "no trailer" branch of the dedup rule.
+            Poll::Ready(None) if !this.saw_trailers => {
+                this.fire(None);
+            }
+            _ => {}
+        }
+        polled
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_none_to_value_rebuilds() {
+        assert_eq!(
+            classify(Some("not-primary"), None),
+            DedupAction::StoreAndRebuild("not-primary".to_string()),
+        );
+    }
+
+    #[test]
+    fn dedup_same_value_is_noop() {
+        assert_eq!(classify(Some("v"), Some("v")), DedupAction::None);
+    }
+
+    #[test]
+    fn dedup_different_value_rebuilds() {
+        assert_eq!(
+            classify(Some("w"), Some("v")),
+            DedupAction::StoreAndRebuild("w".to_string()),
+        );
+    }
+
+    #[test]
+    fn dedup_no_trailer_resets_when_seen() {
+        assert_eq!(classify(None, Some("v")), DedupAction::Reset);
+    }
+
+    #[test]
+    fn dedup_no_trailer_steady_state_is_noop() {
+        assert_eq!(classify(None, None), DedupAction::None);
+    }
+
+    #[test]
+    fn dedup_empty_always_rebuilds_without_state_change() {
+        assert_eq!(classify(Some(""), None), DedupAction::RebuildKeepLast);
+        assert_eq!(classify(Some(""), Some("v")), DedupAction::RebuildKeepLast);
+    }
+}

--- a/crates/libs/util/src/tonic/mod.rs
+++ b/crates/libs/util/src/tonic/mod.rs
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Service Fabric tonic connector with auto-failover.
+//!
+//! See `docs/design/TonicConnectorDesign.md` for the design.
+//!
+//! The public surface is intentionally flat — internal
+//! sub-modules are an organizational detail. Use the re-exports
+//! below.
+
+mod channel;
+mod connector;
+mod middleware;
+mod naming;
+
+pub use self::channel::{SwapChannel, TargetChannel, TargetChannelBuilder};
+pub use self::connector::{TargetConnector, TargetConnectorBuilder};
+pub use self::middleware::ResolveStatusMiddleware;
+pub use self::naming::{
+    BoxError, DialTarget, FabricTargetResolver, FabricTargetResolverBuilder, SelectError,
+    TargetResolver, TargetSelector,
+};

--- a/crates/libs/util/src/tonic/naming/default.rs
+++ b/crates/libs/util/src/tonic/naming/default.rs
@@ -1,0 +1,167 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwapOption;
+use futures::future::BoxFuture;
+use mssf_core::client::FabricClient;
+use mssf_core::client::svc_mgmt_client::{PartitionKeyType, ResolvedServicePartition};
+use mssf_core::types::Uri as FabricUri;
+
+use crate::resolve::ServicePartitionResolver;
+use crate::retry::OperationRetryer;
+
+use super::resolver::{BoxError, TargetResolver};
+use super::selector::{DialTarget, SelectError, TargetSelector};
+
+/// Production [`TargetResolver`] for Service Fabric.
+///
+/// Wraps the existing [`ServicePartitionResolver`], applies the
+/// always-complain rule against a cached
+/// COM-backed `ResolvedServicePartition`, and runs the
+/// user-supplied selector against that RSP to produce a
+/// `DialTarget`.
+pub struct FabricTargetResolver {
+    inner: ServicePartitionResolver,
+    uri: FabricUri,
+    key: PartitionKeyType,
+    timeout: Option<Duration>,
+    selector: TargetSelector,
+    /// `previousResult` for the next SF call. `None` until first
+    /// successful resolve.
+    cached: ArcSwapOption<ResolvedServicePartition>,
+}
+
+impl TargetResolver for FabricTargetResolver {
+    fn resolve(&self) -> BoxFuture<'_, Result<DialTarget, BoxError>> {
+        Box::pin(async move {
+            let prev = self.cached.load_full();
+            let new_rsp = self
+                .inner
+                .resolve(&self.uri, &self.key, prev.as_deref(), self.timeout, None)
+                .await
+                .map_err(|e| Box::new(e) as BoxError)?;
+            // Same-version reply: keep cached Arc identity (avoids
+            // pointer churn under steady-state always-complain).
+            let rsp = match prev.as_deref() {
+                Some(p) => match p.compare_version(&new_rsp) {
+                    Ok(0) => prev.unwrap(),
+                    Ok(_) => {
+                        let arc = Arc::new(new_rsp);
+                        self.cached.store(Some(arc.clone()));
+                        arc
+                    }
+                    // compare_version returns Err only when the two
+                    // RSPs refer to different services / partitions.
+                    // Treat as "newer view," replace cache.
+                    Err(_) => {
+                        let arc = Arc::new(new_rsp);
+                        self.cached.store(Some(arc.clone()));
+                        arc
+                    }
+                },
+                None => {
+                    let arc = Arc::new(new_rsp);
+                    self.cached.store(Some(arc.clone()));
+                    arc
+                }
+            };
+            // Run the user's role-pick + address-parse closure.
+            (self.selector)(&rsp).map_err(|e| match e {
+                SelectError::NoMatch => "no matching endpoint".into(),
+                SelectError::Fatal(b) => b,
+            })
+        })
+    }
+}
+
+/// Builder for [`FabricTargetResolver`].
+pub struct FabricTargetResolverBuilder {
+    fc: FabricClient,
+    uri: Option<FabricUri>,
+    key: PartitionKeyType,
+    timeout: Option<Duration>,
+    retryer: Option<OperationRetryer>,
+    selector: Option<TargetSelector>,
+}
+
+impl FabricTargetResolverBuilder {
+    pub fn new(fc: FabricClient) -> Self {
+        Self {
+            fc,
+            uri: None,
+            key: PartitionKeyType::None,
+            timeout: None,
+            retryer: None,
+            selector: None,
+        }
+    }
+
+    /// Required. The Fabric URI (`fabric:/App/Service`) this
+    /// resolver will look up. Concrete type is
+    /// `mssf_core::types::Uri`, **not** `http::Uri`.
+    pub fn service_uri(mut self, uri: impl Into<FabricUri>) -> Self {
+        self.uri = Some(uri.into());
+        self
+    }
+
+    /// Defaults to `PartitionKeyType::None` (Singleton partitions).
+    pub fn partition_key(mut self, key: PartitionKeyType) -> Self {
+        self.key = key;
+        self
+    }
+
+    /// Per-resolve total deadline. `None` means no extra deadline
+    /// (rely on `OperationRetryer` policy + caller cancellation).
+    pub fn resolve_timeout(mut self, t: Duration) -> Self {
+        self.timeout = Some(t);
+        self
+    }
+
+    /// Retry / backoff policy applied inside
+    /// [`ServicePartitionResolver::resolve`] for transient failures.
+    pub fn retryer(mut self, r: OperationRetryer) -> Self {
+        self.retryer = Some(r);
+        self
+    }
+
+    /// **Required.** Role-pick + address-parse closure run inside
+    /// `resolve()` against the just-confirmed RSP.
+    pub fn target_selector<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&ResolvedServicePartition) -> Result<DialTarget, SelectError> + Send + Sync + 'static,
+    {
+        self.selector = Some(Arc::new(f));
+        self
+    }
+
+    /// Panics if `service_uri` or `target_selector` was not set.
+    /// Returns an `Arc<FabricTargetResolver>`. Coerces implicitly
+    /// to `Arc<dyn TargetResolver>` at the
+    /// [`super::super::TargetConnectorBuilder::resolver`] /
+    /// [`super::super::TargetChannelBuilder::resolver`] call
+    /// site.
+    pub fn build(self) -> Arc<FabricTargetResolver> {
+        let uri = self
+            .uri
+            .expect("FabricTargetResolverBuilder::service_uri is required");
+        let selector = self
+            .selector
+            .expect("FabricTargetResolverBuilder::target_selector is required");
+        let retryer = self
+            .retryer
+            .unwrap_or_else(|| OperationRetryer::builder().build());
+        Arc::new(FabricTargetResolver {
+            inner: ServicePartitionResolver::new(self.fc, retryer),
+            uri,
+            key: self.key,
+            timeout: self.timeout,
+            selector,
+            cached: ArcSwapOption::empty(),
+        })
+    }
+}

--- a/crates/libs/util/src/tonic/naming/default.rs
+++ b/crates/libs/util/src/tonic/naming/default.rs
@@ -45,20 +45,32 @@ impl TargetResolver for FabricTargetResolver {
                 .resolve(&self.uri, &self.key, prev.as_deref(), self.timeout, None)
                 .await
                 .map_err(|e| Box::new(e) as BoxError)?;
-            // Same-version reply: keep cached Arc identity (avoids
-            // pointer churn under steady-state always-complain).
+            // Reconcile the new reply against the cache. The
+            // cache only advances when SF returns a strictly
+            // *newer* RSP — never moves backward to an older
+            // version — so a stale or out-of-order reply doesn't
+            // poison subsequent dials.
+            //
+            // `ResolvedServicePartition: PartialOrd` per
+            // `svc_mgmt_client.rs`: `a > b` ⇔ `a` is newer;
+            // `partial_cmp == None` ⇔ different service /
+            // partition (treat as a hard cache reset).
             let rsp = match prev.as_deref() {
-                Some(p) => match p.compare_version(&new_rsp) {
-                    Ok(0) => prev.unwrap(),
-                    Ok(_) => {
+                Some(p) => match p.partial_cmp(&new_rsp) {
+                    Some(std::cmp::Ordering::Less) => {
+                        // prev < new_rsp → new_rsp is newer → advance.
                         let arc = Arc::new(new_rsp);
                         self.cached.store(Some(arc.clone()));
                         arc
                     }
-                    // compare_version returns Err only when the two
-                    // RSPs refer to different services / partitions.
-                    // Treat as "newer view," replace cache.
-                    Err(_) => {
+                    Some(_) => {
+                        // Equal or prev > new_rsp: keep cached
+                        // Arc identity, drop new_rsp.
+                        prev.unwrap()
+                    }
+                    None => {
+                        // Different service / partition: hard
+                        // reset.
                         let arc = Arc::new(new_rsp);
                         self.cached.store(Some(arc.clone()));
                         arc

--- a/crates/libs/util/src/tonic/naming/mod.rs
+++ b/crates/libs/util/src/tonic/naming/mod.rs
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Naming layer: turn an SF (or any other) name into a `DialTarget`.
+//!
+//! The trait is transport-agnostic: it returns a `DialTarget`
+//! (host + port) and pulls in nothing from tonic / hyper / tower.
+
+mod default;
+mod resolver;
+mod selector;
+
+pub use self::default::{FabricTargetResolver, FabricTargetResolverBuilder};
+pub use self::resolver::{BoxError, TargetResolver};
+pub use self::selector::{DialTarget, SelectError, TargetSelector};

--- a/crates/libs/util/src/tonic/naming/resolver.rs
+++ b/crates/libs/util/src/tonic/naming/resolver.rs
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use futures::future::BoxFuture;
+
+use super::selector::DialTarget;
+
+/// Common boxed error alias used throughout the `tonic` module.
+/// Matches what `tower::Service` impls (including hyper) use, so
+/// it propagates without wrapping.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// SF naming abstraction used by [`super::super::TargetConnector`].
+/// Each call returns the concrete [`DialTarget`] the connector
+/// should dial next.
+///
+/// The trait is intentionally minimal: one method, no arguments,
+/// no associated types. The implementation owns everything between
+/// "what does SF currently say about this partition?" and "where
+/// do I actually open a TCP connection?":
+/// - which Fabric URI to look up,
+/// - which partition key,
+/// - the `previousResult` cache and always-complain rule,
+/// - the per-resolve timeout / cancellation policy,
+/// - the role-pick + address-parse selector that turns an RSP
+///   into a `DialTarget`.
+///
+/// Returning `DialTarget` (not `Arc<View>`) keeps the connector
+/// non-generic. Custom resolvers that want different selection
+/// logic implement the trait directly.
+///
+/// **v1 has no cancellation token on `resolve()`.** Per-call
+/// cancellation works implicitly via future-drop.
+pub trait TargetResolver: Send + Sync + 'static {
+    fn resolve(&self) -> BoxFuture<'_, Result<DialTarget, BoxError>>;
+}

--- a/crates/libs/util/src/tonic/naming/selector.rs
+++ b/crates/libs/util/src/tonic/naming/selector.rs
@@ -1,0 +1,65 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::sync::Arc;
+
+use mssf_core::client::svc_mgmt_client::ResolvedServicePartition;
+
+use super::resolver::BoxError;
+
+/// User-supplied function that picks one connectable target from a
+/// `ResolvedServicePartition`. Combines two concerns: choosing
+/// *which* replica to dial (by role / partition key / round-robin
+/// / ...) and parsing the chosen replica's `address` (which is a
+/// user-defined SF endpoint string — not necessarily a URL) into
+/// a host:port pair.
+///
+/// `TargetSelector` is the value type accepted by
+/// [`super::default::FabricTargetResolverBuilder::target_selector`].
+/// Custom [`super::resolver::TargetResolver`] impls don't have to
+/// use this type — they embed whatever closure shape they like
+/// internally and just return a `DialTarget` from `resolve()`.
+pub type TargetSelector =
+    Arc<dyn Fn(&ResolvedServicePartition) -> Result<DialTarget, SelectError> + Send + Sync>;
+
+/// Returns a concrete dial target. `host` is what we pass to DNS
+/// or parse as an `IpAddr`; `port` is the TCP port. v1 supports
+/// TCP destinations only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DialTarget {
+    pub host: String,
+    pub port: u16,
+}
+
+/// Error returned by a [`TargetSelector`] closure.
+#[derive(Debug)]
+pub enum SelectError {
+    /// No endpoint in the current partition matches. The dial
+    /// fails with this surfaced as a `BoxError`. The caller's
+    /// outer retry loop is responsible for waiting and retrying.
+    NoMatch,
+    /// Hard error — covers both "selector explicitly rejected"
+    /// and "address couldn't be parsed." Won't be fixed by
+    /// re-resolving.
+    Fatal(BoxError),
+}
+
+impl std::fmt::Display for SelectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SelectError::NoMatch => write!(f, "no matching endpoint"),
+            SelectError::Fatal(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for SelectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SelectError::NoMatch => None,
+            SelectError::Fatal(e) => Some(&**e),
+        }
+    }
+}

--- a/crates/libs/util/tests/tonic_middleware.rs
+++ b/crates/libs/util/tests/tonic_middleware.rs
@@ -1,0 +1,234 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! End-to-end tests for [`ResolveStatusMiddleware`] using a mock
+//! inner `Service` that returns scripted bodies with trailers.
+
+#![cfg(feature = "tonic")]
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use http::{HeaderMap, HeaderName, HeaderValue};
+use http_body::{Body as _, Frame};
+use tonic::body::Body;
+use tower::Service;
+
+use mssf_util::tonic::ResolveStatusMiddleware;
+
+/// Counts how many times `()` is called.
+#[derive(Clone, Default)]
+struct RebuildCounter(Arc<AtomicUsize>);
+impl RebuildCounter {
+    fn count(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+    fn fire(&self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+/// Body that yields one trailers frame (or no trailer at all).
+struct ScriptedBody {
+    trailers: Option<HeaderMap>,
+    done: bool,
+}
+
+impl ScriptedBody {
+    fn with_trailer(name: &HeaderName, value: &str) -> Self {
+        let mut map = HeaderMap::new();
+        map.insert(name.clone(), HeaderValue::from_str(value).unwrap());
+        Self {
+            trailers: Some(map),
+            done: false,
+        }
+    }
+    fn no_trailer() -> Self {
+        Self {
+            trailers: None,
+            done: false,
+        }
+    }
+}
+
+impl http_body::Body for ScriptedBody {
+    type Data = Bytes;
+    type Error = tonic::Status;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+        self.done = true;
+        match self.trailers.take() {
+            Some(map) => Poll::Ready(Some(Ok(Frame::trailers(map)))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+/// `Service` that returns scripted responses in order.
+#[derive(Clone)]
+struct ScriptedService {
+    queue: Arc<std::sync::Mutex<std::collections::VecDeque<Body>>>,
+}
+
+impl ScriptedService {
+    fn new<I: IntoIterator<Item = Body>>(items: I) -> Self {
+        Self {
+            queue: Arc::new(std::sync::Mutex::new(items.into_iter().collect())),
+        }
+    }
+}
+
+impl Service<http::Request<Body>> for ScriptedService {
+    type Response = http::Response<Body>;
+    type Error = tonic::transport::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: http::Request<Body>) -> Self::Future {
+        let body = self
+            .queue
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("script exhausted");
+        Box::pin(async move { Ok(http::Response::builder().body(body).unwrap()) })
+    }
+}
+
+/// Drive the middleware once and return after the body is fully
+/// consumed (so the trailer observer has fired).
+async fn dispatch(svc: &mut ResolveStatusMiddleware<ScriptedService>) {
+    use std::future::poll_fn;
+    let req = http::Request::builder().body(Body::empty()).unwrap();
+    let resp = svc.call(req).await.expect("ok");
+    // Drain the body so the wrapper observes trailers / EOS.
+    let mut body = resp.into_body();
+    loop {
+        let frame = poll_fn(|cx| Pin::new(&mut body).poll_frame(cx)).await;
+        if frame.is_none() {
+            break;
+        }
+    }
+}
+
+fn header() -> HeaderName {
+    HeaderName::from_static("mssf-status")
+}
+
+fn build(
+    svc: ScriptedService,
+    counter: RebuildCounter,
+) -> ResolveStatusMiddleware<ScriptedService> {
+    ResolveStatusMiddleware::new(svc, header(), move || counter.fire())
+}
+
+#[tokio::test]
+async fn trailer_on_empty_body_triggers_one_rebuild() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::new(vec![Body::new(ScriptedBody::with_trailer(
+        &header(),
+        "not-primary",
+    ))]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 1);
+}
+
+#[tokio::test]
+async fn same_value_dedups_to_one_rebuild() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::new(vec![
+        Body::new(ScriptedBody::with_trailer(&header(), "v")),
+        Body::new(ScriptedBody::with_trailer(&header(), "v")),
+        Body::new(ScriptedBody::with_trailer(&header(), "v")),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    for _ in 0..3 {
+        dispatch(&mut mw).await;
+    }
+    assert_eq!(counter.count(), 1);
+}
+
+#[tokio::test]
+async fn distinct_values_each_rebuild() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::new(vec![
+        Body::new(ScriptedBody::with_trailer(&header(), "a")),
+        Body::new(ScriptedBody::with_trailer(&header(), "b")),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 2);
+}
+
+#[tokio::test]
+async fn no_trailer_resets_dedup_state() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::new(vec![
+        Body::new(ScriptedBody::with_trailer(&header(), "v")),
+        Body::new(ScriptedBody::no_trailer()),
+        Body::new(ScriptedBody::with_trailer(&header(), "v")),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    // First v -> rebuild #1; no-trailer -> reset; v again -> rebuild #2.
+    assert_eq!(counter.count(), 2);
+}
+
+#[tokio::test]
+async fn empty_value_always_rebuilds_without_poisoning_last_seen() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::new(vec![
+        Body::new(ScriptedBody::with_trailer(&header(), "v")), // rebuild #1
+        Body::new(ScriptedBody::with_trailer(&header(), "")),  // rebuild #2
+        Body::new(ScriptedBody::with_trailer(&header(), "v")), // dedup vs prev v -> no rebuild
+    ]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 2);
+}
+
+#[tokio::test]
+async fn empty_value_twice_rebuilds_twice() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::new(vec![
+        Body::new(ScriptedBody::with_trailer(&header(), "")),
+        Body::new(ScriptedBody::with_trailer(&header(), "")),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 2);
+}
+
+#[tokio::test]
+async fn unrelated_header_does_not_trigger_rebuild() {
+    let counter = RebuildCounter::default();
+    let other = HeaderName::from_static("x-other");
+    let svc = ScriptedService::new(vec![Body::new(ScriptedBody::with_trailer(
+        &other, "anything",
+    ))]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 0);
+}

--- a/crates/libs/util/tests/tonic_middleware.rs
+++ b/crates/libs/util/tests/tonic_middleware.rs
@@ -232,3 +232,36 @@ async fn unrelated_header_does_not_trigger_rebuild() {
     dispatch(&mut mw).await;
     assert_eq!(counter.count(), 0);
 }
+
+/// Concurrent dispatch with the same trailer value must collapse to
+/// exactly one rebuild. Regression test for a race where each
+/// observer of the same value would independently classify
+/// `last_seen=None`, store the value, and call `rebuild()`,
+/// producing N rebuilds instead of 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_same_value_dedups() {
+    use mssf_util::tonic::ResolveStatusMiddleware;
+
+    const N: usize = 32;
+    let counter = RebuildCounter::default();
+    let svc =
+        ScriptedService::new((0..N).map(|_| Body::new(ScriptedBody::with_trailer(&header(), "v"))));
+    // Construct a single middleware shared across N concurrent
+    // dispatches. Cloning is cheap (Arc-shared `last_seen` +
+    // `rebuild` handle); each clone holds its own `inner`
+    // service-clone re-arming pattern.
+    let mw: ResolveStatusMiddleware<ScriptedService> = build(svc, counter.clone());
+    let mut handles = Vec::with_capacity(N);
+    for _ in 0..N {
+        let mut mw = mw.clone();
+        handles.push(tokio::spawn(async move { dispatch(&mut mw).await }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+    assert_eq!(
+        counter.count(),
+        1,
+        "same-value dedup must collapse N concurrent observers to 1 rebuild"
+    );
+}

--- a/docs/design/TonicConnectorDesign.md
+++ b/docs/design/TonicConnectorDesign.md
@@ -44,9 +44,11 @@ resolve API.
    secondaries, etc.). No fixed
    [`ServiceEndpointRole`](../../crates/libs/core/src/client/svc_mgmt_client.rs#L425)
    filter is baked in.
-5. Compose cleanly with TLS via
-   [tonic-tls](https://github.com/youyuanwu/tonic-tls). See
-   [Composition with tonic-tls](#composition-with-tonic-tls).
+5. Compose cleanly with TLS — deferred. v1 ships plain TCP
+   only. The TLS extension requires generalizing
+   [`SwapChannel`](#public-surface) over its inner IO type;
+   today the type is fixed at `TokioIo<TcpStream>`. See
+   [TLS (deferred)](#tls-deferred) and Future Work.
 
 ## Non-Goals
 
@@ -56,8 +58,8 @@ resolve API.
 - **Killing in-flight requests from the client side.** Once
   dispatched, a request's lifecycle belongs to the server.
 - Cross-partition routing.
-- Bundled TLS — composed via tonic-tls, not built into
-  `TargetConnector`.
+- **TLS in v1.** Plain TCP only. See
+  [TLS (deferred)](#tls-deferred).
 
 ## Where this lives
 
@@ -77,12 +79,11 @@ tonic = [
 ]
 ```
 
-The optional sub-feature `tonic-tls` for the `tonic_tls::Transport`
-impl on `TargetConnector` is **deferred** — the recipe in
-[Composition with tonic-tls](#composition-with-tonic-tls) works
-today because `TargetConnector` already implements
-`Service<http::Uri>`; the `tonic_tls::Transport` adapter is a
-small follow-on.
+**TLS is not yet supported.** v1's `SwapChannel` fixes the
+connector IO type at `TokioIo<TcpStream>`, which is incompatible
+with TLS connectors that wrap the stream as
+`TokioIo<TlsStream<...>>`. Adding TLS requires generalizing the
+IO bound — see [TLS (deferred)](#tls-deferred) and Future work.
 
 ### File layout
 
@@ -141,10 +142,6 @@ see the signals it needs to act on:
 +--------------------------+------------------------+
                            v
 +---------------------------------------------------+
-|     (optional) tonic-tls TlsConnector wrapper      |
-+--------------------------+------------------------+
-                           v
-+---------------------------------------------------+
 |                  TargetConnector                   |
 |  - Service<Uri>: ask resolver, TCP dial            |
 |  - holds Arc<dyn TargetResolver>                   |
@@ -167,12 +164,10 @@ Each failure mode is naturally observable at exactly one layer.
 | TCP RST / `GOAWAY` / hyper IO error | hyper pool eviction | next dial → `TargetConnector` re-resolves; failing call surfaces to caller's outer retry |
 | Trailer on response (success or error) | `Frame::trailers()` above the channel | `ResolveStatusMiddleware` calls `swap_channel.rebuild()`; response delivered unchanged |
 | Plain `Code::Unavailable` (no trailer) | gRPC response | propagated unchanged; **no rebuild** (could be a downstream flake, not a role change) |
-| TLS handshake failure | `Service<Uri>` error from tonic-tls | propagated as transport error |
 
 Cross-layer coupling is exactly one `Arc<SwapChannel>` clone held by
 the middleware so it can call `rebuild()`. The connector knows
-nothing about channels; the channel knows nothing about middleware;
-the TLS layer knows nothing about any of them.
+nothing about channels; the channel knows nothing about middleware.
 
 ### Why each layer is the way it is
 
@@ -197,10 +192,10 @@ the TLS layer knows nothing about any of them.
   Channel via `Endpoint::connect_with_connector_lazy` and storing
   it via `ArcSwap`. In-flight requests keep their own Channel
   clones and run to completion.
-- **Connector below tonic-tls.** tonic-tls's `TlsConnector::new`
-  wraps an inner `Transport` whose input is a `Uri`; SF resolution
-  must happen inside that `Transport`. So `TargetConnector` is the
-  inner; the TLS connector wraps it.
+
+(A planned third design point — "connector lives below the TLS
+wrapper" — is deferred along with TLS itself; see
+[TLS (deferred)](#tls-deferred).)
 
 ### Why not `tower::reconnect::Reconnect`?
 
@@ -300,8 +295,8 @@ let mut client = GreeterClient::new(channel);
 
 ### Manual composition
 
-When the convenience builder isn't enough (custom layer ordering,
-manual TLS):
+When the convenience builder isn't enough (custom layer
+ordering, custom endpoint template):
 
 ```rust
 let connector = TargetConnectorBuilder::new().resolver(resolver).build();
@@ -324,8 +319,9 @@ let channel = ResolveStatusMiddleware::new(
 
 `fabric.invalid` uses the [reserved `.invalid`
 TLD](https://datatracker.ietf.org/doc/html/rfc2606#section-2) so a
-misconfigured TLS connector that accidentally resolves the
-placeholder fails loudly with NXDOMAIN.
+misconfigured layer that accidentally resolves the placeholder
+authority fails loudly with NXDOMAIN rather than escaping to the
+public internet.
 
 ### Writing a selector
 
@@ -449,7 +445,7 @@ server that keeps a stream open across a role change is declaring
 ## Rebuild dedup
 
 The dedup state machine has one piece of state — `last_seen:
-ArcSwapOption<String>` — and four transitions. Implemented in
+Mutex<Option<String>>` — and four transitions. Implemented in
 [`middleware.rs::classify`](../../crates/libs/util/src/tonic/middleware.rs)
 and exhaustively unit-tested.
 
@@ -464,6 +460,15 @@ last_seen = Some(_)         (no trailer)                     last_seen = None; n
 
 independent (any state):    mssf-status: (empty value)       rebuild; last_seen UNCHANGED
 ```
+
+**Concurrency.** The load → classify → store sequence runs under
+a `std::sync::Mutex`, so concurrent in-flight RPCs that complete
+with the **same** trailer value collapse to one `rebuild()`
+call. Distinct values still produce one rebuild each. The mutex
+is released **before** invoking the rebuild closure so back-to-back
+`connect_with_connector_lazy` calls don't serialize. The critical
+section is a string comparison + an `Option` write (microseconds);
+contention is bounded by concurrent trailer arrivals.
 
 Why each transition matters:
 
@@ -538,33 +543,60 @@ missed/out-of-order notifications, and a small steady-state
 latency win on a *failover-recovery* path don't justify the
 complexity. See [Future work](#future-work) for the opt-in mode.
 
-## Composition with tonic-tls
+## TLS (deferred)
 
-`TargetConnector` is intentionally plain TCP. TLS is supplied by
-composition: tonic-tls's `TlsConnector::new(transport, ssl, sni)`
-wraps any inner `tonic_tls::Transport` and produces a
-`Service<Uri>` that performs TLS on top.
+v1 ships **plain TCP only**. The `TargetChannelBuilder` has no
+`with_tls(...)` setter and `SwapChannel` fixes its connector slot
+at `BoxCloneSyncService<Uri, TokioIo<TcpStream>, BoxError>`,
+which is incompatible with any TLS wrapper that returns
+`TokioIo<TlsStream<...>>`.
 
-To plug `TargetConnector` straight in, it needs to implement
-`tonic_tls::Transport`. **v1 does not ship that adapter** — the
-`tonic-tls` cargo sub-feature mentioned in [Where this
-lives](#where-this-lives) is a future addition. Until then, users
-who want TLS can write a tiny `tonic_tls::Transport` shim that
-calls a `TargetConnector` and unwraps the `TokioIo` to the bare
-`TcpStream`, or use the manual composition route via
-`SwapChannel::with_connector` with a `Service<Uri>` they assemble
-themselves.
+This was a deliberate scope cut once an earlier `with_tls` API
+was found to be unusable: the bound matched only plain TCP, so
+no real TLS connector — `tonic_tls::*::TlsConnector<...>`,
+rustls, openssl, native-tls, schannel — actually fit. Shipping
+an API whose type bounds reject every realistic implementation
+is worse than not shipping the API.
 
-When `SwapChannel::rebuild()` runs over a TLS-wrapped connector:
-new `tonic::Channel` → empty pool → next request triggers
-`tls_conn.call(uri)` → `target_conn.call(uri)` (fresh TCP via SF
-resolve) → TLS handshake on the new TCP stream → HTTP/2 connection.
-The old TLS connections close along with the rest of the old
-hyper pool.
+### What enabling TLS will require
 
-SNI is taken as an explicit parameter by tonic-tls; the connector
-does not auto-derive it from the resolved endpoint. SF endpoints
-are arbitrary user-defined strings.
+1. **Generalize `SwapChannel`'s IO bound.** Replace the fixed
+   `TokioIo<TcpStream>` with whatever
+   [`Endpoint::connect_with_connector_lazy`](https://docs.rs/tonic/0.14/tonic/transport/struct.Endpoint.html#method.connect_with_connector_lazy)
+   actually requires (`hyper::rt::Read + hyper::rt::Write +
+   Send + Unpin + 'static`). Two implementation shapes:
+   - **Erase further:** store the IO behind a
+     `Box<dyn AsyncRead + AsyncWrite + ...>` so `SwapChannel`
+     stays non-generic. Adds a vtable hop per byte; probably
+     fine.
+   - **Re-generic:** add a type parameter `<S, IO>` to
+     `SwapChannel`. Loses the type-erasure benefit; users have
+     to thread a connector type parameter through their
+     wiring.
+2. **Add a TLS composition seam.** Either ship a
+   `tonic-tls` cargo sub-feature with a
+   [`tonic_tls::Transport`](https://github.com/youyuanwu/tonic-tls)
+   impl on `TargetConnector` (so `TlsConnector::new(target,
+   ssl, sni)` slots straight in), or document the manual
+   composition pattern with the generalized `SwapChannel`.
+3. **Decide the SNI policy.** tonic-tls takes SNI as an
+   explicit parameter; SF endpoint addresses are arbitrary
+   user-defined strings, so we can't auto-derive SNI from the
+   resolved endpoint. v1's selector returns only host+port;
+   passing SNI through requires either widening `DialTarget`
+   (breaking change for existing selectors) or making SNI a
+   builder-time configuration on the TLS layer.
+
+None of the above is hard — the trailer + rebuild + dedup
+plumbing is already TLS-agnostic. It just hasn't been done yet,
+and was scoped out so v1 ships with an honest API surface.
+
+When `SwapChannel::rebuild()` eventually runs over a
+TLS-wrapped connector, it composes naturally: new `tonic::Channel`
+→ empty pool → next request triggers `tls_conn.call(uri)` →
+`target_conn.call(uri)` (fresh TCP via SF resolve) → TLS
+handshake on the new TCP stream → HTTP/2 connection. Old TLS
+connections close along with the rest of the old hyper pool.
 
 ## Refresh path
 
@@ -645,7 +677,9 @@ invalidation path that SF naming exposes via the trailer.
   *written* on a successful resolve.
 - `SwapChannel::rebuild()` is non-blocking and always produces a
   new Channel. Storm dedup is the middleware's job; concurrent
-  same-value trailer arrivals collapse there.
+  same-value trailer arrivals serialize through the middleware's
+  `Mutex<Option<String>>` (see [Rebuild dedup](#rebuild-dedup))
+  and collapse to a single `rebuild()` call.
 - Concurrent failing requests on one Channel are deduplicated by
   hyper's pool checkout (one `MakeConnection` per pool key).
 - `TargetResolver::resolve()` takes no arguments in v1. The
@@ -660,9 +694,8 @@ A few small differences between this doc and what shipped:
 - **Type erasure uses `BoxCloneSyncService`, not `BoxCloneService`.**
   `SwapChannel` is shared via `Arc<Inner>` between the user-facing
   service and the rebuild closure captured by the middleware, so
-  the inner connector slot must be `Sync`. tonic-tls's
-  `TlsConnector` is already `Sync`; user-supplied connectors must
-  be too.
+  the inner connector slot must be `Sync`. `TargetConnector`
+  satisfies this; any user-supplied connector must too.
 - **`ResolveStatusMiddleware::new` is the only constructor.** The
   earlier draft showed `layer` / `layer_with_rebuild`
   factory-style `tower::Layer` helpers; the impl ships only
@@ -756,10 +789,15 @@ Genuinely open:
 
 ## Future work
 
-- **`tonic-tls` adapter.** Ship the `tonic_tls::Transport` impl on
-  `TargetConnector` behind a `tonic-tls` cargo sub-feature, so the
-  recipe in [Composition with tonic-tls](#composition-with-tonic-tls)
-  becomes a one-liner.
+- **TLS support.** See [TLS (deferred)](#tls-deferred). Requires
+  generalizing `SwapChannel`'s IO bound, plus either a
+  `tonic_tls::Transport` adapter on `TargetConnector` (behind a
+  `tonic-tls` cargo sub-feature) or a documented manual recipe.
+  An earlier `TargetChannelBuilder::with_tls` API and the
+  matching `SwapChannel::with_connector` TLS framing were
+  removed before the v1 commit because their type bounds (fixed
+  at `TokioIo<TcpStream>`) rejected every realistic TLS
+  connector.
 - **Live-cluster failover sample / test.** See
   [Testing](#testing).
 - **Trailer-aware caller retry recipe.** A worked
@@ -797,4 +835,3 @@ Genuinely open:
 - [`crates/samples/reflection/src/test.rs`](../../crates/samples/reflection/src/test.rs) — current tonic usage and manual failover handling.
 - [`crates/samples/reflection/src/test2.rs`](../../crates/samples/reflection/src/test2.rs) — `resolve_until_change(.., complain=true)` (prior art).
 - [`ResolveServicePartitionAsync` remarks](https://learn.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.servicemanagementclient.resolveservicepartitionasync) — complaint protocol semantics.
-- [tonic-tls](https://github.com/youyuanwu/tonic-tls) — `Service<Uri>`-based TLS connectors for tonic.

--- a/docs/design/TonicConnectorDesign.md
+++ b/docs/design/TonicConnectorDesign.md
@@ -1,0 +1,800 @@
+# Service Fabric Tonic Connector — Design
+
+Status: Implemented (v1). See [`mssf_util::tonic`](../../crates/libs/util/src/tonic).
+
+Owners: mssf-rs maintainers
+
+## Background
+
+A Service Fabric (SF) stateful service runs as a replica set: one
+primary and one or more secondaries / auxiliaries. Read/write
+traffic is normally routed to the primary, and the primary can move
+between nodes at any time (failover, rebalancing, upgrade). After a
+move the gRPC server endpoint a client previously connected to may
+stop accepting new requests *or* may keep accepting them as a
+secondary that no longer satisfies the request.
+
+Today, callers route gRPC through plain
+[`tonic::transport::Channel`](https://docs.rs/tonic/0.14/tonic/transport/struct.Channel.html)
+and fall back to manually re-resolving via
+[`ServicePartitionResolver::resolve`](../../crates/libs/util/src/resolve.rs#L42)
+in a polling loop on failure (see
+[`crates/samples/reflection/src/test.rs`](../../crates/samples/reflection/src/test.rs)).
+
+This module ships a reusable building block: a tonic-compatible
+channel that automatically re-resolves the current SF endpoint,
+reconnects after failover, and reacts to a server-signalled
+"reconnect for next time" trailer — driven by SF's complaint-based
+resolve API.
+
+## Goals
+
+1. Ship a tonic integration so a user can compose a failover-aware
+   `tonic::Channel` from a `FabricClient` and a small selector
+   closure, then hand it to a generated tonic client.
+2. Reuse the existing
+   [`ServicePartitionResolver`](../../crates/libs/util/src/resolve.rs#L21)
+   so refreshes go through the standard retry / cancellation path.
+   v1 uses **complaint-based resolve only** — see
+   [Resolve strategy](#resolve-strategy).
+3. Keep the public API surface small and feature-gated. tonic /
+   hyper / tower do not become required deps of `mssf-util`.
+4. Support arbitrary user-defined endpoint selection (role,
+   partition key, sticky-by-replica-id, round-robin across
+   secondaries, etc.). No fixed
+   [`ServiceEndpointRole`](../../crates/libs/core/src/client/svc_mgmt_client.rs#L425)
+   filter is baked in.
+5. Compose cleanly with TLS via
+   [tonic-tls](https://github.com/youyuanwu/tonic-tls). See
+   [Composition with tonic-tls](#composition-with-tonic-tls).
+
+## Non-Goals
+
+- A full replacement for tonic's load balancing / service discovery.
+- gRPC-level retry semantics (idempotency, deadlines, hedging).
+  **The client stack does not auto-retry**, on any signal.
+- **Killing in-flight requests from the client side.** Once
+  dispatched, a request's lifecycle belongs to the server.
+- Cross-partition routing.
+- Bundled TLS — composed via tonic-tls, not built into
+  `TargetConnector`.
+
+## Where this lives
+
+All code ships inside `mssf-util` under
+[`mssf_util::tonic`](../../crates/libs/util/src/tonic), gated by the
+`tonic` cargo feature. No new crate.
+
+`Cargo.toml` adds:
+
+```toml
+[features]
+tonic = [
+    "tokio",
+    "dep:tonic", "dep:tower", "dep:hyper",
+    "dep:hyper-util", "dep:http", "dep:http-body",
+    "dep:arc-swap", "dep:futures", "dep:bytes",
+]
+```
+
+The optional sub-feature `tonic-tls` for the `tonic_tls::Transport`
+impl on `TargetConnector` is **deferred** — the recipe in
+[Composition with tonic-tls](#composition-with-tonic-tls) works
+today because `TargetConnector` already implements
+`Service<http::Uri>`; the `tonic_tls::Transport` adapter is a
+small follow-on.
+
+### File layout
+
+```
+crates/libs/util/src/tonic/
+├── mod.rs                          flat `pub use` re-exports
+├── naming/                         naming layer (transport-agnostic)
+│   ├── resolver.rs                 TargetResolver trait + BoxError
+│   ├── selector.rs                 TargetSelector + DialTarget + SelectError
+│   └── default.rs                  FabricTargetResolver(+Builder)
+├── connector/                      Service<Uri> connector
+│   └── service.rs                  TargetConnector(+Builder)
+├── channel/                        channel composition
+│   ├── swap.rs                     SwapChannel
+│   └── builder.rs                  TargetChannel + TargetChannelBuilder
+└── middleware.rs                   ResolveStatusMiddleware + dedup state machine
+```
+
+The naming layer (`naming/`) is technically transport-agnostic and
+could live unconditionally in `mssf_util::naming`. v1 keeps it nested
+under `tonic` because `TargetConnector` is its only consumer; hoisting
+it later is a `mv` plus internal `use`-path tweak that doesn't break
+the public `mssf_util::tonic::*` paths.
+
+## Architecture
+
+Four composable layers, each at the level where it can naturally
+see the signals it needs to act on:
+
+```
++---------------------------------------------------+
+|              user gRPC client                      |
+|             (e.g. GreeterClient)                   |
++--------------------------+------------------------+
+                           v
++---------------------------------------------------+
+|        ResolveStatusMiddleware<SwapChannel>        |
+|  - inspects gRPC trailers via http_body::Frame     |
+|  - on trailer header (default `mssf-status`):      |
+|      swap_channel.rebuild()  (non-blocking)        |
+|  - propagates response unchanged (no retry, no kill)|
+|  - Stateful dedup: see `Rebuild dedup`              |
++--------------------------+------------------------+
+                           v
++---------------------------------------------------+
+|                   SwapChannel                      |
+|  - holds ArcSwap<tonic::Channel>                   |
+|  - holds BoxCloneSyncService<Uri, ...> connector   |
+|  - rebuild(): connect_with_connector_lazy + store  |
+|  - in-flight requests stay on old Channel          |
++--------------------------+------------------------+
+                           v
++---------------------------------------------------+
+|   tonic::Channel (lazy; rebuilt per generation)    |
+|  - hyper Client + connection pool                  |
++--------------------------+------------------------+
+                           v
++---------------------------------------------------+
+|     (optional) tonic-tls TlsConnector wrapper      |
++--------------------------+------------------------+
+                           v
++---------------------------------------------------+
+|                  TargetConnector                   |
+|  - Service<Uri>: ask resolver, TCP dial            |
+|  - holds Arc<dyn TargetResolver>                   |
++--------------------------+------------------------+
+                           v
++---------------------------------------------------+
+|       TargetResolver (e.g. FabricTargetResolver)   |
+|  - owns previousResult cache, selector, timeout    |
+|  - resolve(): complaint resolve + run selector     |
+|              -> DialTarget                         |
++---------------------------------------------------+
+```
+
+### Why four layers, not one
+
+Each failure mode is naturally observable at exactly one layer.
+
+| Failure mode | Observable at | Action |
+|---|---|---|
+| TCP RST / `GOAWAY` / hyper IO error | hyper pool eviction | next dial → `TargetConnector` re-resolves; failing call surfaces to caller's outer retry |
+| Trailer on response (success or error) | `Frame::trailers()` above the channel | `ResolveStatusMiddleware` calls `swap_channel.rebuild()`; response delivered unchanged |
+| Plain `Code::Unavailable` (no trailer) | gRPC response | propagated unchanged; **no rebuild** (could be a downstream flake, not a role change) |
+| TLS handshake failure | `Service<Uri>` error from tonic-tls | propagated as transport error |
+
+Cross-layer coupling is exactly one `Arc<SwapChannel>` clone held by
+the middleware so it can call `rebuild()`. The connector knows
+nothing about channels; the channel knows nothing about middleware;
+the TLS layer knows nothing about any of them.
+
+### Why each layer is the way it is
+
+- **Middleware above the channel.** Hyper does not expose gRPC
+  trailers to the connector; trailers live on `http_body::Frame`,
+  visible only above `tonic::Channel`. `ResolveStatusMiddleware` is
+  the only layer that can observe "the call completed at HTTP/2 but
+  the application told us we're talking to the wrong replica."
+
+  **Layer-ordering constraint:** the middleware MUST sit directly
+  above `SwapChannel`, with no body-transforming layers between
+  them — anything that consumes the response body before trailers
+  are read will hide them.
+- **`SwapChannel` as its own layer.** The middleware sees the
+  trailer; the connector does the next dial. But hyper will keep
+  multiplexing new requests onto the existing alive HTTP/2
+  connection until something tears it down. With the no-kill
+  contract (server completes requests; client never yanks
+  in-flight) nothing tears it down on its own. The only way to make
+  hyper redial is to drop the Channel its pool lives inside.
+  `SwapChannel::rebuild()` does exactly that, building a new
+  Channel via `Endpoint::connect_with_connector_lazy` and storing
+  it via `ArcSwap`. In-flight requests keep their own Channel
+  clones and run to completion.
+- **Connector below tonic-tls.** tonic-tls's `TlsConnector::new`
+  wraps an inner `Transport` whose input is a `Uri`; SF resolution
+  must happen inside that `Transport`. So `TargetConnector` is the
+  inner; the TLS connector wraps it.
+
+### Why not `tower::reconnect::Reconnect`?
+
+`Reconnect` rebuilds when `inner.call(req)` returns `Err`. Our
+most important case is a trailer riding on a **successful**
+response, where `Reconnect` never trips. There is also no way to
+express "rebuild for next time without disrupting in-flight" — only
+"errored ⇒ rebuild." `SwapChannel::rebuild()` is decoupled from
+the response status: the middleware calls it after seeing the
+trailer regardless of Ok/Err, and the response goes back to the
+caller untouched.
+
+`Reconnect` does still have a legitimate role for **bootstrap
+fallback** — wrapping the whole `TargetChannel` so the *initial*
+build can self-heal if SF naming is offline at startup. Listed in
+[Future work](#future-work).
+
+### Properties of the composition
+
+- In-flight requests are never killed. `mssf-status` is a
+  forward-looking hint about the *next* request.
+- No background task. Refresh is synchronous in
+  `TargetConnector::call` when hyper asks for a new connection;
+  rebuild is synchronous (lazy allocation) in
+  `SwapChannel::rebuild()`.
+- Storm-safe dedup. The middleware tracks the last trailer value
+  and only triggers `rebuild()` when the value differs (with a
+  reset on no-trailer responses and an empty-value escape hatch).
+  See [Rebuild dedup](#rebuild-dedup).
+- The user-facing handle (`TargetChannel`) is stable across
+  rebuilds; the inner `tonic::Channel` is what gets swapped.
+- Zero datapath cost. No per-poll atomic checks, no `KillableIo`
+  wrapper. The IO path is plain `TokioIo<TcpStream>`.
+
+## Public surface
+
+All types are re-exported flat from
+[`mssf_util::tonic`](../../crates/libs/util/src/tonic/mod.rs):
+
+| Type | Source | Role |
+|---|---|---|
+| [`TargetResolver`](../../crates/libs/util/src/tonic/naming/resolver.rs) | trait | "what should I dial next?" |
+| `BoxError` | type alias | `Box<dyn Error + Send + Sync + 'static>` |
+| [`DialTarget`](../../crates/libs/util/src/tonic/naming/selector.rs) | struct | `host: String, port: u16` |
+| `TargetSelector` | type alias | `Arc<dyn Fn(&ResolvedServicePartition) -> Result<DialTarget, SelectError> + Send + Sync>` |
+| `SelectError` | enum | `NoMatch \| Fatal(BoxError)` |
+| [`FabricTargetResolver`](../../crates/libs/util/src/tonic/naming/default.rs) | struct | SF-naming impl of `TargetResolver` |
+| `FabricTargetResolverBuilder` | struct | Builder for above |
+| [`TargetConnector`](../../crates/libs/util/src/tonic/connector/service.rs) | struct | `Service<http::Uri>` doing resolve + TCP dial |
+| `TargetConnectorBuilder` | struct | Builder for above |
+| [`SwapChannel`](../../crates/libs/util/src/tonic/channel/swap.rs) | struct | `ArcSwap<tonic::Channel>` + rebuild |
+| [`TargetChannel`](../../crates/libs/util/src/tonic/channel/builder.rs) | type alias | `ResolveStatusMiddleware<SwapChannel>` |
+| `TargetChannelBuilder` | struct | Sugar that composes everything |
+| [`ResolveStatusMiddleware<S>`](../../crates/libs/util/src/tonic/middleware.rs) | struct | trailer-aware `Service` middleware |
+
+Signatures, `where`-bounds, and rustdoc live next to the code. This
+doc only spells out behavior the impl can't express on its own.
+
+## Usage
+
+### Convenience builder
+
+```rust
+use mssf_util::tonic::{
+    DialTarget, FabricTargetResolverBuilder, SelectError, TargetChannelBuilder,
+};
+use mssf_core::client::svc_mgmt_client::{
+    PartitionKeyType, ResolvedServicePartition, ServiceEndpointRole,
+};
+
+let resolver = FabricTargetResolverBuilder::new(fabric_client)
+    .service_uri("fabric:/MyApp/MyService")
+    .partition_key(PartitionKeyType::None)
+    .target_selector(|rsp: &ResolvedServicePartition| {
+        let ep = rsp.endpoints.iter()
+            .find(|e| e.role == ServiceEndpointRole::StatefulPrimary)
+            .ok_or(SelectError::NoMatch)?;
+        let url = url::Url::parse(&ep.address.to_string())
+            .map_err(|e| SelectError::Fatal(e.into()))?;
+        Ok(DialTarget {
+            host: url.host_str()
+                .ok_or_else(|| SelectError::Fatal("missing host".into()))?
+                .to_string(),
+            port: url.port()
+                .ok_or_else(|| SelectError::Fatal("missing port".into()))?,
+        })
+    })
+    .build();
+
+let channel = TargetChannelBuilder::new()
+    .resolver(resolver)
+    .trailer_header("mssf-status")  // SDK convention; required setter
+    .build();
+
+let mut client = GreeterClient::new(channel);
+```
+
+### Manual composition
+
+When the convenience builder isn't enough (custom layer ordering,
+manual TLS):
+
+```rust
+let connector = TargetConnectorBuilder::new().resolver(resolver).build();
+let endpoint = tonic::transport::Endpoint::from_static("http://fabric.invalid")
+    .keep_alive_while_idle(true);
+let swap = SwapChannel::new(endpoint, connector);
+let channel = ResolveStatusMiddleware::new(
+    swap.clone(),
+    http::HeaderName::from_static("mssf-status"),
+    move || swap.rebuild(),
+);
+```
+
+### Two URIs: SF Fabric URI vs. hyper placeholder URI
+
+| URI | Source | Format | Used for |
+|---|---|---|---|
+| **SF Fabric URI** | `FabricTargetResolverBuilder::service_uri("fabric:/...")` | `fabric:/App/Service` (`mssf_core::types::Uri`, **not** `http::Uri`) | Passed to `ServicePartitionResolver::resolve(name, ...)`. The connector never sees it. |
+| **Placeholder URI** | `Endpoint::from_static("http://fabric.invalid")` (defaulted by `TargetChannelBuilder`) | `http(s)://...` (must parse as `http::Uri`) | Hyper connection-pool key; passed to `TargetConnector::call(uri)` which **ignores it** |
+
+`fabric.invalid` uses the [reserved `.invalid`
+TLD](https://datatracker.ietf.org/doc/html/rfc2606#section-2) so a
+misconfigured TLS connector that accidentally resolves the
+placeholder fails loudly with NXDOMAIN.
+
+### Writing a selector
+
+There is no bundled `targets` module. SF endpoint addresses are
+user-defined strings (no canonical encoding the SDK can parse on
+the user's behalf), and role selection is a one-line closure.
+Each app writes its own
+`Fn(&ResolvedServicePartition) -> Result<DialTarget, SelectError>`.
+
+The selector receives the **whole** `ResolvedServicePartition`
+(not just `&[ResolvedServiceEndpoint]`) so it can also see
+`service_name`, `service_partition_kind`, and `partition_key_type`
+— enabling sticky-by-key selectors and selectors that parse extra
+info encoded in the address.
+
+`SelectError::NoMatch` is the soft failure case; the resolver
+surfaces it as a `BoxError` and the caller's outer retry loop
+decides what to do. `SelectError::Fatal` is non-retryable.
+
+## Server contract
+
+Failover detection has two cases. The v1 stack handles both, at
+different layers.
+
+### Case 1 — connection lost (transport-level)
+
+Symptoms: TCP RST / `ECONNREFUSED` / `ECONNRESET`, or HTTP/2
+`GOAWAY`. Hyper detects, evicts from the pool, and the next
+request misses → hyper invokes `TargetConnector` →
+`resolver.resolve()` returns the current `DialTarget` → fresh
+TCP connection.
+
+The middleware does **not** retry the failing call; it surfaces
+to the caller's outer retry, which knows the call's idempotency.
+
+This case occurs **only when the old primary's listener
+disappears** (process crash, role-handler closes the gRPC server,
+node loses connectivity). In normal stateful failover, the replica
+process keeps running — Case 2 is the common path.
+
+### Case 2 — server is alive but no longer the primary
+
+Normal SF failover for stateful services with persistent replicas:
+
+- The replica process keeps running through primary→secondary.
+- Its gRPC listener stays open across the role change.
+- Existing TCP / HTTP/2 connections stay alive.
+- The server **completes** the in-flight request normally —
+  success if the request was satisfiable as a secondary, or an
+  error otherwise — and attaches the trailer (default
+  `mssf-status`) to either to signal "the connection you used is
+  no longer the right one for next time."
+
+Without the middleware + `SwapChannel` pair, hyper would happily
+keep multiplexing new requests onto the same alive HTTP/2
+connection forever. With them, the middleware sees the trailer →
+calls `rebuild()` → next request hits a fresh Channel with an
+empty pool → connector dials the new primary.
+
+### Required server behavior
+
+A SF gRPC service that wants graceful client recovery MUST:
+
+1. Check its current
+   [`ServicePartitionAccessStatus`](../../crates/libs/core/src/runtime/stateful_types.rs)
+   (or equivalent role gate) on every request that requires the
+   chosen role.
+2. **Complete the request normally** — success if it can be
+   satisfied (e.g. read on a secondary if allowed), or an error
+   (typically `Code::Unavailable`) if it cannot.
+3. Attach the trailer (default `mssf-status`) to the response
+   (success or error) when the role state is no longer correct
+   for this client's intended target.
+
+The server does **not** need to close the connection or send
+`GOAWAY` on role change. Client-side invalidation is the
+middleware's job.
+
+### Trailer wire format
+
+The trailer header name is **configured at the middleware** (passed
+to `TargetChannelBuilder::trailer_header` or
+`ResolveStatusMiddleware::new`); the SDK convention is
+`mssf-status`. Values are ASCII opaque strings; the middleware
+does string equality only.
+
+The recommended SDK vocabulary:
+
+- `not-primary` — this replica is no longer the primary.
+- `not-readable` — reads are not granted in the current state.
+- `reconfiguration-pending` — partition is mid-reconfiguration.
+
+Any non-empty value is accepted; values are forward-compatible
+(unknown values are treated like documented ones). Servers wanting
+**per-event** distinction during multi-step failovers can append a
+monotonic suffix (e.g. `not-primary:42`); the dedup will then
+treat each as a distinct event.
+
+Three signals the middleware distinguishes:
+
+| Signal | Meaning |
+|---|---|
+| trailer absent | "I served you and I'm still the right one" — resets dedup |
+| trailer present, value V | "switch for next time" — rebuild if V differs from last seen |
+| trailer present, **empty value** | dumb-server escape hatch: always rebuild, don't store |
+
+If the trailer block contains multiple entries under the
+configured header, the first one wins. Server / client must agree
+on the header name; mismatch silently disables rebuild (no error,
+no log — the steady-state case is *supposed* to be silent).
+
+### Streaming RPCs
+
+The trailer arrives whenever the server **ends the stream**, not
+before — a direct consequence of the no-kill contract. If the
+server wants clients to switch mid-stream, it ends the stream with
+the trailer attached (typically with `Status::unavailable`). A
+server that keeps a stream open across a role change is declaring
+"this stream is still mine to serve." The client honors that.
+
+## Rebuild dedup
+
+The dedup state machine has one piece of state — `last_seen:
+ArcSwapOption<String>` — and four transitions. Implemented in
+[`middleware.rs::classify`](../../crates/libs/util/src/tonic/middleware.rs)
+and exhaustively unit-tested.
+
+```
+state                       observed                         action
+----------------------      -------------------------        --------------------------
+last_seen = None            (no trailer)                     no-op
+last_seen = None            mssf-status: V (non-empty)       last_seen = Some(V); rebuild
+last_seen = Some(V)         mssf-status: V (same value)      no-op
+last_seen = Some(V)         mssf-status: W (different)       last_seen = Some(W); rebuild
+last_seen = Some(_)         (no trailer)                     last_seen = None; no rebuild
+
+independent (any state):    mssf-status: (empty value)       rebuild; last_seen UNCHANGED
+```
+
+Why each transition matters:
+
+- **Different value rebuilds.** A new failover event is a new event.
+- **Same value is a no-op.** A server that conservatively attaches
+  `reconfiguration-pending` to *every* response during a reconfig
+  window (tens of seconds) produces one rebuild for the whole
+  window, not N.
+- **No trailer resets.** Without the reset, the middleware would be
+  stuck at `Some(V)` forever and miss the *next* event if it used
+  the same string V. With the reset, a successful no-trailer
+  response is a positive "still the right one" re-arming signal.
+- **Empty value rebuilds without storing.** The dumb-server
+  contract: a server too simple to track state attaches an empty
+  trailer to any response that should rebuild; every empty trailer
+  rebuilds unconditionally. We deliberately don't store
+  `Some("")` — that would defeat the contract by deduping
+  subsequent empty trailers.
+
+### Out-of-order trailers
+
+Multiple in-flight RPCs may complete in any order. A stale trailer
+arriving after a newer one will trigger one redundant rebuild
+(the new Channel converged on the right target already, but we
+rebuild it again then immediately re-converge on the same target).
+Cost is bounded by in-flight count; harmless to correctness.
+Servers concerned about this can include a monotonic token so the
+dedup distinguishes stale from fresh.
+
+## Caller-side retry
+
+**The v1 stack does not auto-retry on any signal.** Every
+response, success or error, is delivered to the caller unchanged.
+The middleware's only effect is to fire `swap_channel.rebuild()`
+for *future* requests when it sees the trailer.
+
+This is deliberate: we cannot tell at the middleware layer whether
+a mid-stream RST means the request reached a handler, and silently
+retrying a non-idempotent call that already mutated state is
+exactly the bug `tower::retry` plus caller-owned idempotency rules
+are designed to avoid. Idempotency is the caller's policy.
+
+For all error cases the caller needs an outer retry loop:
+
+1. A `tower::retry::Retry` layer wrapping `TargetChannel`,
+   configured with the caller's idempotency rules.
+2. The existing
+   [`OperationRetryer`](../../crates/libs/util/src/retry.rs)
+   wrapped around individual gRPC calls.
+3. Application-level retry at the call site for non-idempotent
+   operations.
+
+## Resolve strategy
+
+v1 uses **complaint-based resolve only**. Per the .NET docs for
+[`ResolveServicePartitionAsync`](https://learn.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.servicemanagementclient.resolveservicepartitionasync):
+
+> When called **with** `previousResult` … the system will try to
+> return a more up-to-date `ResolvedServicePartition` than
+> `previousResult` in the most efficient way possible.
+
+`FabricTargetResolver` always passes the cached RSP back as
+`previousResult`. SF either confirms (same-version reply) or
+returns something fresher. The connector never decides whether to
+refresh; it just always asks. Eliminates an entire class of
+"did we remember to invalidate the cache?" bugs.
+
+**Why not notifications in v1.** Filter lifecycle (`Drop` can't
+`await`), the FabricClient cleanup race
+([issue #184](https://github.com/Azure/service-fabric-rs/issues/184)),
+missed/out-of-order notifications, and a small steady-state
+latency win on a *failover-recovery* path don't justify the
+complexity. See [Future work](#future-work) for the opt-in mode.
+
+## Composition with tonic-tls
+
+`TargetConnector` is intentionally plain TCP. TLS is supplied by
+composition: tonic-tls's `TlsConnector::new(transport, ssl, sni)`
+wraps any inner `tonic_tls::Transport` and produces a
+`Service<Uri>` that performs TLS on top.
+
+To plug `TargetConnector` straight in, it needs to implement
+`tonic_tls::Transport`. **v1 does not ship that adapter** — the
+`tonic-tls` cargo sub-feature mentioned in [Where this
+lives](#where-this-lives) is a future addition. Until then, users
+who want TLS can write a tiny `tonic_tls::Transport` shim that
+calls a `TargetConnector` and unwraps the `TokioIo` to the bare
+`TcpStream`, or use the manual composition route via
+`SwapChannel::with_connector` with a `Service<Uri>` they assemble
+themselves.
+
+When `SwapChannel::rebuild()` runs over a TLS-wrapped connector:
+new `tonic::Channel` → empty pool → next request triggers
+`tls_conn.call(uri)` → `target_conn.call(uri)` (fresh TCP via SF
+resolve) → TLS handshake on the new TCP stream → HTTP/2 connection.
+The old TLS connections close along with the rest of the old
+hyper pool.
+
+SNI is taken as an explicit parameter by tonic-tls; the connector
+does not auto-derive it from the resolved endpoint. SF endpoints
+are arbitrary user-defined strings.
+
+## Refresh path
+
+The connector is invoked by hyper (via `tonic::Channel`'s
+`MakeConnection` hook) whenever the pool needs a new connection.
+**No background task**, **no channel cache** (hyper's pool serves
+that role), **no in-process single-flight mutex** (hyper's pool
+checkout already serializes `MakeConnection` calls per pool key).
+
+Two paths in:
+
+1. **`SwapChannel::rebuild()` (trailer-driven, Case 2).**
+   Middleware → rebuild → new `tonic::Channel` with empty pool →
+   next request pool-misses → connector → resolver returns the
+   post-failover `DialTarget`.
+2. **Hyper pool miss on the existing Channel (transport-error,
+   Case 1).** Old connection died. Hyper evicts it; next request
+   misses; same connector path runs.
+
+In both, the connector's behavior is identical: always pass the
+cached RSP back to SF as `previousResult`.
+
+### Why always resolve?
+
+A simpler alternative to tracking "is the cache stale?" is to
+always pass the cache back and let SF's complaint protocol confirm
+or supersede it. Trade-offs:
+
+- For single-primary selectors, this does the same network work
+  as a heuristic-based design — every connector invocation issues
+  one resolve.
+- For non-deterministic selectors (round-robin, custom shard
+  routing), it costs one extra resolve per dial that *would* have
+  been served from a stable cached RSP. The resolve is cheap
+  (same-version reply) and dials are per-connection, not
+  per-request.
+- Eliminates an entire class of correctness bugs.
+
+### Mental model: Fabric URI ≈ DNS name
+
+| | DNS | Service Fabric |
+|---|---|---|
+| Stable name | hostname | Fabric URI (`fabric:/App/Service`) |
+| Resolves to | A/AAAA records | `ResolvedServicePartition` |
+| Resolution mechanism | UDP/TCP query | FabricClient COM call |
+| Client cache | OS resolver, TTL-bound | FabricClient cache, version-tracked |
+| Stale-result feedback | none — TTL only | `previousResult` complaint |
+| Re-resolve on transport failure | **no** (hyper's IP-pinning sharp edge) | **yes** (`TargetConnector`) |
+| Re-resolve on application-level signal | **no** | **yes** (`SwapChannel::rebuild()` on trailer) |
+
+The connector is the "pluggable resolver" piece that hyper
+deliberately doesn't ship for DNS, plus an application-level
+invalidation path that SF naming exposes via the trailer.
+
+## Lifecycle & cleanup
+
+- All public types are `Clone`. Clones share `Arc<Inner>`.
+- Sync construction; no IO until first request.
+- Drop of last `Arc<Inner>` releases everything. No background task,
+  no notification filter, no `Drop` dance. Pooled HTTP/2
+  connections are owned by hyper inside whatever generation of
+  `tonic::Channel` is alive; they close when the last in-flight
+  response on each generation drops.
+- Graceful shutdown: drop the channel handle. In-flight requests
+  hold their own clones of whatever generation of inner
+  `tonic::Channel` they were dispatched on; they run to completion
+  if the tokio runtime is still alive. We deliberately do not add
+  an explicit `shutdown()` API; the no-kill contract makes
+  "drop and let outstanding finish" the natural pattern.
+
+## Concurrency
+
+- Per-RPC cancellation: tonic's built-in cancellation propagation
+  works as-is.
+- Connector-call cancellation falls out of future-drop. The only
+  shared per-call state is the resolver's
+  `ArcSwapOption<ResolvedServicePartition>`, which is only
+  *written* on a successful resolve.
+- `SwapChannel::rebuild()` is non-blocking and always produces a
+  new Channel. Storm dedup is the middleware's job; concurrent
+  same-value trailer arrivals collapse there.
+- Concurrent failing requests on one Channel are deduplicated by
+  hyper's pool checkout (one `MakeConnection` per pool key).
+- `TargetResolver::resolve()` takes no arguments in v1. The
+  builder-configured `resolve_timeout` plus the resolver's
+  internal retryer bound the call. A future revision can add
+  `&CancellationToken` additively.
+
+## Implementation deviations from earlier drafts
+
+A few small differences between this doc and what shipped:
+
+- **Type erasure uses `BoxCloneSyncService`, not `BoxCloneService`.**
+  `SwapChannel` is shared via `Arc<Inner>` between the user-facing
+  service and the rebuild closure captured by the middleware, so
+  the inner connector slot must be `Sync`. tonic-tls's
+  `TlsConnector` is already `Sync`; user-supplied connectors must
+  be too.
+- **`ResolveStatusMiddleware::new` is the only constructor.** The
+  earlier draft showed `layer` / `layer_with_rebuild`
+  factory-style `tower::Layer` helpers; the impl ships only
+  `new(inner, header_name, rebuild)`, which is enough for both the
+  convenience builder and manual composition. A `Layer` impl is
+  trivial to add if/when a user needs one.
+- **Readiness driven inside the response future.** `SwapChannel`'s
+  `poll_ready` always returns `Ready(Ok(()))`; the
+  per-`tonic::Channel` readiness is awaited inside the future
+  returned by `call`. Necessary because tonic's `Channel` is
+  internally buffered (`poll_ready` and `call` must hit the same
+  instance); also avoids leaking a stale readied snapshot via
+  `#[derive(Clone)]` when a layer above us clones `SwapChannel`
+  between `poll_ready` and `call` — and across a `rebuild()`.
+- **`tonic-tls` adapter is deferred.** See
+  [Composition with tonic-tls](#composition-with-tonic-tls). The
+  `tonic-tls` cargo sub-feature isn't shipped yet; users wire TLS
+  via `SwapChannel::with_connector`.
+- **The integration test against a live SF cluster is deferred.**
+  See [Testing](#testing).
+
+## Testing
+
+### Unit / integration tests (shipped)
+
+- 6 dedup state-machine tests in
+  [`middleware.rs`](../../crates/libs/util/src/tonic/middleware.rs).
+- 7 end-to-end middleware tests in
+  [`tonic_middleware.rs`](../../crates/libs/util/tests/tonic_middleware.rs)
+  using a scripted inner `Service` + scripted bodies with trailers:
+  trailer→rebuild, same-value dedup, distinct-value rebuilds,
+  no-trailer reset, empty-value escape hatch, empty-value twice,
+  unrelated-header ignored.
+- 3 e2e failover tests in
+  [`tests/mssf-tests/tests/tonic_failover.rs`](../../tests/mssf-tests/tests/tonic_failover.rs)
+  spinning up two real HTTP/2 servers on ephemeral ports with
+  graceful shutdown:
+  - `failover_via_trailer_and_resolver_flip` — A trailers always,
+    flip resolver to B between calls; assert routing landed
+    correctly and resolver call counts are exactly 2.
+  - `no_trailer_no_rebuild_pool_reused` — steady-state HTTP/2 pool
+    reuse, exactly 1 resolver call across 3 requests.
+  - `server_becomes_stable_after_one_trailer` — single server
+    starts unstable then quiesces; exercises the `Reset`
+    transition + same-target rebuild + steady state.
+
+### Deferred — live-cluster failover sample
+
+Originally planned as a stateful `ReflectionApp` with `MyGreeter`
+honoring the trailer contract, plus `move_primary` /
+`restart_replica` orchestration. Deferred — the e2e mock-server
+suite covers the channel layers, the dedup state machine, and the
+failover orchestration deterministically. The live-cluster test
+is most useful for validating
+[`FabricTargetResolver`](../../crates/libs/util/src/tonic/naming/default.rs)'s
+always-complain bookkeeping and address-parse selectors against
+real SF naming, neither of which is exercised by the mock tests.
+
+When it lands, the test plan is:
+
+1. Stateful service with target/min replicas (3,3,0); `MyGreeter`
+   gates on `ServicePartitionAccessStatus` and attaches
+   `mssf-status: not-primary` on writes from non-primaries.
+2. Build a `TargetChannel` for the service URI with a primary-only
+   selector.
+3. Clean failover (Case 2): `move_primary` so the former primary
+   stays up as a secondary. First call returns trailer; second
+   call lands on new primary without test-level retry.
+4. Process-restart failover (Case 1): `restart_replica`; next call
+   succeeds without test-level retry.
+5. In-flight survival under failover.
+6. TLS composition repeat once the `tonic_tls::Transport` adapter
+   ships.
+
+## Open questions
+
+Most of the original 14 are resolved or moved to Future Work.
+Genuinely open:
+
+- **Exposed types.** We expose `ResolvedServicePartition` (and
+  transitively `ResolvedServiceEndpoint`) directly to the
+  user-supplied selector. Alternative: a smaller `EndpointInfo`
+  struct insulating users from internal type churn. v1 prioritizes
+  not losing information. Custom `TargetResolver` impls don't see
+  RSP, so this is strictly a `FabricTargetResolver` concern.
+- **Generic transport.** `TargetConnector` doesn't depend on tonic
+  at the type level — it's a hyper-compatible `Service<Uri>`.
+  Could be advertised as usable with any `hyper::Client`. v1
+  documents the tonic recipe; generic-HTTP usage is supported but
+  not the headline.
+
+## Future work
+
+- **`tonic-tls` adapter.** Ship the `tonic_tls::Transport` impl on
+  `TargetConnector` behind a `tonic-tls` cargo sub-feature, so the
+  recipe in [Composition with tonic-tls](#composition-with-tonic-tls)
+  becomes a one-liner.
+- **Live-cluster failover sample / test.** See
+  [Testing](#testing).
+- **Trailer-aware caller retry recipe.** A worked
+  `tower::retry::Policy` that inspects the trailer for callers
+  who want to retry on `not-primary` even when the gRPC status
+  isn't `Unavailable`. Requires body-plumbing in the policy to
+  read trailers before deciding; v1 sidesteps this by guaranteeing
+  the next request goes through a fresh Channel.
+- **Notification-backed resolve mode.** Opt-in mode that registers
+  a `ServiceNotificationFilterDescription` so steady-state
+  resolves hit the FabricClient cache. Requires designing for
+  filter lifecycle on `Drop`, the FabricClient cleanup race, and
+  fall-back to complaint resolve when notifications go quiet.
+- **Bootstrap fallback via `tower::reconnect::Reconnect`.** Today
+  the *first* dial happens on the first user request; if SF naming
+  is offline at startup, that first request fails. Wrapping
+  `TargetChannel` in `Reconnect<TargetChannelMaker>` would let it
+  self-heal on subsequent requests.
+- **`Channel::balance_channel`** for fan-out to stateless /
+  secondary replicas.
+- **Per-call deadline propagation** from the gRPC call into the
+  resolver call. Requires plumbing the deadline through hyper's
+  `Service<Uri>` invocation, which has no standard mechanism.
+- **Metrics hooks** (`tracing` spans for resolve / dial / rebuild
+  / trailer detection).
+- **Hoist the naming layer.** When a second client lands (e.g. a
+  non-tonic transport over SF), move `naming/` to
+  `mssf_util::naming` and have `mssf_util::tonic` re-export.
+  Internal refactor; `mssf_util::tonic::*` paths stay stable.
+
+## References
+
+- [`crates/libs/core/src/client/svc_mgmt_client.rs`](../../crates/libs/core/src/client/svc_mgmt_client.rs) — `resolve_service_partition`, partition key types, `ResolvedServicePartition`.
+- [`crates/libs/util/src/resolve.rs`](../../crates/libs/util/src/resolve.rs) — `ServicePartitionResolver`.
+- [`crates/samples/reflection/src/test.rs`](../../crates/samples/reflection/src/test.rs) — current tonic usage and manual failover handling.
+- [`crates/samples/reflection/src/test2.rs`](../../crates/samples/reflection/src/test2.rs) — `resolve_until_change(.., complain=true)` (prior art).
+- [`ResolveServicePartitionAsync` remarks](https://learn.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.servicemanagementclient.resolveservicepartitionasync) — complaint protocol semantics.
+- [tonic-tls](https://github.com/youyuanwu/tonic-tls) — `Service<Uri>`-based TLS connectors for tonic.

--- a/tests/mssf-tests/Cargo.toml
+++ b/tests/mssf-tests/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dev-dependencies]
-mssf-util = { workspace = true, default-features = true }
+mssf-util = { workspace = true, default-features = true, features = ["tonic"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "sync"] }
 tokio-util = { workspace = true }
 hyper = { workspace = true, features = ["server", "http2"] }

--- a/tests/mssf-tests/Cargo.toml
+++ b/tests/mssf-tests/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mssf-tests"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[dev-dependencies]
+mssf-util = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "sync"] }
+tokio-util = { workspace = true }
+hyper = { workspace = true, features = ["server", "http2"] }
+hyper-util = { workspace = true, features = ["server", "tokio"] }
+http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
+tonic.workspace = true
+tower.workspace = true
+arc-swap.workspace = true
+futures.workspace = true
+bytes.workspace = true

--- a/tests/mssf-tests/src/lib.rs
+++ b/tests/mssf-tests/src/lib.rs
@@ -1,0 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Integration tests for `mssf_util::tonic`.
+
+#![cfg(test)]

--- a/tests/mssf-tests/tests/tonic_failover.rs
+++ b/tests/mssf-tests/tests/tonic_failover.rs
@@ -1,0 +1,460 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! End-to-end failover test for `mssf_util::tonic::TargetChannel`.
+//!
+//! Spins up two real HTTP/2 servers on ephemeral ports. A custom
+//! [`TargetResolver`] backed by [`ArcSwap`] starts pointing at
+//! server A; server A always attaches `mssf-status: not-primary`
+//! to its responses; server B attaches no trailer.
+//!
+//! Sequence of events:
+//!
+//! 1. Resolver returns A.
+//! 2. First request lands on A. Server A responds with
+//!    `mssf-status: not-primary` trailer. The middleware fires
+//!    `rebuild()` on the [`SwapChannel`]; the new inner
+//!    `tonic::Channel` has an empty hyper pool.
+//! 3. Test flips the resolver to point at B.
+//! 4. Second request through the freshly-rebuilt Channel triggers
+//!    a pool miss → the connector calls the resolver → B is
+//!    dialed → server B responds with no trailer.
+//!
+//! Assertions verify the request landed on the expected server and
+//! the rebuild signal fired exactly once.
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use arc_swap::ArcSwap;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use http::{HeaderMap, HeaderValue, Method, Request, Response, Uri};
+use http_body::Frame;
+use http_body_util::BodyExt as _;
+use hyper::body::Incoming;
+use hyper::server::conn::http2;
+use hyper::service::service_fn;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::net::TcpListener;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tonic::body::Body;
+use tower::{Service, ServiceExt as _};
+
+use mssf_util::tonic::{BoxError, DialTarget, TargetChannel, TargetChannelBuilder, TargetResolver};
+
+// ---------------------------------------------------------------
+// Switchable resolver: ArcSwap<DialTarget>; tests flip it at will.
+// ---------------------------------------------------------------
+
+#[derive(Clone)]
+struct SwitchableResolver {
+    target: Arc<ArcSwap<DialTarget>>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl SwitchableResolver {
+    fn new(initial: DialTarget) -> Self {
+        Self {
+            target: Arc::new(ArcSwap::from_pointee(initial)),
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+    fn point_at(&self, t: DialTarget) {
+        self.target.store(Arc::new(t));
+    }
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl TargetResolver for SwitchableResolver {
+    fn resolve(&self) -> BoxFuture<'_, Result<DialTarget, BoxError>> {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok((**self.target.load()).clone())
+        })
+    }
+}
+
+// ---------------------------------------------------------------
+// Tiny HTTP/2 server. Each accepted connection responds to every
+// request with 200 + `server-id` header + (optionally) the
+// trailer currently configured on the shared `TrailerSwitch`.
+// Tests flip the switch between calls to drive the dedup state
+// machine into the stable / unstable cases at will.
+// ---------------------------------------------------------------
+
+/// Shared mutable trailer policy. `Some("v")` → attach
+/// `mssf-status: v`. `None` → omit the trailer (steady state).
+#[derive(Clone, Default)]
+struct TrailerSwitch(Arc<arc_swap::ArcSwapOption<String>>);
+
+impl TrailerSwitch {
+    fn set<S: Into<String>>(&self, value: Option<S>) {
+        match value {
+            Some(v) => self.0.store(Some(Arc::new(v.into()))),
+            None => self.0.store(None),
+        }
+    }
+    fn current(&self) -> Option<Arc<String>> {
+        self.0.load_full()
+    }
+}
+
+#[derive(Clone)]
+struct ServerCfg {
+    id: &'static str,
+    /// Switchable trailer policy (shared with the test).
+    trailer: TrailerSwitch,
+    /// Counts requests served, for assertions.
+    hits: Arc<AtomicUsize>,
+}
+
+/// Body that emits a tiny DATA frame and then a trailers frame.
+/// Real HTTP/2 transports require the data frame to land before
+/// trailing HEADERS — a trailer-only body can be collapsed into
+/// the initial HEADERS with END_STREAM, hiding our trailer.
+struct DataThenTrailerBody {
+    state: u8, // 0 = data, 1 = trailers, 2 = done
+    trailers: Option<HeaderMap>,
+}
+
+impl DataThenTrailerBody {
+    fn new(trailers: Option<HeaderMap>) -> Self {
+        Self { state: 0, trailers }
+    }
+}
+
+impl http_body::Body for DataThenTrailerBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.state {
+            0 => {
+                self.state = 1;
+                Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(
+                    b"\x00\x00\x00\x00\x00",
+                )))))
+            }
+            1 => {
+                self.state = 2;
+                match self.trailers.take() {
+                    Some(map) => Poll::Ready(Some(Ok(Frame::trailers(map)))),
+                    None => Poll::Ready(None),
+                }
+            }
+            _ => Poll::Ready(None),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.state == 2
+    }
+}
+
+async fn handle(
+    cfg: ServerCfg,
+    _req: Request<Incoming>,
+) -> Result<Response<DataThenTrailerBody>, Infallible> {
+    cfg.hits.fetch_add(1, Ordering::SeqCst);
+    let trailers = cfg.trailer.current().map(|v| {
+        let mut m = HeaderMap::new();
+        m.insert("mssf-status", HeaderValue::from_str(v.as_str()).unwrap());
+        m
+    });
+    let resp = Response::builder()
+        .status(200)
+        .header("server-id", cfg.id)
+        .header("content-type", "application/grpc")
+        .body(DataThenTrailerBody::new(trailers))
+        .unwrap();
+    Ok(resp)
+}
+
+/// Spawn an HTTP/2 server bound to an ephemeral port. Returns
+/// the bound address and a [`ServerHandle`] whose [`shutdown`]
+/// method triggers a graceful shutdown via cancellation token
+/// and awaits the listener task plus every accepted connection.
+async fn spawn_server(cfg: ServerCfg) -> (SocketAddr, ServerHandle) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let cancel = CancellationToken::new();
+    let cancel_listener = cancel.clone();
+    let listener_task = tokio::spawn(async move {
+        let mut conns: JoinSet<()> = JoinSet::new();
+        loop {
+            tokio::select! {
+                _ = cancel_listener.cancelled() => break,
+                accept = listener.accept() => {
+                    let (sock, _) = match accept {
+                        Ok(x) => x,
+                        Err(_) => break,
+                    };
+                    let cfg2 = cfg.clone();
+                    let cancel_conn = cancel_listener.clone();
+                    conns.spawn(async move {
+                        let svc = service_fn(move |req| handle(cfg2.clone(), req));
+                        let mut conn = std::pin::pin!(
+                            http2::Builder::new(TokioExecutor::new())
+                                .serve_connection(TokioIo::new(sock), svc)
+                        );
+                        tokio::select! {
+                            _ = cancel_conn.cancelled() => {
+                                conn.as_mut().graceful_shutdown();
+                                let _ = conn.await;
+                            }
+                            res = conn.as_mut() => { let _ = res; }
+                        }
+                    });
+                }
+            }
+        }
+        // Drain any in-flight connections so the test waits for
+        // their `graceful_shutdown` to complete.
+        while conns.join_next().await.is_some() {}
+    });
+    let handle = ServerHandle {
+        cancel,
+        task: Some(listener_task),
+    };
+    (addr, handle)
+}
+
+/// Owns the listener task + cancellation token. Call
+/// [`shutdown`](Self::shutdown) (or drop) to stop the server.
+struct ServerHandle {
+    cancel: CancellationToken,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ServerHandle {
+    async fn shutdown(mut self) {
+        self.cancel.cancel();
+        if let Some(t) = self.task.take() {
+            let _ = t.await;
+        }
+    }
+}
+
+impl Drop for ServerHandle {
+    fn drop(&mut self) {
+        // Best-effort cancel on drop so a panicking test doesn't
+        // leak the listener task; the explicit `shutdown().await`
+        // is what gives deterministic ordering.
+        self.cancel.cancel();
+        if let Some(t) = self.task.take() {
+            t.abort();
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Test driver
+// ---------------------------------------------------------------
+
+/// Send one HTTP request through the channel and return the
+/// `server-id` response header (so the test knows which backend
+/// served it).
+async fn send_one(channel: &mut TargetChannel) -> String {
+    let req: Request<Body> = Request::builder()
+        .method(Method::POST)
+        .uri(Uri::from_static("http://fabric.invalid/test/Method"))
+        .header("content-type", "application/grpc")
+        .body(Body::empty())
+        .unwrap();
+    let svc = channel.ready().await.expect("ready");
+    let resp = svc.call(req).await.expect("response");
+    let (parts, body) = resp.into_parts();
+    let server_id = parts
+        .headers
+        .get("server-id")
+        .map(|v| v.to_str().unwrap().to_string())
+        .unwrap_or_default();
+    // Drain the body so the trailer observer fires before we
+    // dispatch the next request.
+    let _ = body.collect().await.unwrap();
+    server_id
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failover_via_trailer_and_resolver_flip() {
+    // -- Server A: starts attaching mssf-status: not-primary --
+    let trailer_a = TrailerSwitch::default();
+    trailer_a.set(Some("not-primary"));
+    let hits_a = Arc::new(AtomicUsize::new(0));
+    let cfg_a = ServerCfg {
+        id: "A",
+        trailer: trailer_a.clone(),
+        hits: hits_a.clone(),
+    };
+    let (addr_a, srv_a) = spawn_server(cfg_a).await;
+
+    // -- Server B: no trailer --
+    let trailer_b = TrailerSwitch::default();
+    let hits_b = Arc::new(AtomicUsize::new(0));
+    let cfg_b = ServerCfg {
+        id: "B",
+        trailer: trailer_b.clone(),
+        hits: hits_b.clone(),
+    };
+    let (addr_b, srv_b) = spawn_server(cfg_b).await;
+
+    // -- Switchable resolver, pointing at A initially --
+    let resolver = Arc::new(SwitchableResolver::new(DialTarget {
+        host: addr_a.ip().to_string(),
+        port: addr_a.port(),
+    }));
+
+    // -- TargetChannel via the convenience builder --
+    let mut channel = TargetChannelBuilder::new()
+        .resolver(resolver.clone())
+        .trailer_header("mssf-status")
+        .build();
+
+    // 1. First request: lands on A, sees the trailer, middleware
+    //    fires rebuild(). Response delivered to caller as-is.
+    let id1 = send_one(&mut channel).await;
+    assert_eq!(id1, "A");
+    assert_eq!(hits_a.load(Ordering::SeqCst), 1);
+    assert_eq!(hits_b.load(Ordering::SeqCst), 0);
+
+    // 2. Flip the resolver to point at B (simulating an SF
+    //    primary move). Subsequent dials go to B.
+    resolver.point_at(DialTarget {
+        host: addr_b.ip().to_string(),
+        port: addr_b.port(),
+    });
+
+    // 3. Second request: the rebuilt Channel has an empty pool,
+    //    so the connector dials → resolver returns B → lands
+    //    on B (no trailer).
+    let id2 = send_one(&mut channel).await;
+    assert_eq!(id2, "B");
+    assert_eq!(
+        hits_a.load(Ordering::SeqCst),
+        1,
+        "A should not be hit again"
+    );
+    assert_eq!(hits_b.load(Ordering::SeqCst), 1);
+
+    // 4. Resolver call count: 1 cold dial against A, 1 cold dial
+    //    against B (the rebuilt Channel's first request).
+    assert_eq!(resolver.calls(), 2);
+
+    // 5. Third request reuses B's hyper pool — no new dial, no
+    //    new resolve, server B's hits increments.
+    let id3 = send_one(&mut channel).await;
+    assert_eq!(id3, "B");
+    assert_eq!(hits_b.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        resolver.calls(),
+        2,
+        "no extra resolve when reusing the live HTTP/2 connection"
+    );
+
+    // Drop the client first so its connections close, then
+    // gracefully drain both servers.
+    drop(channel);
+    srv_a.shutdown().await;
+    srv_b.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_trailer_no_rebuild_pool_reused() {
+    // Server B: no trailer, ever. Multiple requests should reuse
+    // the same HTTP/2 connection — only one resolver call total.
+    let hits = Arc::new(AtomicUsize::new(0));
+    let cfg = ServerCfg {
+        id: "B",
+        trailer: TrailerSwitch::default(),
+        hits: hits.clone(),
+    };
+    let (addr, srv) = spawn_server(cfg).await;
+
+    let resolver = Arc::new(SwitchableResolver::new(DialTarget {
+        host: addr.ip().to_string(),
+        port: addr.port(),
+    }));
+
+    let mut channel = TargetChannelBuilder::new()
+        .resolver(resolver.clone())
+        .trailer_header("mssf-status")
+        .build();
+
+    for _ in 0..3 {
+        assert_eq!(send_one(&mut channel).await, "B");
+    }
+    assert_eq!(hits.load(Ordering::SeqCst), 3);
+    assert_eq!(
+        resolver.calls(),
+        1,
+        "steady-state should reuse the pooled connection"
+    );
+
+    drop(channel);
+    srv.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_becomes_stable_after_one_trailer() {
+    // Single server. Starts attaching `mssf-status: not-primary`.
+    // After the test flips its trailer off, subsequent requests
+    // run cleanly. We expect: 1 rebuild, then steady state with
+    // the SAME server (same `host:port`, but a fresh hyper pool
+    // because rebuild() dropped the old Channel).
+    let trailer = TrailerSwitch::default();
+    trailer.set(Some("not-primary"));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let cfg = ServerCfg {
+        id: "S",
+        trailer: trailer.clone(),
+        hits: hits.clone(),
+    };
+    let (addr, srv) = spawn_server(cfg).await;
+
+    let resolver = Arc::new(SwitchableResolver::new(DialTarget {
+        host: addr.ip().to_string(),
+        port: addr.port(),
+    }));
+    let mut channel = TargetChannelBuilder::new()
+        .resolver(resolver.clone())
+        .trailer_header("mssf-status")
+        .build();
+
+    // 1. First call: server is "unstable" → trailer fires once
+    //    → rebuild scheduled. last_seen = Some("not-primary").
+    assert_eq!(send_one(&mut channel).await, "S");
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+    assert_eq!(resolver.calls(), 1);
+
+    // 2. Server switches to stable (no trailer).
+    trailer.set::<String>(None);
+
+    // 3. Second call: rebuilt Channel has empty pool → fresh
+    //    dial → resolver returns same target → server now
+    //    serves cleanly → dedup `Reset`, last_seen = None.
+    assert_eq!(send_one(&mut channel).await, "S");
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+    assert_eq!(resolver.calls(), 2, "rebuild caused one new dial");
+
+    // 4. Third call: pool reused, no resolve, no trailer, no
+    //    rebuild. Steady state.
+    assert_eq!(send_one(&mut channel).await, "S");
+    assert_eq!(hits.load(Ordering::SeqCst), 3);
+    assert_eq!(resolver.calls(), 2, "steady state should not re-dial");
+
+    drop(channel);
+    srv.shutdown().await;
+}


### PR DESCRIPTION
This is part of the work for proxyless service mesh on top of SF naming resolution.
Ships a tonic-compatible channel that auto-resolves SF endpoints, reconnects after failover, and reacts to a server-signalled 'mssf-status' trailer. Gated by the 'tonic' cargo feature.

Public surface (re-exported flat from mssf_util::tonic):
  - TargetResolver trait + BoxError
  - DialTarget, TargetSelector, SelectError
  - FabricTargetResolver(+Builder)  —> SF naming impl
  - TargetConnector(+Builder)        —> Service<Uri>: resolve + TCP dial
  - SwapChannel                      —> ArcSwap<tonic::Channel>
  - ResolveStatusMiddleware       —> trailer dedup + rebuild trigger
  - TargetChannel + TargetChannelBuilder —> convenience composition

Architecture: 4 composable layers (middleware over SwapChannel over tonic::Channel over TargetConnector over TargetResolver). Trailer dedup state machine handles storm, reset, dumb-server escape hatch. No background task; no in-flight kill; complaint-based resolve only.

Tests:
  - 6 dedup classify() unit tests
  - 7 middleware integration tests (scripted Service + bodies)
  - 3 e2e failover tests in new mssf-tests crate using two real HTTP/2 servers + switchable resolver + graceful shutdown

Design doc: docs/design/TonicConnectorDesign.md.
TLS adapter and live-cluster sample test deferred to Future Work.

Part of #293 