### PR TITLE
[test] Test concurrent create delete of services

### DIFF
--- a/crates/samples/reflection/src/test_cluster.rs
+++ b/crates/samples/reflection/src/test_cluster.rs
@@ -32,12 +32,17 @@
 
 use std::time::Duration;
 
+use mssf_core::client::FabricClient;
+use mssf_core::types::{
+    ServicePartitionInformation, ServicePartitionQueryDescription, ServicePartitionQueryResultItem,
+    Uri,
+};
 use tonic::transport::{Channel, Endpoint};
 
 use crate::grpc_control::REFLECTION_CONTROL_BASE_PORT;
 use crate::grpc_control::proto::{
     ApprovalEvent, ApprovalKind, ApproveRequest, Empty, ListPendingRequest, ReplicaRef,
-    WaitForApprovalRequest, approve_request::Decision as ApproveDecisionOneof,
+    approve_request::Decision as ApproveDecisionOneof, list_pending_request::ReplicaFilter,
     replica_control_client::ReplicaControlClient,
 };
 
@@ -49,9 +54,6 @@ pub const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Default total time `poll_for_pending` will wait before panicking.
 pub const POLL_BUDGET: Duration = Duration::from_secs(30);
-
-/// gRPC `WaitForApproval` deadline sent to the server.
-pub const WAIT_FOR_APPROVAL_TIMEOUT_MS: u32 = 30_000;
 
 /// Hostname-or-IP that resolves to the cluster.
 ///
@@ -66,6 +68,63 @@ pub fn cluster_host() -> String {
     #[cfg(not(windows))]
     const DEFAULT_HOST: &str = "onebox";
     std::env::var("REFLECTION_CLUSTER_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string())
+}
+
+/// Look up the (Singleton) `partition_id` for `service_name` via the
+/// SF query manager, retrying until SF surfaces the partition (it is
+/// not necessarily visible the instant `create_service` returns).
+///
+/// Returns the partition_id formatted exactly as the
+/// `ReplicaControl` proto expects (`{:?}` of `mssf_core::GUID`,
+/// uppercase dashed, no braces) so the result can be passed straight
+/// into [`Cluster::partition_driver`].
+///
+/// Tests must use this instead of [`Cluster::poll_for_pending`] when
+/// they may run in parallel with other tests on the same cluster:
+/// cluster-wide polling can otherwise grab another test's `Open`
+/// gate by mistake.
+pub async fn discover_partition_id(fc: &FabricClient, service_name: &Uri) -> String {
+    const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+    const POLL_BACKOFF: Duration = Duration::from_millis(250);
+    const POLL_BUDGET: Duration = Duration::from_secs(30);
+
+    let q = fc.get_query_manager();
+    let desc = ServicePartitionQueryDescription {
+        service_name: service_name.clone(),
+        partition_id_filter: None,
+    };
+
+    let deadline = std::time::Instant::now() + POLL_BUDGET;
+    loop {
+        match q.get_partition_list(&desc, QUERY_TIMEOUT, None).await {
+            Ok(list) => {
+                let pid = list
+                    .service_partitions
+                    .into_iter()
+                    .filter_map(|p| match p {
+                        ServicePartitionQueryResultItem::Stateful(s) => {
+                            match s.partition_information {
+                                ServicePartitionInformation::Singleton(info) => Some(info.id),
+                                _ => None,
+                            }
+                        }
+                        _ => None,
+                    })
+                    .next();
+                if let Some(guid) = pid {
+                    return format!("{guid:?}");
+                }
+            }
+            Err(e) => tracing::debug!("get_partition_list({service_name}): {e}; retrying"),
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "no Singleton partition for {service_name} within {POLL_BUDGET:?}: \
+                 service may not have been created or is not stateful Singleton"
+            );
+        }
+        tokio::time::sleep(POLL_BACKOFF).await;
+    }
 }
 
 /// Holds one connection slot per candidate `ReplicaControl` port.
@@ -164,32 +223,13 @@ impl Cluster {
     /// placed on a previously-idle node is discovered without extra
     /// retry logic in the caller.
     ///
+    /// Cluster-wide (no partition filter); use this for the very
+    /// first OPEN before the partition_id is known. After that, build
+    /// a [`PartitionDriver`] and use its `wait_*` methods.
+    ///
     /// Panics if no matching gate appears within [`POLL_BUDGET`].
     pub async fn poll_for_pending(
         &mut self,
-        expected_kind: Option<ApprovalKind>,
-    ) -> (usize, ApprovalEvent) {
-        self.poll_for_pending_inner(None, expected_kind).await
-    }
-
-    /// Like [`Cluster::poll_for_pending`] but only matches gates whose
-    /// target's `partition_id` equals `partition_id`. Useful when SF
-    /// rebuilds a replica after a failed `change_role` (the
-    /// `replica_id` changes but the partition does not), or when the
-    /// test must coexist with parallel test runs in the same cluster
-    /// (each test scopes its polling to its own partition).
-    pub async fn poll_for_pending_in_partition(
-        &mut self,
-        partition_id: &str,
-        expected_kind: Option<ApprovalKind>,
-    ) -> (usize, ApprovalEvent) {
-        self.poll_for_pending_inner(Some(partition_id), expected_kind)
-            .await
-    }
-
-    async fn poll_for_pending_inner(
-        &mut self,
-        partition_id: Option<&str>,
         expected_kind: Option<ApprovalKind>,
     ) -> (usize, ApprovalEvent) {
         let deadline = std::time::Instant::now() + POLL_BUDGET;
@@ -199,7 +239,7 @@ impl Cluster {
             for (i, client) in self.iter_connected_mut() {
                 let resp = match client
                     .list_pending(ListPendingRequest {
-                        partition_id: partition_id.unwrap_or("").to_string(),
+                        partition_id: String::new(),
                         replica_filter: None,
                     })
                     .await
@@ -226,7 +266,7 @@ impl Cluster {
             if std::time::Instant::now() >= deadline {
                 panic!(
                     "no pending gate of kind {expected_kind:?} found within {POLL_BUDGET:?} \
-                     (partition_filter={partition_id:?}, connected_nodes={})",
+                     (connected_nodes={})",
                     self.connected_count(),
                 );
             }
@@ -295,96 +335,127 @@ impl Default for Cluster {
 }
 
 impl Cluster {
-    /// Build a [`ReplicaClient`] handle pointing at one specific
-    /// replica. The returned handle borrows the cluster mutably; it
-    /// owns the `(node_idx, target)` pair and exposes every per-replica
-    /// operation (`wait_for_gate`, `approve_proceed`, etc.) as methods.
+    /// Build a [`PartitionDriver`] for the given partition. The driver
+    /// exposes manual primitives (`wait_next`, `wait_next_kind`,
+    /// `wait_new_replica`, `wait_for_replica`, `approve_proceed`,
+    /// `approve_fail`) that the test composes explicitly.
     ///
-    /// Typical flow after [`Cluster::poll_for_pending`]:
-    ///
-    /// ```ignore
-    /// let (node_idx, ev) = cluster.poll_for_pending(Some(ApprovalKind::ApprovalOpen)).await;
-    /// let target = ev.target.clone().unwrap();
-    /// let mut replica = cluster.replica_client(node_idx, target);
-    /// replica.approve_proceed(ev.gate_id).await;
-    /// let cr = replica.observe_and_approve(ApprovalKind::ApprovalChangeRole).await;
-    /// ```
-    pub fn replica_client(&mut self, node_idx: usize, target: ReplicaRef) -> ReplicaClient<'_> {
-        ReplicaClient {
+    /// The driver does **not** assume a single linear gate stream per
+    /// partition. SF brings replicas up serially, but later gates from
+    /// different replicas in the same partition interleave. The test
+    /// is responsible for routing each gate to the appropriate
+    /// per-replica logic.
+    pub fn partition_driver(&mut self, partition_id: impl Into<String>) -> PartitionDriver<'_> {
+        PartitionDriver {
             cluster: self,
-            node_idx,
-            target,
+            partition_id: partition_id.into(),
         }
     }
 }
 
 // ----------------------------------------------------------------------
-// ReplicaClient — per-replica handle borrowing the cluster.
+// PartitionDriver — partition-scoped manual primitives
 // ----------------------------------------------------------------------
 
-/// Borrowing handle that pins a single `(node_idx, replica_target)` and
-/// exposes every per-replica operation as a method, so tests don't
-/// have to thread `node_idx` and `target` through every call.
+/// Partition-scoped handle for waiting on and approving gates within
+/// one partition. Provides both manual primitives and a per-replica
+/// sequence helper.
 ///
-/// One `ReplicaClient` may exist at a time per `Cluster` (it holds an
-/// exclusive borrow). Tests that need to drive multiple replicas
-/// concurrently should keep `(node_idx, target)` pairs and re-acquire
-/// the handle via [`Cluster::replica_client`] for each operation.
-pub struct ReplicaClient<'a> {
+/// ## Single replica
+///
+/// After discovering the replica's first gate via `wait_*` (or via
+/// the cluster-wide [`Cluster::poll_for_pending`]), drive the rest of
+/// its lifecycle with [`PartitionDriver::drive_replica_sequence`] or
+/// [`PartitionDriver::approve_replica_sequence`].
+///
+/// ## Multiple replicas
+///
+/// SF brings replicas up serially (replica 1's Open parks before SF
+/// starts replica 2), but **post-Open lifecycle gates can interleave
+/// across replicas** with no SF-guaranteed order. Sequences are
+/// per-replica precisely so the test does not bake a cross-replica
+/// race into its expectations.
+///
+/// ```ignore
+/// // 1. Discover replica 1.
+/// let (n, ev1) = driver.wait_next_kind(ApprovalKind::ApprovalOpen).await;
+/// let r1 = ev1.target.as_ref().unwrap().replica_id;
+/// driver.approve_proceed(n, ev1.target.clone().unwrap(), ev1.gate_id.clone()).await;
+///
+/// // 2. Discover replica 2 (any open from a different replica).
+/// let (n, ev2) = driver.wait_new_replica(&[r1], Some(ApprovalKind::ApprovalOpen)).await;
+/// let r2 = ev2.target.as_ref().unwrap().replica_id;
+/// driver.approve_proceed(n, ev2.target.clone().unwrap(), ev2.gate_id.clone()).await;
+///
+/// // 3. Drive the rest concurrently. Two PartitionDrivers built from
+/// //    the same cluster cannot coexist (mutable borrow); use two
+/// //    cluster handles, or drive sequentially when ordering is OK.
+/// driver.drive_replica_sequence(r1, &[
+///     TestStep::proceed(ApprovalKind::ApprovalChangeRole), // -> Primary
+///     TestStep::proceed(ApprovalKind::ApprovalClose),
+/// ]).await;
+/// driver.drive_replica_sequence(r2, &[
+///     TestStep::proceed(ApprovalKind::ApprovalChangeRole), // -> Secondary
+///     TestStep::proceed(ApprovalKind::ApprovalClose),
+/// ]).await;
+/// ```
+///
+/// ## Rebuild handling
+///
+/// SF may rebuild a replica with a different `replica_id` (e.g. after
+/// `change_role` returns Err — see `tests/fail_change_role.rs`).
+/// `drive_replica_sequence` is pinned to a single `replica_id`, so a
+/// rebuild ends the sequence; the test re-discovers the new
+/// `replica_id` via `wait_*` and starts a fresh sequence against it.
+pub struct PartitionDriver<'a> {
     cluster: &'a mut Cluster,
-    node_idx: usize,
-    target: ReplicaRef,
+    partition_id: String,
 }
 
-impl<'a> ReplicaClient<'a> {
-    pub fn node_idx(&self) -> usize {
-        self.node_idx
+impl<'a> PartitionDriver<'a> {
+    pub fn partition_id(&self) -> &str {
+        &self.partition_id
     }
 
-    pub fn target(&self) -> &ReplicaRef {
-        &self.target
+    /// Wait for any pending gate in this partition (any replica, any kind).
+    pub async fn wait_next(&mut self) -> (usize, ApprovalEvent) {
+        self.poll_partition(None, &[], None).await
     }
 
-    fn client(&mut self) -> &mut ReplicaControlClient<Channel> {
-        self.cluster.client_mut(self.node_idx)
+    /// Wait for the next pending gate of `kind` in this partition (any replica).
+    pub async fn wait_next_kind(&mut self, kind: ApprovalKind) -> (usize, ApprovalEvent) {
+        self.poll_partition(Some(kind), &[], None).await
     }
 
-    /// Wait for a *specific* gate kind on this replica.
-    pub async fn wait_for_gate(&mut self, expected_kind: ApprovalKind) -> ApprovalEvent {
-        let target = self.target.clone();
-        let resp = self
-            .client()
-            .wait_for_approval(WaitForApprovalRequest {
-                target: Some(target),
-                timeout_ms: WAIT_FOR_APPROVAL_TIMEOUT_MS,
-                expected: expected_kind as i32,
-            })
-            .await
-            .unwrap_or_else(|s| panic!("WaitForApproval({expected_kind:?}) failed: {s}"));
-        resp.into_inner()
+    /// Wait for a pending gate from a replica whose `replica_id` is
+    /// *not* in `seen`. Use this to discover the next replica that SF
+    /// brings up after the previously-known ones; pass
+    /// `Some(ApprovalKind::ApprovalOpen)` when waiting for a fresh
+    /// activation.
+    pub async fn wait_new_replica(
+        &mut self,
+        seen: &[i64],
+        kind: Option<ApprovalKind>,
+    ) -> (usize, ApprovalEvent) {
+        self.poll_partition(kind, seen, None).await
     }
 
-    /// Wait for the *next* gate of any kind on this replica. Useful
-    /// during teardown where SF may issue `change_role(None)` before
-    /// `close` and the test wants to drain whatever comes next.
-    pub async fn wait_for_any_gate(&mut self) -> ApprovalEvent {
-        let target = self.target.clone();
-        let resp = self
-            .client()
-            .wait_for_approval(WaitForApprovalRequest {
-                target: Some(target),
-                timeout_ms: WAIT_FOR_APPROVAL_TIMEOUT_MS,
-                expected: ApprovalKind::ApprovalUnspecified as i32,
-            })
-            .await
-            .unwrap_or_else(|s| panic!("WaitForApproval(any) failed: {s}"));
-        resp.into_inner()
+    /// Wait for a pending gate from a specific `replica_id`. `kind`
+    /// filters the gate kind; `None` accepts any kind.
+    pub async fn wait_for_replica(
+        &mut self,
+        replica_id: i64,
+        kind: Option<ApprovalKind>,
+    ) -> (usize, ApprovalEvent) {
+        self.poll_partition(kind, &[], Some(replica_id)).await
     }
 
-    /// Approve a specific gate with `Decision::Proceed`.
-    pub async fn approve_proceed(&mut self, gate_id: String) {
-        let target = self.target.clone();
-        self.client()
+    /// Approve a previously-discovered gate with `Decision::Proceed`.
+    /// `node_idx`, `target` and `gate_id` come from the matching
+    /// `wait_*` return value.
+    pub async fn approve_proceed(&mut self, node_idx: usize, target: ReplicaRef, gate_id: String) {
+        self.cluster
+            .client_mut(node_idx)
             .approve(ApproveRequest {
                 target: Some(target),
                 gate_id: gate_id.clone(),
@@ -394,12 +465,18 @@ impl<'a> ReplicaClient<'a> {
             .unwrap_or_else(|s| panic!("Approve(gate_id={gate_id}) failed: {s}"));
     }
 
-    /// Approve a specific gate with `Decision::Fail(message)`. Note:
-    /// `fail_message` is rejected with `InvalidArgument` for an
-    /// `Approval::Abort` gate (SF's `abort` cannot fail).
-    pub async fn approve_fail(&mut self, gate_id: String, message: String) {
-        let target = self.target.clone();
-        self.client()
+    /// Approve a previously-discovered gate with `Decision::Fail(message)`.
+    /// Note: `Approval::Abort` rejects `fail_message` with
+    /// `InvalidArgument` (SF's `abort` cannot fail).
+    pub async fn approve_fail(
+        &mut self,
+        node_idx: usize,
+        target: ReplicaRef,
+        gate_id: String,
+        message: String,
+    ) {
+        self.cluster
+            .client_mut(node_idx)
             .approve(ApproveRequest {
                 target: Some(target),
                 gate_id: gate_id.clone(),
@@ -411,38 +488,180 @@ impl<'a> ReplicaClient<'a> {
             });
     }
 
-    /// Wait for a gate of `expected_kind`, then approve it with
-    /// `Decision::Proceed`. Returns the observed event so the test
-    /// can inspect `new_role` etc.
-    pub async fn observe_and_approve(&mut self, expected_kind: ApprovalKind) -> ApprovalEvent {
-        let ev = self.wait_for_gate(expected_kind).await;
-        let gate_id = ev.gate_id.clone();
-        self.approve_proceed(gate_id).await;
-        ev
+    /// Snapshot of every pending gate in this partition across all
+    /// reachable nodes. Useful for assertions like "no replica is
+    /// parked after teardown".
+    pub async fn list_pending(&mut self) -> Vec<ApprovalEvent> {
+        let mut out = Vec::new();
+        let mut to_invalidate = Vec::new();
+        let pid = self.partition_id.clone();
+        for (i, client) in self.cluster.iter_connected_mut() {
+            match client
+                .list_pending(ListPendingRequest {
+                    partition_id: pid.clone(),
+                    replica_filter: None,
+                })
+                .await
+            {
+                Ok(r) => out.extend(r.into_inner().events),
+                Err(_) => to_invalidate.push(i),
+            }
+        }
+        for i in to_invalidate {
+            self.cluster.invalidate(i);
+        }
+        out
     }
 
-    /// Wait for the next gate of any kind, then approve with
-    /// `Decision::Proceed`. Used during teardown loops where the
-    /// caller doesn't care which gate fires next.
-    pub async fn drain_next_gate(&mut self) -> ApprovalEvent {
-        let ev = self.wait_for_any_gate().await;
-        let gate_id = ev.gate_id.clone();
-        self.approve_proceed(gate_id).await;
-        ev
+    /// Drive a fixed sequence of gates against one specific replica.
+    /// Each step polls `ListPending` with the server-side
+    /// `replica_filter` so it only matches gates from `replica_id`,
+    /// then approves with the step's decision.
+    ///
+    /// Per-replica (not partition-wide) by design: SF makes no
+    /// guarantees about cross-replica ordering once both replicas in
+    /// a partition are open, so a single tagged sequence covering
+    /// multiple replicas would bake a race into the test. To drive
+    /// two replicas concurrently, run two `drive_replica_sequence`
+    /// futures from separate `PartitionDriver`s and `tokio::join!`
+    /// them.
+    ///
+    /// Strict on kind matching — panics with actual vs. expected if
+    /// SF's lifecycle changes shape.
+    pub async fn drive_replica_sequence(
+        &mut self,
+        replica_id: i64,
+        steps: &[TestStep],
+    ) -> Vec<ApprovalEvent> {
+        let mut observed = Vec::with_capacity(steps.len());
+        for (i, step) in steps.iter().enumerate() {
+            let (node_idx, ev) = self
+                .poll_partition(Some(step.expected), &[], Some(replica_id))
+                .await;
+            let actual =
+                ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
+            assert_eq!(
+                actual, step.expected,
+                "drive_replica_sequence step {i} (replica={replica_id}): \
+                 expected {:?}, got {actual:?} (gate_id={})",
+                step.expected, ev.gate_id,
+            );
+            let target = ev
+                .target
+                .clone()
+                .expect("ApprovalEvent.target on partition-scoped poll");
+            let gate_id = ev.gate_id.clone();
+            match &step.decision {
+                TestDecision::Proceed => self.approve_proceed(node_idx, target, gate_id).await,
+                TestDecision::Fail(msg) => {
+                    self.approve_fail(node_idx, target, gate_id, msg.clone())
+                        .await
+                }
+            }
+            observed.push(ev);
+        }
+        observed
     }
 
-    /// `ListPending` filtered to this replica's partition. Useful for
-    /// "is the replica gone?" assertions after `Close` is approved.
-    pub async fn list_pending_in_partition(&mut self) -> Vec<ApprovalEvent> {
-        let partition_id = self.target.partition_id.clone();
-        self.client()
-            .list_pending(ListPendingRequest {
-                partition_id,
-                replica_filter: None,
-            })
-            .await
-            .expect("ListPending failed")
-            .into_inner()
-            .events
+    /// Convenience for the all-`Proceed` case of
+    /// [`PartitionDriver::drive_replica_sequence`].
+    pub async fn approve_replica_sequence(
+        &mut self,
+        replica_id: i64,
+        kinds: &[ApprovalKind],
+    ) -> Vec<ApprovalEvent> {
+        let steps: Vec<TestStep> = kinds
+            .iter()
+            .map(|k| TestStep::new(*k, TestDecision::Proceed))
+            .collect();
+        self.drive_replica_sequence(replica_id, &steps).await
+    }
+
+    /// Internal polling loop with combined filters. Polls
+    /// `ListPending` across every reachable node with backoff up to
+    /// [`POLL_BUDGET`].
+    async fn poll_partition(
+        &mut self,
+        kind_filter: Option<ApprovalKind>,
+        exclude_replicas: &[i64],
+        require_replica: Option<i64>,
+    ) -> (usize, ApprovalEvent) {
+        let pid = self.partition_id.clone();
+        let deadline = std::time::Instant::now() + POLL_BUDGET;
+        // Server-side replica_filter when we know the exact id.
+        let replica_filter = require_replica.map(ReplicaFilter::SpecificReplicaId);
+        loop {
+            self.cluster.ensure().await;
+            let mut to_invalidate = Vec::new();
+            for (i, client) in self.cluster.iter_connected_mut() {
+                let resp = match client
+                    .list_pending(ListPendingRequest {
+                        partition_id: pid.clone(),
+                        replica_filter,
+                    })
+                    .await
+                {
+                    Ok(r) => r,
+                    Err(_) => {
+                        to_invalidate.push(i);
+                        continue;
+                    }
+                };
+                for ev in resp.into_inner().events {
+                    if let Some(k) = kind_filter
+                        && ev.kind != k as i32
+                    {
+                        continue;
+                    }
+                    let rid = ev.target.as_ref().map(|t| t.replica_id).unwrap_or(0);
+                    if exclude_replicas.contains(&rid) {
+                        continue;
+                    }
+                    return (i, ev);
+                }
+            }
+            for i in to_invalidate {
+                self.cluster.invalidate(i);
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "no pending gate (partition={pid}, kind={kind_filter:?}, \
+                     exclude={exclude_replicas:?}, require={require_replica:?}) \
+                     within {POLL_BUDGET:?} (connected_nodes={})",
+                    self.cluster.connected_count(),
+                );
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Decision passed to [`PartitionDriver::drive_replica_sequence`]. A
+/// test-side mirror of the proto `Decision` oneof so callers don't
+/// have to import generated types.
+#[derive(Debug, Clone)]
+pub enum TestDecision {
+    Proceed,
+    Fail(String),
+}
+
+/// One entry in a [`PartitionDriver::drive_replica_sequence`] step list.
+#[derive(Debug, Clone)]
+pub struct TestStep {
+    pub expected: ApprovalKind,
+    pub decision: TestDecision,
+}
+
+impl TestStep {
+    pub fn new(expected: ApprovalKind, decision: TestDecision) -> Self {
+        Self { expected, decision }
+    }
+
+    pub fn proceed(expected: ApprovalKind) -> Self {
+        Self::new(expected, TestDecision::Proceed)
+    }
+
+    pub fn fail(expected: ApprovalKind, message: impl Into<String>) -> Self {
+        Self::new(expected, TestDecision::Fail(message.into()))
     }
 }

--- a/crates/samples/reflection/tests/concurrent_close.rs
+++ b/crates/samples/reflection/tests/concurrent_close.rs
@@ -1,0 +1,281 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Concurrent-lifecycle e2e: five single-replica services are
+//! brought up, then each is told to delete and parked at the
+//! `Close` gate so its `delete_service` task is blocked. While
+//! all five are stuck, a sixth service is created and deleted
+//! end-to-end (proving SF can interleave create/delete on
+//! unrelated partitions independent of in-flight Close approvals
+//! elsewhere). Finally the five parked Closes are released and
+//! their `delete_service` tasks are joined.
+//!
+//! Demonstrates two properties of the `ReplicaControl` plane:
+//!
+//! 1. A replica parked at `Close` does not leak across partitions
+//!    — SF can place and drive a brand-new partition's lifecycle
+//!    without waiting on the unrelated parked Closes.
+//!
+//! 2. The test driver can multiplex many partitions through a
+//!    single `Cluster` by building a fresh `PartitionDriver` per
+//!    partition (drivers borrow the cluster mutably, so they are
+//!    used one at a time; concurrent SF work continues in
+//!    background tokio tasks regardless).
+//!
+//! Same prerequisites as `control_e2e.rs`.
+
+use std::time::Duration;
+
+use mssf_core::WString;
+use mssf_core::client::FabricClient;
+use mssf_core::types::{
+    PartitionSchemeDescription, ServiceDescription, StatefulServiceDescription, Uri,
+};
+use prost::Message;
+use samples_reflection::control::ReplicaInitData;
+use samples_reflection::grpc_control::proto::{ApprovalKind, ReplicaRole as ProtoReplicaRole};
+use samples_reflection::test_cluster::{Cluster, TestStep, discover_partition_id};
+use uuid::Uuid;
+
+const APP_NAME: &str = "fabric:/ReflectionApp";
+const SERVICE_TYPE: &str = "ReflectionAppService";
+const SF_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Number of services that are parked at `Close` simultaneously.
+const STUCK_COUNT: usize = 5;
+
+/// Build a single-replica controlled service description (control=true
+/// initdata so the replica uses GrpcController and parks at every
+/// lifecycle gate).
+fn make_controlled_singleton_desc(service_name: &Uri) -> ServiceDescription {
+    let initdata = ReplicaInitData { control: true }.encode_to_vec();
+    ServiceDescription::Stateful(
+        StatefulServiceDescription::new(
+            Uri::from(APP_NAME),
+            service_name.clone(),
+            WString::from(SERVICE_TYPE),
+            PartitionSchemeDescription::Singleton,
+        )
+        .with_has_persistent_state(true)
+        .with_service_activation_mode(mssf_core::types::ServicePackageActivationMode::SharedProcess)
+        .with_min_replica_set_size(1)
+        .with_target_replica_set_size(1)
+        .with_initialization_data(initdata),
+    )
+}
+
+/// Per-stuck-service bookkeeping.
+struct StuckService {
+    name: Uri,
+    partition_id: String,
+    replica_id: i64,
+    delete_handle: tokio::task::JoinHandle<mssf_core::Result<()>>,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
+async fn five_stuck_at_close_then_create_delete_sixth() {
+    let suffix = Uuid::new_v4().simple().to_string();
+    let mut cluster = Cluster::new();
+
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+    let sm = fc.get_service_manager().clone();
+
+    // ---- Phase 1: bring up STUCK_COUNT services to Up state ----
+    //
+    // Drive each service Open + ChangeRole(Primary) sequentially.
+    // Each service's `partition_id` is discovered via the SF query
+    // manager so the per-partition driver only sees its own gates.
+    let mut up_services: Vec<(Uri, String, i64)> = Vec::with_capacity(STUCK_COUNT);
+    for i in 0..STUCK_COUNT {
+        let name_str = format!("{APP_NAME}/StuckClose_{i}_{suffix}");
+        let name = Uri::from(name_str.as_str());
+        sm.create_service(&make_controlled_singleton_desc(&name), SF_TIMEOUT, None)
+            .await
+            .unwrap_or_else(|e| panic!("create_service[{i}] failed: {e}"));
+        tracing::info!("svc[{i}] created: {name_str}");
+
+        let pid = discover_partition_id(&fc, &name).await;
+        let mut driver = cluster.partition_driver(pid.clone());
+        let (n, open_ev) = driver.wait_next_kind(ApprovalKind::ApprovalOpen).await;
+        let target = open_ev.target.clone().expect("ApprovalEvent.target");
+        let rid = target.replica_id;
+        tracing::info!("svc[{i}] OPEN node #{n} partition={pid} replica={rid}");
+
+        driver
+            .approve_proceed(n, target, open_ev.gate_id.clone())
+            .await;
+        let cr = driver
+            .approve_replica_sequence(rid, &[ApprovalKind::ApprovalChangeRole])
+            .await;
+        assert_eq!(
+            cr[0].new_role,
+            ProtoReplicaRole::Primary as i32,
+            "svc[{i}]: first ChangeRole should be Primary, got new_role={}",
+            cr[0].new_role,
+        );
+        tracing::info!("svc[{i}] -> Primary; replica is Up");
+
+        up_services.push((name, pid, rid));
+    }
+
+    // ---- Phase 2: trigger delete on all five and park each at Close ----
+    //
+    // For each service: spawn `delete_service`, then approve the
+    // ChangeRole(None) that SF emits, then wait for the Close gate to
+    // appear *without* approving it. The replica stays parked and the
+    // background `delete_service` task stays blocked on that Close.
+    let mut stuck: Vec<StuckService> = Vec::with_capacity(STUCK_COUNT);
+    for (i, (name, pid, rid)) in up_services.iter().enumerate() {
+        let delete_handle = {
+            let sm2 = sm.clone();
+            let svc = name.clone();
+            tokio::spawn(async move { sm2.delete_service(&svc, SF_TIMEOUT, None).await })
+        };
+
+        let mut driver = cluster.partition_driver(pid.clone());
+
+        // Approve ChangeRole(None) — SF then issues Close.
+        let cr_none = driver
+            .approve_replica_sequence(*rid, &[ApprovalKind::ApprovalChangeRole])
+            .await;
+        assert_eq!(
+            cr_none[0].new_role,
+            ProtoReplicaRole::None as i32,
+            "svc[{i}]: teardown ChangeRole new_role should be None, got {}",
+            cr_none[0].new_role,
+        );
+
+        // Confirm Close has been emitted (it stays parked because we
+        // never approve it). `wait_for_replica` returns as soon as
+        // the gate is observed — no approval is sent.
+        let (_, close_ev) = driver
+            .wait_for_replica(*rid, Some(ApprovalKind::ApprovalClose))
+            .await;
+        tracing::info!(
+            "svc[{i}] parked at Close gate_id={} (delete_service blocked)",
+            close_ev.gate_id,
+        );
+
+        stuck.push(StuckService {
+            name: name.clone(),
+            partition_id: pid.clone(),
+            replica_id: *rid,
+            delete_handle,
+        });
+    }
+
+    // Sanity: every delete task should still be blocked.
+    for (i, s) in stuck.iter().enumerate() {
+        assert!(
+            !s.delete_handle.is_finished(),
+            "delete_service[{i}] for {} should still be blocked on Close approval",
+            s.name,
+        );
+    }
+
+    // ---- Phase 3: while five are stuck, create+delete a sixth ----
+    let sixth_name_str = format!("{APP_NAME}/StuckClose_six_{suffix}");
+    let sixth_name = Uri::from(sixth_name_str.as_str());
+    sm.create_service(
+        &make_controlled_singleton_desc(&sixth_name),
+        SF_TIMEOUT,
+        None,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("create_service[6th] failed: {e}"));
+    tracing::info!("6th service created: {sixth_name_str}");
+
+    // Discover the 6th's partition_id by service name and scope the
+    // driver to it. This is necessary because the five stuck
+    // services still have *Close* gates pending in their own
+    // partitions and we don't want to confuse them with the 6th's
+    // gates (and protects against parallel test runs too).
+    let sixth_pid = discover_partition_id(&fc, &sixth_name).await;
+    assert!(
+        !stuck.iter().any(|s| s.partition_id == sixth_pid),
+        "6th partition_id {sixth_pid} unexpectedly matched a stuck service"
+    );
+    let mut sixth_driver = cluster.partition_driver(sixth_pid.clone());
+    let (n_six, sixth_open) = sixth_driver
+        .wait_next_kind(ApprovalKind::ApprovalOpen)
+        .await;
+    let sixth_target = sixth_open.target.clone().expect("ApprovalEvent.target");
+    let sixth_rid = sixth_target.replica_id;
+    tracing::info!("6th OPEN node #{n_six} partition={sixth_pid} replica={sixth_rid}");
+
+    sixth_driver
+        .approve_proceed(n_six, sixth_target, sixth_open.gate_id.clone())
+        .await;
+    let sixth_cr = sixth_driver
+        .approve_replica_sequence(sixth_rid, &[ApprovalKind::ApprovalChangeRole])
+        .await;
+    assert_eq!(
+        sixth_cr[0].new_role,
+        ProtoReplicaRole::Primary as i32,
+        "6th: first ChangeRole should be Primary, got new_role={}",
+        sixth_cr[0].new_role,
+    );
+
+    // Delete the 6th end-to-end. Its delete_service must complete
+    // while the five stuck Closes are still pending.
+    let sixth_delete = {
+        let sm2 = sm.clone();
+        let svc = sixth_name.clone();
+        tokio::spawn(async move { sm2.delete_service(&svc, SF_TIMEOUT, None).await })
+    };
+    sixth_driver
+        .drive_replica_sequence(
+            sixth_rid,
+            &[
+                TestStep::proceed(ApprovalKind::ApprovalChangeRole),
+                TestStep::proceed(ApprovalKind::ApprovalClose),
+            ],
+        )
+        .await;
+    sixth_delete
+        .await
+        .expect("6th delete task panicked")
+        .expect("6th delete_service failed");
+    tracing::info!("6th service deleted while {STUCK_COUNT} are still stuck at Close");
+
+    // Sanity: the five stuck deletes are *still* blocked. The 6th's
+    // lifecycle did not accidentally wake them.
+    for (i, s) in stuck.iter().enumerate() {
+        assert!(
+            !s.delete_handle.is_finished(),
+            "stuck delete[{i}] for {} unexpectedly finished after 6th delete",
+            s.name,
+        );
+    }
+
+    // ---- Phase 4: release all five parked Close gates ----
+    //
+    // Approve each Close in turn (driving via `drive_replica_sequence`
+    // so the kind is asserted) and join the corresponding delete
+    // task. After this phase the cluster is back to its pre-test
+    // state for these services.
+    for (i, s) in stuck.into_iter().enumerate() {
+        let mut driver = cluster.partition_driver(s.partition_id.clone());
+        driver
+            .drive_replica_sequence(
+                s.replica_id,
+                &[TestStep::proceed(ApprovalKind::ApprovalClose)],
+            )
+            .await;
+        s.delete_handle
+            .await
+            .unwrap_or_else(|e| panic!("stuck delete[{i}] task panicked: {e}"))
+            .unwrap_or_else(|e| panic!("stuck delete[{i}] failed: {e}"));
+        tracing::info!("svc[{i}] {} fully deleted", s.name);
+    }
+
+    tracing::info!(
+        "concurrent-close e2e complete: {STUCK_COUNT} parked-then-released, plus 1 in-between"
+    );
+}

--- a/crates/samples/reflection/tests/control_e2e.rs
+++ b/crates/samples/reflection/tests/control_e2e.rs
@@ -26,8 +26,8 @@ use mssf_core::types::{
 };
 use prost::Message;
 use samples_reflection::control::ReplicaInitData;
-use samples_reflection::grpc_control::proto::ApprovalKind;
-use samples_reflection::test_cluster::Cluster;
+use samples_reflection::grpc_control::proto::{ApprovalKind, ReplicaRole as ProtoReplicaRole};
+use samples_reflection::test_cluster::{Cluster, TestStep, discover_partition_id};
 use uuid::Uuid;
 
 const APP_NAME: &str = "fabric:/ReflectionApp";
@@ -78,28 +78,35 @@ async fn approve_open_change_role_close_singleton_replica() {
         .expect("create_service failed");
     tracing::info!("service created; waiting for OPEN gate to appear");
 
-    // Wait for OPEN to learn (node, target). Then bind a ReplicaClient
-    // that owns those for the rest of the test.
-    let (node_idx, open_ev) = cluster
-        .poll_for_pending(Some(ApprovalKind::ApprovalOpen))
-        .await;
+    // Discover the partition_id for this specific service via the SF
+    // query manager rather than relying on cluster-wide polling. That
+    // way we don't accidentally pick up an OPEN gate belonging to a
+    // sibling test running on the same cluster.
+    let partition_id = discover_partition_id(&fc, &service_name).await;
+    tracing::info!("partition_id={partition_id}");
+
+    let mut driver = cluster.partition_driver(partition_id);
+    let (node_idx, open_ev) = driver.wait_next_kind(ApprovalKind::ApprovalOpen).await;
     let target = open_ev.target.clone().expect("ApprovalEvent.target");
+    let replica_id = target.replica_id;
     tracing::info!(
-        "OPEN gate observed on node #{node_idx}: partition={}, replica={}, gate_id={}",
-        target.partition_id,
-        target.replica_id,
+        "OPEN gate observed on node #{node_idx}: replica={replica_id}, gate_id={}",
         open_ev.gate_id,
     );
 
-    let mut replica = cluster.replica_client(node_idx, target.clone());
-
-    // ---- Approve OPEN ----
-    replica.approve_proceed(open_ev.gate_id.clone()).await;
-
-    // ---- ChangeRole(Primary) ----
-    let cr_ev = replica
-        .observe_and_approve(ApprovalKind::ApprovalChangeRole)
+    driver
+        .approve_proceed(node_idx, target.clone(), open_ev.gate_id.clone())
         .await;
+
+    // Drive the rest of the singleton replica's lifecycle as one
+    // per-replica sequence. SF emits ChangeRole(Primary), and once
+    // the service is Up we delete it (in a background task) so SF
+    // emits ChangeRole(None) -> Close. The Approve for Close is
+    // what unblocks the delete task.
+    let observed = driver
+        .approve_replica_sequence(replica_id, &[ApprovalKind::ApprovalChangeRole])
+        .await;
+    let cr_ev = &observed[0];
     tracing::info!(
         "CHANGE_ROLE gate observed: new_role={}, gate_id={}",
         cr_ev.new_role,
@@ -117,20 +124,23 @@ async fn approve_open_change_role_close_singleton_replica() {
         tokio::spawn(async move { sm.delete_service(&svc_name, SF_TIMEOUT, None).await })
     };
 
-    // ---- Teardown: drain change_role(None) (if any) then Close ----
-    // SF may issue any number of change_role gates before close (e.g.
-    // demoting Primary -> None). Approve them all; stop after Close.
-    loop {
-        let ev = replica.drain_next_gate().await;
+    // Teardown sequence for the same replica: ChangeRole(None) then Close.
+    let teardown = driver
+        .drive_replica_sequence(
+            replica_id,
+            &[
+                TestStep::proceed(ApprovalKind::ApprovalChangeRole),
+                TestStep::proceed(ApprovalKind::ApprovalClose),
+            ],
+        )
+        .await;
+    for ev in &teardown {
         let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
         tracing::info!(
             "teardown gate observed: kind={kind:?}, new_role={}, gate_id={}",
             ev.new_role,
             ev.gate_id,
         );
-        if matches!(kind, ApprovalKind::ApprovalClose) {
-            break;
-        }
     }
 
     delete_handle
@@ -139,15 +149,182 @@ async fn approve_open_change_role_close_singleton_replica() {
         .expect("delete_service failed");
 
     // After close completes the registry entry is gone. A follow-up
-    // ListPending should not show the replica.
+    // ListPending in the partition should not show the replica.
     tracing::info!("verifying replica is removed from registry");
-    let probe = replica.list_pending_in_partition().await;
+    let probe = driver.list_pending().await;
     assert!(
         probe
             .iter()
-            .all(|ev| ev.target.as_ref().map(|t| t.replica_id) != Some(target.replica_id)),
+            .all(|ev| ev.target.as_ref().map(|t| t.replica_id) != Some(replica_id)),
         "replica still appears in ListPending after Close approval: {probe:?}"
     );
 
     tracing::info!("e2e flow complete");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
+async fn approve_open_change_role_close_two_replicas() {
+    // Two-replica happy path: target=2, min=2.
+    //
+    // SF activation order is **not** uniform across platforms:
+    // - On Linux onebox SF tends to be strictly serial (primary
+    //   reaches stable role before the secondary's Open is even
+    //   created), so the first OPEN observed is always the primary.
+    // - On Windows onebox SF can interleave: it places both
+    //   replicas first, then issues ChangeRole — which means the
+    //   *first* OPEN may belong to the replica that ends up as
+    //   IdleSecondary.
+    //
+    // Rather than encode that platform difference, the test:
+    //   1. Discovers the partition via the SF query manager.
+    //   2. Drains every gate within the partition, approving each.
+    //   3. Identifies which replica is primary / secondary by the
+    //      `new_role` on its ChangeRole event, not by ordering.
+    //   4. Stops once a Primary and an ActiveSecondary have been
+    //      observed.
+    // Then teardown drives the deterministic `ChangeRole(None) ->
+    // Close` per replica via the server-side `replica_filter`.
+
+    let svc_suffix = Uuid::new_v4().simple().to_string();
+    let service_name_str = format!("{APP_NAME}/ApprovalE2eTwo_{svc_suffix}");
+    let service_name = Uri::from(service_name_str.as_str());
+
+    let mut cluster = Cluster::new();
+
+    let initdata = ReplicaInitData { control: true }.encode_to_vec();
+    let desc = ServiceDescription::Stateful(
+        StatefulServiceDescription::new(
+            Uri::from(APP_NAME),
+            service_name.clone(),
+            WString::from(SERVICE_TYPE),
+            PartitionSchemeDescription::Singleton,
+        )
+        .with_has_persistent_state(true)
+        .with_service_activation_mode(mssf_core::types::ServicePackageActivationMode::SharedProcess)
+        .with_min_replica_set_size(2)
+        .with_target_replica_set_size(2)
+        .with_initialization_data(initdata),
+    );
+
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+
+    fc.get_service_manager()
+        .create_service(&desc, SF_TIMEOUT, None)
+        .await
+        .expect("create_service failed");
+    tracing::info!("service {service_name_str} created (target=2 min=2)");
+
+    let partition_id = discover_partition_id(&fc, &service_name).await;
+    tracing::info!("partition_id={partition_id}");
+    let mut driver = cluster.partition_driver(partition_id);
+
+    // ---- Activation drain ----
+    //
+    // Approve every gate the partition emits, classifying each
+    // ChangeRole's `new_role`. Stop once one replica has reached
+    // Primary and another has reached ActiveSecondary.
+    let mut primary_id: Option<i64> = None;
+    let mut secondary_id: Option<i64> = None;
+    let mut seen_replicas: Vec<i64> = Vec::new();
+
+    while primary_id.is_none() || secondary_id.is_none() {
+        let (n, ev) = driver.wait_next().await;
+        let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
+        let target = ev.target.clone().expect("ApprovalEvent.target");
+        let rid = target.replica_id;
+
+        if !seen_replicas.contains(&rid) {
+            seen_replicas.push(rid);
+            tracing::info!("discovered replica={rid} on node #{n} via {kind:?}");
+        }
+
+        if kind == ApprovalKind::ApprovalChangeRole {
+            if ev.new_role == ProtoReplicaRole::Primary as i32 {
+                primary_id = Some(rid);
+                tracing::info!("replica {rid} -> Primary (gate_id={})", ev.gate_id);
+            } else if ev.new_role == ProtoReplicaRole::ActiveSecondary as i32 {
+                secondary_id = Some(rid);
+                tracing::info!("replica {rid} -> ActiveSecondary (gate_id={})", ev.gate_id);
+            } else {
+                tracing::info!(
+                    "replica {rid} ChangeRole intermediate new_role={} gate_id={}",
+                    ev.new_role,
+                    ev.gate_id,
+                );
+            }
+        }
+
+        driver.approve_proceed(n, target, ev.gate_id.clone()).await;
+    }
+
+    let primary = primary_id.expect("Primary replica observed");
+    let secondary = secondary_id.expect("ActiveSecondary replica observed");
+    assert_ne!(primary, secondary, "primary and secondary must differ");
+    assert_eq!(
+        seen_replicas.len(),
+        2,
+        "expected exactly 2 replica IDs across activation, got {seen_replicas:?}",
+    );
+    tracing::info!("activation done; primary={primary} secondary={secondary}");
+
+    // ---- Teardown ----
+    //
+    // Delete the service in the background; SF will drive both
+    // replicas through ChangeRole(None) -> Close. Each per-replica
+    // sequence uses server-side `replica_filter`, so call order is
+    // independent of SF's actual close ordering.
+    tracing::info!("deleting service to trigger teardown gates");
+    let delete_handle = {
+        let sm = fc.get_service_manager().clone();
+        let svc = service_name.clone();
+        tokio::spawn(async move { sm.delete_service(&svc, SF_TIMEOUT, None).await })
+    };
+
+    let teardown_steps = [
+        TestStep::proceed(ApprovalKind::ApprovalChangeRole),
+        TestStep::proceed(ApprovalKind::ApprovalClose),
+    ];
+
+    let primary_teardown = driver
+        .drive_replica_sequence(primary, &teardown_steps)
+        .await;
+    assert_eq!(
+        primary_teardown[0].new_role,
+        ProtoReplicaRole::None as i32,
+        "primary teardown ChangeRole new_role should be None, got {}",
+        primary_teardown[0].new_role,
+    );
+    tracing::info!("primary {primary} teardown done");
+
+    let secondary_teardown = driver
+        .drive_replica_sequence(secondary, &teardown_steps)
+        .await;
+    assert_eq!(
+        secondary_teardown[0].new_role,
+        ProtoReplicaRole::None as i32,
+        "secondary teardown ChangeRole new_role should be None, got {}",
+        secondary_teardown[0].new_role,
+    );
+    tracing::info!("secondary {secondary} teardown done");
+
+    delete_handle
+        .await
+        .expect("delete_service task panicked")
+        .expect("delete_service failed");
+
+    // After both Closes the partition's registry is empty.
+    let probe = driver.list_pending().await;
+    assert!(
+        probe.iter().all(|ev| {
+            let rid = ev.target.as_ref().map(|t| t.replica_id);
+            rid != Some(primary) && rid != Some(secondary)
+        }),
+        "replica still pending after Close: {probe:?}"
+    );
+
+    tracing::info!("two-replica e2e flow complete");
 }

--- a/crates/samples/reflection/tests/fail_change_role.rs
+++ b/crates/samples/reflection/tests/fail_change_role.rs
@@ -19,19 +19,19 @@
 //!     SF -> change_role(Primary)  Approve(Fail("..."))
 //!     SF -> abort()          Approve(Proceed)   // tear down the failed replica
 //!     [~15 s back-off]
-//!     SF -> open()           Approve(Proceed)   // SAME replica_id, fresh activation
+//!     SF -> open()           Approve(Proceed)   // fresh activation, possibly new replica_id / node
 //!     SF -> change_role(Primary)  Approve(Proceed)   // service is now Up
 //! ```
 //!
 //! Two non-obvious points:
 //!
-//! 1. **`replica_id` is preserved across the failure.** SF reuses the
-//!    same replica id for the recovery activation rather than minting
-//!    a new one. We discovered this by logging `target.replica_id`
-//!    on every gate — the first OPEN and the second OPEN see the
-//!    *same* id. Polling by `partition_id` (what this test does)
-//!    works either way and is more robust against future SF
-//!    behaviour changes.
+//! 1. **`replica_id` and node placement may change across the
+//!    failure.** SF sometimes reuses the same `replica_id` and node
+//!    for the recovery activation, but not always — across runs we
+//!    have seen both same-id-same-node and new-id-different-node
+//!    outcomes. Polling by `partition_id` is therefore mandatory for
+//!    this test (the [`PartitionDriver`] used below re-discovers the
+//!    current pending replica per gate).
 //!
 //! 2. **There is a noticeable back-off (~15 s in onebox)** between
 //!    the abort approval and the second open. This is SF's internal
@@ -40,19 +40,18 @@
 //!    10-second-and-up runtime category, not sub-second.
 //!
 //! On the gRPC side, each gate gets a fresh `gate_id` UUID even
-//! though the `(partition_id, replica_id)` tuple is unchanged — the
+//! when the `(partition_id, replica_id)` tuple is unchanged — the
 //! controller mints a new id every time `await_approval` populates
-//! `pending`. So a test holding a stale `gate_id` from before the
+//! `pending`. A test holding a stale `gate_id` from before the
 //! failure cannot misroute an `Approve` to the recovery gate.
 //!
 //! ## Discovery strategy
 //!
-//! Polls by `partition_id` rather than `replica_id`. Even though SF
-//! happens to reuse the replica_id in our case, polling by partition
-//! also works for any future variation where SF rebuilds with a fresh
-//! id, and it lets parallel tests in the same cluster operate with
-//! clean isolation by scoping each test's polling to its own
-//! partition.
+//! Polls by `partition_id` rather than `replica_id`. The partition
+//! is stable for the service's lifetime; the replica may be rebuilt
+//! one or more times during the recovery sequence. Each test's
+//! `partition_id` also keeps it isolated from any parallel test runs
+//! in the same cluster.
 //!
 //! Same prerequisites as `control_e2e.rs`.
 
@@ -66,7 +65,7 @@ use mssf_core::types::{
 use prost::Message;
 use samples_reflection::control::ReplicaInitData;
 use samples_reflection::grpc_control::proto::ApprovalKind;
-use samples_reflection::test_cluster::Cluster;
+use samples_reflection::test_cluster::{Cluster, TestStep, discover_partition_id};
 use uuid::Uuid;
 
 const APP_NAME: &str = "fabric:/ReflectionApp";
@@ -110,147 +109,75 @@ async fn fail_change_role_then_approve_retry() {
         .expect("create_service failed");
     tracing::info!("service {service_name_str} created");
 
-    // Wait for the first OPEN to learn our partition_id. From this
-    // point on we poll only within this partition so parallel tests
-    // can't see each other's gates.
-    let (mut n, first_ev) = cluster
-        .poll_for_pending(Some(ApprovalKind::ApprovalOpen))
-        .await;
-    let partition_id = first_ev
-        .target
-        .as_ref()
-        .expect("ApprovalEvent.target")
-        .partition_id
-        .clone();
-    tracing::info!("OPEN observed; partition_id={partition_id}");
+    // Discover this service's partition_id via the SF query manager
+    // so the test only sees gates from its own partition (avoids
+    // cross-test pollution when integration tests run in parallel).
+    let partition_id = discover_partition_id(&fc, &service_name).await;
+    tracing::info!("partition_id={partition_id}");
+    let mut driver = cluster.partition_driver(partition_id);
 
-    // Drive the first OPEN through the same loop used for everything
-    // else by feeding it as if poll_for_pending_in_partition had just
-    // returned it. After this initial seed, every subsequent gate is
-    // discovered by polling within the partition.
-    let mut next: Option<(
-        usize,
-        samples_reflection::grpc_control::proto::ApprovalEvent,
-    )> = Some((n, first_ev));
-
-    let mut open_count = 0usize;
-    let mut change_role_count = 0usize;
-    let mut abort_count = 0usize;
-
-    loop {
-        let (node_idx, ev) = match next.take() {
-            Some(pair) => pair,
-            None => {
-                cluster
-                    .poll_for_pending_in_partition(&partition_id, None)
-                    .await
-            }
-        };
-        n = node_idx;
-        let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
-        let target = ev.target.clone().expect("ApprovalEvent.target");
-
-        match kind {
-            ApprovalKind::ApprovalOpen => {
-                // Two cases observed in practice:
-                //   open #1: the initial replica activation
-                //   open #2: SF re-activating the SAME replica_id
-                //            after the failed change_role + abort
-                open_count += 1;
-                tracing::info!(
-                    "OPEN #{open_count} replica={} gate_id={} -> approving",
-                    target.replica_id,
-                    ev.gate_id,
-                );
-                cluster
-                    .replica_client(n, target)
-                    .approve_proceed(ev.gate_id)
-                    .await;
-            }
-            ApprovalKind::ApprovalChangeRole => {
-                // First change_role: inject a Fail to trigger SF's
-                // recovery path. Second change_role (after the abort
-                // + reopen): approve so the service comes up.
-                change_role_count += 1;
-                if change_role_count == 1 {
-                    tracing::info!(
-                        "CHANGE_ROLE #1 replica={} gate_id={} -> failing",
-                        target.replica_id,
-                        ev.gate_id,
-                    );
-                    cluster
-                        .replica_client(n, target)
-                        .approve_fail(ev.gate_id, "test-induced ChangeRole failure".to_string())
-                        .await;
-                } else {
-                    tracing::info!(
-                        "CHANGE_ROLE #{change_role_count} replica={} gate_id={} -> approving",
-                        target.replica_id,
-                        ev.gate_id,
-                    );
-                    cluster
-                        .replica_client(n, target)
-                        .approve_proceed(ev.gate_id)
-                        .await;
-                    break;
-                }
-            }
-            ApprovalKind::ApprovalAbort => {
-                // SF aborts the failed replica before re-opening it.
-                // Approve immediately so SF can move on; the
-                // ~15s back-off before the second OPEN happens
-                // entirely on SF's side after this approval returns.
-                abort_count += 1;
-                tracing::info!(
-                    "ABORT #{abort_count} replica={} gate_id={} -> approving (recovery)",
-                    target.replica_id,
-                    ev.gate_id,
-                );
-                cluster
-                    .replica_client(n, target)
-                    .approve_proceed(ev.gate_id)
-                    .await;
-            }
-            ApprovalKind::ApprovalClose => {
-                // Not expected on the recovery path — SF prefers
-                // abort over close after a lifecycle failure — but
-                // approve defensively if it ever shows up so the
-                // test doesn't deadlock.
-                tracing::info!(
-                    "CLOSE replica={} gate_id={} -> approving (unexpected before retry but ok)",
-                    target.replica_id,
-                    ev.gate_id,
-                );
-                cluster
-                    .replica_client(n, target)
-                    .approve_proceed(ev.gate_id)
-                    .await;
-            }
-            ApprovalKind::ApprovalUnspecified => {
-                panic!("ApprovalKind::ApprovalUnspecified observed: {ev:?}");
-            }
-        }
-    }
-
+    // First OPEN within this partition: scoped poll, no risk of
+    // hijacking another test's gate.
+    let (node_idx, first_open) = driver.wait_next_kind(ApprovalKind::ApprovalOpen).await;
+    let first_target = first_open.target.clone().expect("ApprovalEvent.target");
+    let r1_id = first_target.replica_id;
     tracing::info!(
-        "recovery summary: open={open_count}, change_role={change_role_count}, abort={abort_count}"
-    );
-    assert!(
-        change_role_count >= 2,
-        "expected SF to issue at least 2 CHANGE_ROLE gates; saw {change_role_count}"
-    );
-    assert!(
-        abort_count >= 1,
-        "expected SF to abort the failed replica at least once; saw {abort_count}"
+        "OPEN #1 observed on node #{node_idx} replica={r1_id} gate_id={}",
+        first_open.gate_id,
     );
 
-    // Teardown: delete the service and drain remaining gates in this
-    // partition until Close is approved.
-    //
-    // For a normal happy-path teardown SF issues:
-    //   change_role(None)   // demote primary
-    //   close()
-    // The test approves both with Proceed and exits when Close fires.
+    driver
+        .approve_proceed(node_idx, first_target, first_open.gate_id.clone())
+        .await;
+
+    // First-replica failure sequence: ChangeRole(fail) -> Abort.
+    // Pinned to r1_id so SF's recovery activation cannot be confused
+    // with the original replica's gates.
+    let r1_failure = driver
+        .drive_replica_sequence(
+            r1_id,
+            &[
+                TestStep::fail(
+                    ApprovalKind::ApprovalChangeRole,
+                    "test-induced ChangeRole failure",
+                ),
+                TestStep::proceed(ApprovalKind::ApprovalAbort),
+            ],
+        )
+        .await;
+    tracing::info!(
+        "replica {r1_id} failure sequence done: {} gates",
+        r1_failure.len(),
+    );
+
+    // Recovery: SF re-activates with a fresh `replica_id` (and
+    // possibly a different node) after a back-off (~15 s in onebox).
+    // Discover that new replica via a partition-wide wait, then drive
+    // its happy-path lifecycle.
+    let (n2, second_open) = driver.wait_next_kind(ApprovalKind::ApprovalOpen).await;
+    let second_target = second_open.target.clone().expect("ApprovalEvent.target");
+    let r2_id = second_target.replica_id;
+    tracing::info!(
+        "OPEN #2 observed on node #{n2} replica={r2_id} gate_id={} (previously r1={r1_id})",
+        second_open.gate_id,
+    );
+    driver
+        .approve_proceed(n2, second_target, second_open.gate_id.clone())
+        .await;
+
+    // Recovery replica: ChangeRole(Primary) -> service is Up.
+    let r2_up = driver
+        .approve_replica_sequence(r2_id, &[ApprovalKind::ApprovalChangeRole])
+        .await;
+    tracing::info!(
+        "replica {r2_id} ChangeRole done: new_role={}, gate_id={}",
+        r2_up[0].new_role,
+        r2_up[0].gate_id,
+    );
+
+    // Teardown: delete the service and drive r2's shutdown sequence
+    // (ChangeRole(None) -> Close). The Approve for Close unblocks
+    // the background delete task.
     tracing::info!("deleting service to trigger teardown gates");
     let delete_handle = {
         let sm = fc.get_service_manager().clone();
@@ -258,24 +185,21 @@ async fn fail_change_role_then_approve_retry() {
         tokio::spawn(async move { sm.delete_service(&svc, SF_TIMEOUT, None).await })
     };
 
-    loop {
-        let (n, ev) = cluster
-            .poll_for_pending_in_partition(&partition_id, None)
-            .await;
+    let teardown = driver
+        .drive_replica_sequence(
+            r2_id,
+            &[
+                TestStep::proceed(ApprovalKind::ApprovalChangeRole),
+                TestStep::proceed(ApprovalKind::ApprovalClose),
+            ],
+        )
+        .await;
+    for ev in &teardown {
         let kind = ApprovalKind::try_from(ev.kind).unwrap_or(ApprovalKind::ApprovalUnspecified);
-        let target = ev.target.clone().expect("ApprovalEvent.target");
         tracing::info!(
-            "teardown gate kind={kind:?} replica={} gate_id={}",
-            target.replica_id,
+            "teardown gate kind={kind:?} replica={r2_id} gate_id={}",
             ev.gate_id,
         );
-        cluster
-            .replica_client(n, target)
-            .approve_proceed(ev.gate_id)
-            .await;
-        if matches!(kind, ApprovalKind::ApprovalClose) {
-            break;
-        }
     }
 
     delete_handle


### PR DESCRIPTION
Using the reflection app callback approval framework, creates 5 services and delete them and make them stuck at replica close call. In the meantime, create and delete a new service.
This ensures stuck services does not block SF's ability to operate on new services.