### PR TITLE
feat: tonic connector failover middleware + reflection app adoption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,9 +834,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "mssf-util",
+ "prost",
  "tokio",
  "tokio-util",
  "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
 ]
 
@@ -1170,6 +1173,7 @@ name = "samples_reflection"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "http",
  "mssf-core",
  "mssf-util",
  "prost",

--- a/crates/libs/util/src/tonic/middleware.rs
+++ b/crates/libs/util/src/tonic/middleware.rs
@@ -3,8 +3,25 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-//! Trailer-aware middleware: inspects gRPC response trailers and
-//! triggers a non-blocking rebuild on the configured header.
+//! Status-aware middleware: inspects the configured header on
+//! gRPC responses and triggers a non-blocking rebuild when it
+//! appears. The header is inspected on **both** the initial
+//! response `HeaderMap` *and* any trailers frame in the body,
+//! because tonic's wire placement of user metadata differs by
+//! call shape:
+//!
+//! | Call shape                         | Where the header lands       |
+//! |------------------------------------|------------------------------|
+//! | Unary `Ok` + `metadata_mut()`      | Initial HEADERS frame        |
+//! | Unary `Err(Status::with_metadata)` | Trailers-only HEADERS frame  |
+//! | Streaming `Ok` + initial metadata  | Initial HEADERS frame        |
+//! | Streaming yielding `Err(Status..)` | Real HTTP/2 trailers frame   |
+//!
+//! Both wire locations surface to a Tower service as either
+//! `response.headers()` (the first three rows) or as a
+//! body-level `Frame::trailers()` (the last row). We classify
+//! whichever fires first and short-circuit the other; at most
+//! one rebuild signal is consumed per response.
 //!
 //! Lives **above** `SwapChannel` in the tower stack. The dedup
 //! state machine is documented in
@@ -20,19 +37,20 @@ use http_body::Frame;
 use tonic::body::Body;
 use tower::Service;
 
-/// Inspects gRPC response trailers; on the configured trailer
-/// header triggers a non-blocking rebuild of the inner Channel
-/// via the supplied rebuild handle.
+/// Inspects gRPC response headers and trailers; on the
+/// configured header (whichever surface it arrives on)
+/// triggers a non-blocking rebuild of the inner Channel via the
+/// supplied rebuild handle.
 ///
-/// Stateful for dedup: tracks the last trailer value observed
+/// Stateful for dedup: tracks the last header value observed
 /// and only triggers `rebuild()` when the value differs (with
-/// two special signals — absent trailer resets state, empty
+/// two special signals — absent header resets state, empty
 /// value always rebuilds without affecting state).
 ///
 /// **Concurrency.** The dedup decision
 /// (load → classify → store) is serialized under a
 /// `std::sync::Mutex`, so concurrent in-flight RPCs that
-/// complete with the **same** trailer value collapse to one
+/// complete with the **same** header value collapse to one
 /// `rebuild()` call. Distinct values still produce one rebuild
 /// each. The mutex is held only across the decision; the
 /// rebuild closure runs outside the lock so back-to-back
@@ -68,16 +86,16 @@ impl<S> ResolveStatusMiddleware<S> {
 /// tests trivial.
 #[derive(Debug, PartialEq, Eq)]
 enum DedupAction {
-    /// No-op; trailer absent and `last_seen` already `None`, or
-    /// trailer matched `last_seen`.
+    /// No-op; header absent and `last_seen` already `None`, or
+    /// header matched `last_seen`.
     None,
-    /// Trailer present (non-empty) with a value differing from
+    /// Header present (non-empty) with a value differing from
     /// `last_seen`; store it and rebuild.
     StoreAndRebuild(String),
-    /// Trailer present with empty value; rebuild without
+    /// Header present with empty value; rebuild without
     /// touching `last_seen`.
     RebuildKeepLast,
-    /// No trailer on the response; reset `last_seen` to `None`,
+    /// No header on the response; reset `last_seen` to `None`,
     /// no rebuild.
     Reset,
 }
@@ -98,6 +116,56 @@ fn classify(observed: Option<&str>, last_seen: Option<&str>) -> DedupAction {
             Some(prev) if prev == v => DedupAction::None,
             _ => DedupAction::StoreAndRebuild(v.to_string()),
         },
+    }
+}
+
+/// Single-shot dedup-and-rebuild. Loads `last_seen`, classifies
+/// `observed`, updates state, and (outside the lock) invokes
+/// `rebuild` if the decision called for it. Shared by the
+/// initial-headers path (in `call()`) and the trailers/EOS path
+/// (in `TrailerObserver::fire`).
+///
+/// Emits a single `tracing::info!` per actual rebuild, carrying
+/// the value that triggered it, the previous `last_seen` value
+/// (so a prod operator can tell first-ever-signal apart from
+/// failover-after-failover), and the dedup decision variant.
+/// Skipped decisions (no-op, reset) are not logged at info
+/// level to keep the channel quiet in steady state.
+fn apply_dedup(
+    observed: Option<&str>,
+    last_seen: &Mutex<Option<String>>,
+    rebuild: &(dyn Fn() + Send + Sync),
+) {
+    // Capture `prev` and the chosen action inside the lock so
+    // the trace below has accurate context; the `rebuild()`
+    // closure itself runs outside the lock (it does its own
+    // lazy reconnect work and shouldn't be serialized).
+    let (action, prev, should_rebuild) = {
+        let mut guard = last_seen.lock().expect("middleware mutex poisoned");
+        let prev: Option<String> = guard.clone();
+        let action = classify(observed, prev.as_deref());
+        let should_rebuild = match &action {
+            DedupAction::None => false,
+            DedupAction::Reset => {
+                *guard = None;
+                false
+            }
+            DedupAction::RebuildKeepLast => true,
+            DedupAction::StoreAndRebuild(v) => {
+                *guard = Some(v.clone());
+                true
+            }
+        };
+        (action, prev, should_rebuild)
+    };
+    if should_rebuild {
+        tracing::info!(
+            observed = observed.unwrap_or("<absent>"),
+            previous = prev.as_deref().unwrap_or("<none>"),
+            decision = ?action,
+            "ResolveStatusMiddleware firing channel rebuild",
+        );
+        rebuild();
     }
 }
 
@@ -131,17 +199,46 @@ where
         Box::pin(async move {
             let resp = inner.call(req).await?;
             let (parts, body) = resp.into_parts();
-            let observer = TrailerObserver::new(body, header, last_seen, rebuild);
-            let wrapped = Body::new(observer);
+            // Inspect the initial response HeaderMap first. This
+            // covers (a) unary Ok with `Response::metadata_mut()`
+            // metadata (rides on the initial HEADERS frame) and
+            // (b) unary Err via `Status::with_metadata`, which
+            // tonic emits as a gRPC "Trailers-Only" response —
+            // a single HEADERS frame with END_STREAM carrying
+            // `grpc-status` + user metadata, no DATA, no
+            // separate trailers frame. Either way the metadata
+            // surfaces on `parts.headers`.
+            //
+            // If we fire here, the body needs no observation:
+            // we've already consumed this response's at-most-one
+            // rebuild signal, so we skip wrapping it in
+            // `TrailerObserver` and let the original body flow
+            // through unchanged. That avoids one `poll_frame`
+            // indirection per body frame on the streaming hot
+            // path. Otherwise we wrap the body and let the
+            // observer watch for a trailers frame (streaming-Err
+            // path) or end-of-stream (no-signal reset).
+            let wrapped = match parts.headers.get(&header).and_then(|v| v.to_str().ok()) {
+                Some(v) => {
+                    apply_dedup(Some(v), &last_seen, &*rebuild);
+                    body
+                }
+                None => Body::new(TrailerObserver::new(body, header, last_seen, rebuild)),
+            };
             Ok(http::Response::from_parts(parts, wrapped))
         })
     }
 }
 
-/// Body wrapper that delegates `poll_frame` and inspects the
-/// final trailer frame. Apply the dedup rule before forwarding
-/// the frame downstream so the caller observes trailers
-/// unchanged.
+/// Body wrapper that delegates `poll_frame` and inspects any
+/// trailer frame the body produces. Apply the dedup rule before
+/// forwarding the frame downstream so the caller observes
+/// trailers unchanged.
+///
+/// Only installed when the initial response headers did **not**
+/// carry the configured header — if they did, `call()` fires
+/// immediately and returns the original body unwrapped (at most
+/// one rebuild signal per response).
 struct TrailerObserver {
     inner: Body,
     header: http::HeaderName,
@@ -150,9 +247,9 @@ struct TrailerObserver {
     /// Set once we observe a trailer frame; if the body ends
     /// without one we apply the "no trailer" branch.
     saw_trailers: bool,
-    /// Set once we've applied the dedup decision (either via a
-    /// trailer frame or via the end-of-stream reset). Prevents
-    /// double-firing within a single response body.
+    /// Set once we've applied the dedup decision (via a trailer
+    /// frame or the end-of-stream reset). Prevents double-firing
+    /// within a single response body.
     fired: bool,
 }
 
@@ -178,34 +275,7 @@ impl TrailerObserver {
             return;
         }
         self.fired = true;
-
-        // Hold the lock across load + classify + store so
-        // concurrent observers of the same value collapse to a
-        // single decision. Drop the guard *before* invoking the
-        // rebuild closure: rebuild does its own lazy work
-        // (connect_with_connector_lazy + ArcSwap::store) and
-        // doesn't need to be serialized; we only need the
-        // decision step itself to be atomic.
-        let should_rebuild = {
-            let mut guard = self.last_seen.lock().expect("middleware mutex poisoned");
-            let prev_str: Option<&str> = guard.as_deref();
-            let action = classify(observed, prev_str);
-            match action {
-                DedupAction::None => false,
-                DedupAction::Reset => {
-                    *guard = None;
-                    false
-                }
-                DedupAction::RebuildKeepLast => true,
-                DedupAction::StoreAndRebuild(v) => {
-                    *guard = Some(v);
-                    true
-                }
-            }
-        };
-        if should_rebuild {
-            (self.rebuild)();
-        }
+        apply_dedup(observed, &self.last_seen, &*self.rebuild);
     }
 }
 

--- a/crates/libs/util/src/tonic/naming/default.rs
+++ b/crates/libs/util/src/tonic/naming/default.rs
@@ -40,11 +40,20 @@ impl TargetResolver for FabricTargetResolver {
     fn resolve(&self) -> BoxFuture<'_, Result<DialTarget, BoxError>> {
         Box::pin(async move {
             let prev = self.cached.load_full();
+            let had_cache = prev.is_some();
             let new_rsp = self
                 .inner
                 .resolve(&self.uri, &self.key, prev.as_deref(), self.timeout, None)
                 .await
-                .map_err(|e| Box::new(e) as BoxError)?;
+                .map_err(|e| {
+                    tracing::warn!(
+                        uri = %self.uri,
+                        had_cache,
+                        error = ?e,
+                        "FabricTargetResolver: SF resolve_service_partition failed",
+                    );
+                    Box::new(e) as BoxError
+                })?;
             // Reconcile the new reply against the cache. The
             // cache only advances when SF returns a strictly
             // *newer* RSP — never moves backward to an older
@@ -55,38 +64,67 @@ impl TargetResolver for FabricTargetResolver {
             // `svc_mgmt_client.rs`: `a > b` ⇔ `a` is newer;
             // `partial_cmp == None` ⇔ different service /
             // partition (treat as a hard cache reset).
-            let rsp = match prev.as_deref() {
+            let (rsp, cache_outcome) = match prev.as_deref() {
                 Some(p) => match p.partial_cmp(&new_rsp) {
                     Some(std::cmp::Ordering::Less) => {
                         // prev < new_rsp → new_rsp is newer → advance.
                         let arc = Arc::new(new_rsp);
                         self.cached.store(Some(arc.clone()));
-                        arc
+                        (arc, "advanced")
                     }
                     Some(_) => {
                         // Equal or prev > new_rsp: keep cached
                         // Arc identity, drop new_rsp.
-                        prev.unwrap()
+                        (prev.unwrap(), "kept")
                     }
                     None => {
                         // Different service / partition: hard
                         // reset.
                         let arc = Arc::new(new_rsp);
                         self.cached.store(Some(arc.clone()));
-                        arc
+                        (arc, "hard-reset")
                     }
                 },
                 None => {
                     let arc = Arc::new(new_rsp);
                     self.cached.store(Some(arc.clone()));
-                    arc
+                    (arc, "first")
                 }
             };
             // Run the user's role-pick + address-parse closure.
-            (self.selector)(&rsp).map_err(|e| match e {
-                SelectError::NoMatch => "no matching endpoint".into(),
-                SelectError::Fatal(b) => b,
-            })
+            match (self.selector)(&rsp) {
+                Ok(target) => {
+                    tracing::info!(
+                        uri = %self.uri,
+                        had_cache,
+                        cache = cache_outcome,
+                        host = %target.host,
+                        port = target.port,
+                        "FabricTargetResolver: resolved dial target",
+                    );
+                    Ok(target)
+                }
+                Err(SelectError::NoMatch) => {
+                    tracing::warn!(
+                        uri = %self.uri,
+                        had_cache,
+                        cache = cache_outcome,
+                        endpoint_count = rsp.endpoints.len(),
+                        "FabricTargetResolver: selector found no matching endpoint",
+                    );
+                    Err("no matching endpoint".into())
+                }
+                Err(SelectError::Fatal(b)) => {
+                    tracing::warn!(
+                        uri = %self.uri,
+                        had_cache,
+                        cache = cache_outcome,
+                        error = %b,
+                        "FabricTargetResolver: selector returned fatal error",
+                    );
+                    Err(b)
+                }
+            }
         })
     }
 }

--- a/crates/libs/util/tests/tonic_middleware.rs
+++ b/crates/libs/util/tests/tonic_middleware.rs
@@ -76,14 +76,28 @@ impl http_body::Body for ScriptedBody {
     }
 }
 
-/// `Service` that returns scripted responses in order.
+/// `Service` that returns scripted responses in order. Each
+/// scripted response is a pair of optional initial headers and
+/// a body. The headers ride on `parts.headers` (covering the
+/// unary-Ok-with-metadata and unary-Err-Trailers-Only wire
+/// shapes); the body carries optional trailer frames (covering
+/// the streaming-Err-mid-stream wire shape).
+type ResponseQueue = Arc<std::sync::Mutex<std::collections::VecDeque<(Option<HeaderMap>, Body)>>>;
+
 #[derive(Clone)]
 struct ScriptedService {
-    queue: Arc<std::sync::Mutex<std::collections::VecDeque<Body>>>,
+    queue: ResponseQueue,
 }
 
 impl ScriptedService {
     fn new<I: IntoIterator<Item = Body>>(items: I) -> Self {
+        Self {
+            queue: Arc::new(std::sync::Mutex::new(
+                items.into_iter().map(|b| (None, b)).collect(),
+            )),
+        }
+    }
+    fn with_responses<I: IntoIterator<Item = (Option<HeaderMap>, Body)>>(items: I) -> Self {
         Self {
             queue: Arc::new(std::sync::Mutex::new(items.into_iter().collect())),
         }
@@ -100,13 +114,21 @@ impl Service<http::Request<Body>> for ScriptedService {
     }
 
     fn call(&mut self, _req: http::Request<Body>) -> Self::Future {
-        let body = self
+        let (headers, body) = self
             .queue
             .lock()
             .unwrap()
             .pop_front()
             .expect("script exhausted");
-        Box::pin(async move { Ok(http::Response::builder().body(body).unwrap()) })
+        Box::pin(async move {
+            let mut builder = http::Response::builder();
+            if let Some(map) = headers {
+                for (k, v) in map.iter() {
+                    builder = builder.header(k, v);
+                }
+            }
+            Ok(builder.body(body).unwrap())
+        })
     }
 }
 
@@ -128,6 +150,16 @@ async fn dispatch(svc: &mut ResolveStatusMiddleware<ScriptedService>) {
 
 fn header() -> HeaderName {
     HeaderName::from_static("mssf-status")
+}
+
+/// Construct an initial-header map carrying the configured
+/// status header with the given value — mirrors the wire
+/// position used by tonic for unary-Ok-with-metadata and
+/// unary-Err Trailers-Only responses.
+fn initial_headers(value: &str) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    map.insert(header(), HeaderValue::from_str(value).unwrap());
+    map
 }
 
 fn build(
@@ -231,6 +263,104 @@ async fn unrelated_header_does_not_trigger_rebuild() {
     let mut mw = build(svc, counter.clone());
     dispatch(&mut mw).await;
     assert_eq!(counter.count(), 0);
+}
+
+// -- Initial-headers path (unary Ok with metadata, unary Err
+// -- Trailers-Only). These cover the wire shapes that the
+// -- trailer-frame-only v1.0 middleware missed.
+
+#[tokio::test]
+async fn header_on_initial_response_triggers_rebuild() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::with_responses(vec![(
+        Some(initial_headers("not-primary")),
+        Body::new(ScriptedBody::no_trailer()),
+    )]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 1);
+}
+
+#[tokio::test]
+async fn header_on_initial_response_dedups_against_same_value() {
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::with_responses(vec![
+        (
+            Some(initial_headers("v")),
+            Body::new(ScriptedBody::no_trailer()),
+        ),
+        (
+            Some(initial_headers("v")),
+            Body::new(ScriptedBody::no_trailer()),
+        ),
+        (
+            Some(initial_headers("v")),
+            Body::new(ScriptedBody::no_trailer()),
+        ),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    for _ in 0..3 {
+        dispatch(&mut mw).await;
+    }
+    assert_eq!(counter.count(), 1);
+}
+
+#[tokio::test]
+async fn header_then_no_signal_resets_then_header_rebuilds_again() {
+    // Header -> rebuild #1; clean response -> reset; same
+    // header value -> rebuild #2 because state was reset.
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::with_responses(vec![
+        (
+            Some(initial_headers("v")),
+            Body::new(ScriptedBody::no_trailer()),
+        ),
+        (None, Body::new(ScriptedBody::no_trailer())),
+        (
+            Some(initial_headers("v")),
+            Body::new(ScriptedBody::no_trailer()),
+        ),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 2);
+}
+
+#[tokio::test]
+async fn header_and_trailer_both_present_fires_once() {
+    // Pathological belt-and-braces case: same value on both
+    // surfaces. The initial-headers path fires first; the
+    // trailer-frame observation is short-circuited.
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::with_responses(vec![(
+        Some(initial_headers("v")),
+        Body::new(ScriptedBody::with_trailer(&header(), "v")),
+    )]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 1);
+}
+
+#[tokio::test]
+async fn header_dedup_state_is_shared_with_trailer_path() {
+    // First call sets state via the initial-headers path.
+    // Second call would normally dedup against the same value,
+    // but here the value arrives on the trailers frame
+    // instead. The shared `last_seen` must dedup it.
+    let counter = RebuildCounter::default();
+    let svc = ScriptedService::with_responses(vec![
+        (
+            Some(initial_headers("v")),
+            Body::new(ScriptedBody::no_trailer()),
+        ),
+        (None, Body::new(ScriptedBody::with_trailer(&header(), "v"))),
+    ]);
+    let mut mw = build(svc, counter.clone());
+    dispatch(&mut mw).await;
+    dispatch(&mut mw).await;
+    assert_eq!(counter.count(), 1);
 }
 
 /// Concurrent dispatch with the same trailer value must collapse to

--- a/crates/samples/reflection/Cargo.toml
+++ b/crates/samples/reflection/Cargo.toml
@@ -31,7 +31,8 @@ prost.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 mssf-core = { workspace = true, default-features = true }
-mssf-util = { workspace = true, default-features = true }
+mssf-util = { workspace = true, default-features = true, features = ["tonic"] }
+http.workspace = true
 
 [build-dependencies]
 tonic-prost-build.workspace = true

--- a/crates/samples/reflection/proto/helloworld.proto
+++ b/crates/samples/reflection/proto/helloworld.proto
@@ -6,6 +6,13 @@ service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply);
   // Get all replicas, optionally filtered by partition ID
   rpc GetReplicas (GetReplicasRequest) returns (GetReplicasResponse);
+  // Role-gated write. Only succeeds on the primary replica; on
+  // secondaries the server returns `Status::unavailable` with
+  // an `mssf-status` metadata entry that the
+  // `ResolveStatusMiddleware` uses to trigger a channel rebuild.
+  // The client must set the `mssf-partition-id` request metadata
+  // header so the server can look up the right partition.
+  rpc Write (WriteRequest) returns (WriteReply);
 }
 
 message HelloRequest {
@@ -23,6 +30,17 @@ message GetReplicasRequest {
 
 message GetReplicasResponse {
   repeated ReplicaInfo replicas = 1;
+}
+
+message WriteRequest {
+  string payload = 1;
+}
+
+message WriteReply {
+  // Stringified `{partition_id:?}/{replica_id}` of the replica
+  // that handled the write. Lets the client correlate a
+  // post-failover ack with the new primary.
+  string acked_by = 1;
 }
 
 enum ReplicaRole {

--- a/crates/samples/reflection/src/grpc.rs
+++ b/crates/samples/reflection/src/grpc.rs
@@ -8,7 +8,8 @@ use std::sync::{Arc, Mutex};
 
 use tonic::{Request, Response, Status};
 
-use mssf_core::types::ReplicaRole;
+use mssf_core::runtime::IStatefulServicePartition;
+use mssf_core::types::{ReplicaRole, ServicePartitionAccessStatus};
 
 use crate::control::ReplicaController;
 
@@ -17,7 +18,23 @@ pub mod hello_world {
 }
 
 use hello_world::greeter_server::{Greeter, GreeterServer};
-use hello_world::{GetReplicasRequest, GetReplicasResponse, HelloReply, HelloRequest, ReplicaInfo};
+use hello_world::{
+    GetReplicasRequest, GetReplicasResponse, HelloReply, HelloRequest, ReplicaInfo, WriteReply,
+    WriteRequest,
+};
+
+/// Trailer/header name the SF Rust SDK uses to carry the
+/// failover signal back to the client. Mirrors the constant in
+/// `mssf_util::tonic` (kept as a `&str` here so this crate
+/// doesn't have to depend on `http` at the proto-include site).
+pub const MSSF_STATUS_TRAILER: &str = "mssf-status";
+
+/// Request metadata header the client must set so a role-gated
+/// RPC can identify which partition it's talking to. Required
+/// because a single process can host multiple partitions of the
+/// same service and the tonic handler has no other way to tell
+/// them apart.
+pub const MSSF_PARTITION_ID_HEADER: &str = "mssf-partition-id";
 
 fn replica_role_to_proto(role: ReplicaRole) -> i32 {
     match role {
@@ -44,11 +61,32 @@ pub struct ReplicaEntry {
     pub controller: Option<Arc<dyn ReplicaController>>,
 }
 
+/// Per-partition state. Bundles the list of replicas hosted in
+/// this process plus the live `IStatefulServicePartition`
+/// handle (when one of those replicas has been opened by SF).
+/// The handle is what role-gated RPCs (`Write`) consult via
+/// `partition.get_write_status()`.
+#[derive(Default)]
+struct PartitionState {
+    replicas: Vec<ReplicaEntry>,
+    /// Set by `bind_partition` (called from `Replica::open`),
+    /// cleared by `unbind_partition` (called from
+    /// `Replica::close` / `Replica::abort`). `None` means "no
+    /// live replica is currently open for this partition".
+    partition: Option<Arc<dyn IStatefulServicePartition>>,
+}
+
 /// Shared state between gRPC server and Service Fabric service factory.
 /// Keyed by partition_id.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ReplicaRegistry {
-    inner: Arc<Mutex<HashMap<mssf_core::GUID, Vec<ReplicaEntry>>>>,
+    inner: Arc<Mutex<HashMap<mssf_core::GUID, PartitionState>>>,
+}
+
+impl std::fmt::Debug for ReplicaRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplicaRegistry").finish_non_exhaustive()
+    }
 }
 
 impl ReplicaRegistry {
@@ -78,7 +116,7 @@ impl ReplicaRegistry {
         controller: Option<Arc<dyn ReplicaController>>,
     ) {
         let mut map = self.inner.lock().unwrap();
-        let entries = map.entry(partition_id).or_default();
+        let state = map.entry(partition_id).or_default();
         // SF can call Factory::create_replica again with the same
         // (partition_id, replica_id) after a failed Open or
         // change_role (the failed replica is dropped, a fresh one
@@ -93,11 +131,59 @@ impl ReplicaRegistry {
             role: ReplicaRole::Unknown,
             controller,
         };
-        if let Some(existing) = entries.iter_mut().find(|e| e.replica_id == replica_id) {
+        if let Some(existing) = state
+            .replicas
+            .iter_mut()
+            .find(|e| e.replica_id == replica_id)
+        {
             *existing = new_entry;
         } else {
-            entries.push(new_entry);
+            state.replicas.push(new_entry);
         }
+    }
+
+    /// Bind the live `IStatefulServicePartition` handle for a
+    /// partition. Called from `Replica::open` once SF has handed
+    /// us the partition; only one replica per partition is
+    /// opened on this node at a time so this overwrites any
+    /// stale prior binding (defensive — should not normally
+    /// happen).
+    pub fn bind_partition(
+        &self,
+        partition_id: mssf_core::GUID,
+        partition: Arc<dyn IStatefulServicePartition>,
+    ) {
+        let mut map = self.inner.lock().unwrap();
+        map.entry(partition_id).or_default().partition = Some(partition);
+    }
+
+    /// Clear the partition handle for `partition_id`. Called
+    /// from `Replica::close` and `Replica::abort`. If the
+    /// partition state is then empty (no replicas and no
+    /// partition), the entry is dropped to keep the map tidy.
+    pub fn unbind_partition(&self, partition_id: mssf_core::GUID) {
+        let mut map = self.inner.lock().unwrap();
+        if let Some(state) = map.get_mut(&partition_id) {
+            state.partition = None;
+            if state.replicas.is_empty() {
+                map.remove(&partition_id);
+            }
+        }
+    }
+
+    /// Look up the currently bound partition handle. Returns
+    /// `None` if no replica is currently open for this
+    /// partition on this node.
+    pub fn get_partition(
+        &self,
+        partition_id: mssf_core::GUID,
+    ) -> Option<Arc<dyn IStatefulServicePartition>> {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(&partition_id)?
+            .partition
+            .clone()
     }
 
     /// Look up a replica's controller (if any).
@@ -110,6 +196,7 @@ impl ReplicaRegistry {
             .lock()
             .unwrap()
             .get(&partition_id)?
+            .replicas
             .iter()
             .find(|e| e.replica_id == replica_id)?
             .controller
@@ -122,39 +209,34 @@ impl ReplicaRegistry {
             .lock()
             .unwrap()
             .values()
-            .flatten()
-            .cloned()
+            .flat_map(|s| s.replicas.iter().cloned())
             .collect()
     }
 
     pub fn update_role(&self, partition_id: mssf_core::GUID, replica_id: i64, role: ReplicaRole) {
         let mut map = self.inner.lock().unwrap();
-        if let Some(entry) = map
-            .get_mut(&partition_id)
-            .and_then(|replicas| replicas.iter_mut().find(|e| e.replica_id == replica_id))
-        {
+        if let Some(entry) = map.get_mut(&partition_id).and_then(|state| {
+            state
+                .replicas
+                .iter_mut()
+                .find(|e| e.replica_id == replica_id)
+        }) {
             entry.role = role;
         }
     }
 
     pub fn remove(&self, partition_id: mssf_core::GUID, replica_id: i64) {
         let mut map = self.inner.lock().unwrap();
-        if let Some(replicas) = map.get_mut(&partition_id) {
-            replicas.retain(|e| e.replica_id != replica_id);
-            if replicas.is_empty() {
+        if let Some(state) = map.get_mut(&partition_id) {
+            state.replicas.retain(|e| e.replica_id != replica_id);
+            if state.replicas.is_empty() && state.partition.is_none() {
                 map.remove(&partition_id);
             }
         }
     }
 
     fn get_all(&self) -> Vec<ReplicaEntry> {
-        self.inner
-            .lock()
-            .unwrap()
-            .values()
-            .flatten()
-            .cloned()
-            .collect()
+        self.snapshot()
     }
 
     fn get_by_partition(&self, partition_id: mssf_core::GUID) -> Vec<ReplicaEntry> {
@@ -162,7 +244,7 @@ impl ReplicaRegistry {
             .lock()
             .unwrap()
             .get(&partition_id)
-            .cloned()
+            .map(|s| s.replicas.clone())
             .unwrap_or_default()
     }
 }
@@ -210,10 +292,170 @@ impl Greeter for MyGreeter {
 
         Ok(Response::new(GetReplicasResponse { replicas }))
     }
+
+    async fn write(&self, request: Request<WriteRequest>) -> Result<Response<WriteReply>, Status> {
+        // Identify the target partition from the required
+        // `mssf-partition-id` request metadata header. Missing
+        // or malformed -> invalid_argument; an absent partition
+        // (process has never opened this partition or it has
+        // closed) -> unavailable so the client retries via a
+        // resolve.
+        let partition_id = parse_partition_id_header(&request)?;
+        let partition = self.registry.get_partition(partition_id).ok_or_else(|| {
+            Status::unavailable(format!(
+                "partition {partition_id:?} is not currently hosted on this node"
+            ))
+        })?;
+        let write_status = partition
+            .get_write_status()
+            .map_err(|e| Status::internal(format!("get_write_status failed: {e:?}")))?;
+        match write_status {
+            ServicePartitionAccessStatus::Granted => {
+                let replica_id = self
+                    .registry
+                    .get_by_partition(partition_id)
+                    .first()
+                    .map(|e| e.replica_id)
+                    .unwrap_or(0);
+                let payload = request.into_inner().payload;
+                tracing::info!(
+                    partition = ?partition_id,
+                    replica_id,
+                    payload_len = payload.len(),
+                    "Write accepted on primary"
+                );
+                Ok(Response::new(WriteReply {
+                    acked_by: format!("{:?}/{}", partition_id, replica_id),
+                }))
+            }
+            ServicePartitionAccessStatus::NotPrimary => Err(status_with_mssf(
+                tonic::Code::Unavailable,
+                "not primary",
+                "not-primary",
+            )),
+            ServicePartitionAccessStatus::ReconfigurationPending => Err(status_with_mssf(
+                tonic::Code::Unavailable,
+                "reconfiguration pending",
+                "reconfiguration-pending",
+            )),
+            // Transient on the same primary; the client should
+            // retry against this same channel without rebuilding.
+            // No mssf-status metadata.
+            ServicePartitionAccessStatus::NoWriteQuorum => {
+                Err(Status::unavailable("no write quorum"))
+            }
+            ServicePartitionAccessStatus::Invalid => {
+                Err(Status::internal("partition reported Invalid write status"))
+            }
+        }
+    }
+}
+
+/// Parse and validate the `mssf-partition-id` request metadata
+/// header. Returns `invalid_argument` on missing / non-ascii /
+/// non-GUID values.
+fn parse_partition_id_header<T>(request: &Request<T>) -> Result<mssf_core::GUID, Status> {
+    let raw = request
+        .metadata()
+        .get(MSSF_PARTITION_ID_HEADER)
+        .ok_or_else(|| {
+            Status::invalid_argument(format!(
+                "missing required `{MSSF_PARTITION_ID_HEADER}` metadata header"
+            ))
+        })?
+        .to_str()
+        .map_err(|_| {
+            Status::invalid_argument(format!("`{MSSF_PARTITION_ID_HEADER}` must be ASCII"))
+        })?;
+    let uuid = uuid::Uuid::parse_str(raw).map_err(|e| {
+        Status::invalid_argument(format!(
+            "`{MSSF_PARTITION_ID_HEADER}` is not a valid UUID: {e}"
+        ))
+    })?;
+    Ok(mssf_core::GUID::from_u128(uuid.as_u128()))
+}
+
+/// Build an error `Status` carrying the `mssf-status` metadata
+/// entry that triggers a channel rebuild in
+/// [`mssf_util::tonic::ResolveStatusMiddleware`].
+fn status_with_mssf(code: tonic::Code, message: &str, mssf_status: &str) -> Status {
+    let mut md = tonic::metadata::MetadataMap::new();
+    md.insert(
+        MSSF_STATUS_TRAILER,
+        mssf_status.parse().expect("valid ascii"),
+    );
+    Status::with_metadata(code, message.to_string(), md)
 }
 
 pub fn greeter_server(registry: ReplicaRegistry) -> GreeterServer<MyGreeter> {
     GreeterServer::new(MyGreeter { registry })
+}
+
+// ===== Client-side helpers (Phase 2) =====================
+//
+// These wrap `mssf_util::tonic` so a caller building a
+// `GreeterClient` against `fabric:/.../ReflectionApp/<svc>`
+// doesn't have to repeat the resolver/selector/channel wiring.
+// The selector picks the StatefulPrimary endpoint and parses
+// its `ReflectionUrl`-encoded address into a TCP `DialTarget`;
+// the channel attaches `ResolveStatusMiddleware` to watch for
+// the `mssf-status` failover signal.
+
+use mssf_core::client::FabricClient;
+use mssf_core::client::svc_mgmt_client::{
+    PartitionKeyType, ResolvedServicePartition, ServiceEndpointRole,
+};
+use mssf_util::tonic::{
+    DialTarget, FabricTargetResolverBuilder, SelectError, TargetChannel, TargetChannelBuilder,
+};
+
+/// Selector that returns the dial target for the
+/// `StatefulPrimary` endpoint of a singleton partition. Used by
+/// [`build_primary_channel`]; exposed as a standalone fn for
+/// callers that want to share the parse-and-select logic with a
+/// custom resolver.
+pub fn primary_selector()
+-> impl Fn(&ResolvedServicePartition) -> Result<DialTarget, SelectError> + Send + Sync + 'static {
+    |rsp| {
+        let ep = rsp
+            .endpoints
+            .iter()
+            .find(|e| e.role == ServiceEndpointRole::StatefulPrimary)
+            .ok_or(SelectError::NoMatch)?;
+        let url = ReflectionUrl::parse(&ep.address.to_string())
+            .map_err(|e| SelectError::Fatal(e.into()))?;
+        let host = url
+            .base_url
+            .host_str()
+            .ok_or_else(|| SelectError::Fatal("ReflectionUrl missing host".into()))?
+            .to_string();
+        let port = url
+            .base_url
+            .port()
+            .ok_or_else(|| SelectError::Fatal("ReflectionUrl missing port".into()))?;
+        Ok(DialTarget { host, port })
+    }
+}
+
+/// Build a failover-aware `tonic::Channel` for the reflection
+/// sample's `Greeter` service. Resolves `service_uri` (a
+/// `fabric:/...` URI) via SF naming, dials the current primary,
+/// and rebuilds the inner channel when the server attaches an
+/// `mssf-status` metadata entry (via [`MyGreeter::write`] on a
+/// non-primary).
+///
+/// Pure construction — no IO until the first RPC.
+pub fn build_primary_channel(fc: FabricClient, service_uri: &str) -> TargetChannel {
+    let uri = mssf_core::types::Uri::from(service_uri);
+    let resolver = FabricTargetResolverBuilder::new(fc)
+        .service_uri(uri)
+        .partition_key(PartitionKeyType::None)
+        .target_selector(primary_selector())
+        .build();
+    TargetChannelBuilder::new()
+        .resolver(resolver)
+        .trailer_header(MSSF_STATUS_TRAILER)
+        .build()
 }
 
 /// A parsed reflection service URL containing the gRPC base address,

--- a/crates/samples/reflection/src/statefulstore.rs
+++ b/crates/samples/reflection/src/statefulstore.rs
@@ -213,6 +213,11 @@ impl IStatefulServiceReplica for Replica {
         }
         self.lifecycle.complete_open()?;
         self.ctx.init(partition.clone());
+        // Make the partition handle visible to role-gated gRPC
+        // handlers (`MyGreeter::write`) via the shared registry.
+        // Unbind happens in `close` and `abort`.
+        self.registry
+            .bind_partition(self.partition_id, partition.clone());
         self.svc.start_loop_in_background(&partition);
         // Use empty replicator
         Ok(Box::new(EmptyReplicator::new(
@@ -262,6 +267,7 @@ impl IStatefulServiceReplica for Replica {
         }
         self.lifecycle.complete_close()?;
         self.registry.remove(self.partition_id, self.replica_id);
+        self.registry.unbind_partition(self.partition_id);
         self.svc.stop();
         Ok(())
     }
@@ -288,6 +294,7 @@ impl IStatefulServiceReplica for Replica {
             let _ = controller.await_approval(Approval::Abort).await;
         });
         self.registry.remove(self.partition_id, self.replica_id);
+        self.registry.unbind_partition(self.partition_id);
         self.svc.stop();
     }
 }

--- a/crates/samples/reflection/src/test_admin.rs
+++ b/crates/samples/reflection/src/test_admin.rs
@@ -63,9 +63,16 @@ pub struct TestClient {
 
 impl TestClient {
     pub fn new(fc: FabricClient) -> Self {
+        Self::with_uri(fc, Uri::from(SVC_URI))
+    }
+
+    /// Construct against a non-default service URI. Used by
+    /// tests that create their own service (e.g.
+    /// `tonic_failover.rs`'s `fabric:/ReflectionApp/TonicFailoverTest`).
+    pub fn with_uri(fc: FabricClient, service_uri: Uri) -> Self {
         Self {
             fc,
-            service_uri: Uri::from(SVC_URI),
+            service_uri,
             timeout: Duration::from_secs(1),
         }
     }

--- a/crates/samples/reflection/tests/tonic_failover.rs
+++ b/crates/samples/reflection/tests/tonic_failover.rs
@@ -1,0 +1,214 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Live-cluster integration test for the failover-aware tonic
+//! channel built by
+//! [`samples_reflection::grpc::build_primary_channel`].
+//!
+//! Drives the `Write` RPC against `fabric:/ReflectionApp/TonicFailoverTest`
+//! through a [`TargetChannel`](mssf_util::tonic::TargetChannel)
+//! and asserts that the channel rebuilds (and the next request
+//! succeeds against the new primary) after a `restart_replica`
+//! triggered failover. Companion to
+//! [`failover.rs`](failover.rs) — that test exercises the
+//! bare-resolve path; this one exercises the channel.
+//!
+//! Requires the `ReflectionApp` application package to be
+//! deployed on the local onebox (see top-level test
+//! instructions). The new partitioned service is created and
+//! deleted by the test itself.
+
+use std::time::Duration;
+
+use mssf_core::{
+    GUID, WString,
+    client::{FabricClient, svc_mgmt_client::PartitionKeyType},
+    types::Uri,
+};
+use mssf_util::resolve::ServicePartitionResolver;
+use mssf_util::tonic::TargetChannel;
+use tonic::Request;
+
+use samples_reflection::grpc::{
+    MSSF_PARTITION_ID_HEADER, build_primary_channel,
+    hello_world::{WriteRequest, greeter_client::GreeterClient},
+};
+use samples_reflection::test_admin::{
+    TestClient, TestCreateUpdateClient, TestPartitionReplicaLayout,
+};
+
+const SERVICE_URI: &str = "fabric:/ReflectionApp/TonicFailoverTest";
+
+/// Invalid memory access https://github.com/Azure/service-fabric-rs/issues/184
+/// happens when this test finishes. Delaying the process clean
+/// up is helping with the issue. Mirrors the helper of the same
+/// name in [`failover.rs`](failover.rs).
+async fn fabric_client_drop_hack(fc: FabricClient) {
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    drop(fc);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+}
+
+/// Resolve the test service until it has the full target
+/// replica set, then return the singleton partition id.
+async fn wait_for_ready(fc: &FabricClient, uri: &Uri) -> GUID {
+    let retryer = mssf_util::retry::OperationRetryer::builder().build();
+    let srv = ServicePartitionResolver::new(fc.clone(), retryer);
+    let mut prev = None;
+    loop {
+        let rsp = srv
+            .resolve(uri, &PartitionKeyType::None, prev.as_ref(), None, None)
+            .await
+            .unwrap();
+        if rsp.endpoints.len() >= 3 {
+            // Find the partition id by querying SF for the
+            // service partitions (RSP doesn't carry it
+            // directly).
+            let tc = TestClient::with_uri(fc.clone(), uri.clone());
+            let (_, single) = tc.get_partition().await.unwrap();
+            return single.id;
+        }
+        prev = Some(rsp);
+        tracing::debug!("Waiting for service to be ready...");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Build a `Write` request with the required
+/// `mssf-partition-id` metadata header. The header value uses
+/// the GUID's `Debug` formatting (the canonical hyphenated UUID
+/// representation, e.g. `{12345678-1234-1234-1234-1234567890ab}`)
+/// so the server's `uuid::Uuid::parse_str` accepts it.
+fn write_request(partition_id: GUID, payload: &str) -> Request<WriteRequest> {
+    let mut req = Request::new(WriteRequest {
+        payload: payload.to_string(),
+    });
+    // Debug format is `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`;
+    // strip the surrounding braces so `Uuid::parse_str` accepts
+    // the plain hyphenated form.
+    let raw = format!("{:?}", partition_id);
+    let header_value = raw.trim_matches(|c| c == '{' || c == '}').to_string();
+    req.metadata_mut().insert(
+        MSSF_PARTITION_ID_HEADER,
+        header_value.parse().expect("valid ascii UUID"),
+    );
+    req
+}
+
+/// Try `write` up to `max_attempts` times, returning the first
+/// `Ok` ack string. Treats `Unavailable` and transport errors
+/// as retryable — those are exactly the surfaces the failover
+/// channel is supposed to recover from.
+async fn write_until_ok(
+    client: &mut GreeterClient<TargetChannel>,
+    partition_id: GUID,
+    payload: &str,
+    max_attempts: usize,
+) -> String {
+    let mut last_err = None;
+    for attempt in 0..max_attempts {
+        match client.write(write_request(partition_id, payload)).await {
+            Ok(resp) => {
+                let acked_by = resp.into_inner().acked_by;
+                tracing::info!(attempt, %acked_by, "write succeeded");
+                return acked_by;
+            }
+            Err(status) => {
+                tracing::info!(attempt, ?status, "write returned error; retrying");
+                last_err = Some(status);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    panic!(
+        "write did not succeed within {max_attempts} attempts; last error: {:?}",
+        last_err
+    );
+}
+
+/// End-to-end failover via `restart_replica`. Exercises the
+/// design's [`Case 1 — connection lost`](../../docs/design/TonicConnectorDesign.md#case-1--connection-lost-transport-level).
+#[tokio::test]
+#[test_log::test]
+async fn tonic_channel_recovers_after_primary_restart() {
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+    let uri = Uri::from(SERVICE_URI);
+
+    // Setup: create the service.
+    let sm = TestCreateUpdateClient::new(fc.clone());
+    sm.create_service(
+        &uri,
+        &mssf_core::types::PartitionSchemeDescription::Singleton,
+        TestPartitionReplicaLayout::TargetMinAux(3, 3, 0),
+    )
+    .await;
+
+    let partition_id = wait_for_ready(&fc, &uri).await;
+
+    // Build the failover-aware channel.
+    let channel = build_primary_channel(fc.clone(), SERVICE_URI);
+    let mut client = GreeterClient::new(channel);
+
+    // Steady-state write succeeds on the current primary.
+    let acked_first = write_until_ok(&mut client, partition_id, "hello", 3).await;
+    tracing::info!(%acked_first, "steady-state ack");
+
+    // Trigger failover (restart the current primary). Reuses
+    // the helper from `test_admin.rs`, which waits until the
+    // primary's node changes.
+    let tc = TestClient::with_uri(fc.clone(), uri.clone());
+    tc.restart_primary_wait_for_replica_id_change(partition_id)
+        .await;
+
+    // Next write should eventually succeed against the new
+    // primary. May surface one `Unavailable` (with
+    // `mssf-status: not-primary`) or one transport error
+    // first, depending on whether hyper's connection pool
+    // still holds the old TCP/HTTP2 connection.
+    let acked_after_restart = write_until_ok(&mut client, partition_id, "after-restart", 5).await;
+    tracing::info!(%acked_after_restart, "post-failover ack");
+    assert_ne!(
+        acked_first, acked_after_restart,
+        "after restart_replica the ack should come from a different replica"
+    );
+
+    // Concurrency / dedup. Restart again, then fire N writes
+    // concurrently. All must eventually succeed; we don't
+    // attempt to count rebuilds from outside (that would
+    // require test-only instrumentation on the resolver) —
+    // the deterministic dedup behaviour is covered by the
+    // unit-test suite at
+    // `crates/libs/util/tests/tonic_middleware.rs`.
+    tc.restart_primary_wait_for_replica_id_change(partition_id)
+        .await;
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        // `GreeterClient<TargetChannel>` is `Clone` because
+        // `TargetChannel` (= `ResolveStatusMiddleware<SwapChannel>`)
+        // is `Clone`. Each clone shares the same dedup state via
+        // the inner `Arc<Mutex<...>>` in the middleware.
+        let mut client_clone = client.clone();
+        handles.push(tokio::spawn(async move {
+            write_until_ok(
+                &mut client_clone,
+                partition_id,
+                &format!("concurrent-{i}"),
+                5,
+            )
+            .await
+        }));
+    }
+    for h in handles {
+        let ack = h.await.unwrap();
+        tracing::info!(%ack, "concurrent ack");
+    }
+
+    // Teardown.
+    sm.delete_service(&uri).await;
+    fabric_client_drop_hack(fc).await;
+}

--- a/crates/samples/reflection/tests/tonic_failover.rs
+++ b/crates/samples/reflection/tests/tonic_failover.rs
@@ -53,27 +53,32 @@ async fn fabric_client_drop_hack(fc: FabricClient) {
 
 /// Resolve the test service until it has the full target
 /// replica set, then return the singleton partition id.
+/// Panics if the service is not ready within 60 seconds.
 async fn wait_for_ready(fc: &FabricClient, uri: &Uri) -> GUID {
-    let retryer = mssf_util::retry::OperationRetryer::builder().build();
-    let srv = ServicePartitionResolver::new(fc.clone(), retryer);
-    let mut prev = None;
-    loop {
-        let rsp = srv
-            .resolve(uri, &PartitionKeyType::None, prev.as_ref(), None, None)
-            .await
-            .unwrap();
-        if rsp.endpoints.len() >= 3 {
-            // Find the partition id by querying SF for the
-            // service partitions (RSP doesn't carry it
-            // directly).
-            let tc = TestClient::with_uri(fc.clone(), uri.clone());
-            let (_, single) = tc.get_partition().await.unwrap();
-            return single.id;
+    tokio::time::timeout(Duration::from_secs(60), async {
+        let retryer = mssf_util::retry::OperationRetryer::builder().build();
+        let srv = ServicePartitionResolver::new(fc.clone(), retryer);
+        let mut prev = None;
+        loop {
+            let rsp = srv
+                .resolve(uri, &PartitionKeyType::None, prev.as_ref(), None, None)
+                .await
+                .unwrap();
+            if rsp.endpoints.len() >= 3 {
+                // Find the partition id by querying SF for the
+                // service partitions (RSP doesn't carry it
+                // directly).
+                let tc = TestClient::with_uri(fc.clone(), uri.clone());
+                let (_, single) = tc.get_partition().await.unwrap();
+                return single.id;
+            }
+            prev = Some(rsp);
+            tracing::debug!("Waiting for service to be ready...");
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
-        prev = Some(rsp);
-        tracing::debug!("Waiting for service to be ready...");
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
+    })
+    .await
+    .expect("service did not become ready within 60s")
 }
 
 /// Build a `Write` request with the required
@@ -98,9 +103,11 @@ fn write_request(partition_id: GUID, payload: &str) -> Request<WriteRequest> {
 }
 
 /// Try `write` up to `max_attempts` times, returning the first
-/// `Ok` ack string. Treats `Unavailable` and transport errors
-/// as retryable — those are exactly the surfaces the failover
-/// channel is supposed to recover from.
+/// `Ok` ack string. Only retries on `Unavailable` and
+/// `Unknown` (transport-level) errors — these are the surfaces
+/// the failover channel is designed to recover from. Any other
+/// gRPC status code is considered a non-retryable bug and
+/// panics immediately.
 async fn write_until_ok(
     client: &mut GreeterClient<TargetChannel>,
     partition_id: GUID,
@@ -115,10 +122,16 @@ async fn write_until_ok(
                 tracing::info!(attempt, %acked_by, "write succeeded");
                 return acked_by;
             }
-            Err(status) => {
-                tracing::info!(attempt, ?status, "write returned error; retrying");
+            Err(status)
+                if status.code() == tonic::Code::Unavailable
+                    || status.code() == tonic::Code::Unknown =>
+            {
+                tracing::info!(attempt, ?status, "write returned retryable error");
                 last_err = Some(status);
                 tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(status) => {
+                panic!("write returned non-retryable error: {status:?}");
             }
         }
     }
@@ -139,8 +152,18 @@ async fn tonic_channel_recovers_after_primary_restart() {
         .unwrap();
     let uri = Uri::from(SERVICE_URI);
 
-    // Setup: create the service.
+    // Setup: best-effort cleanup of any leftover from a
+    // previous failed run, so re-runs are idempotent.
     let sm = TestCreateUpdateClient::new(fc.clone());
+    if let Err(e) = fc
+        .get_service_manager()
+        .delete_service(&uri, Duration::from_secs(10), None)
+        .await
+    {
+        tracing::debug!(?e, "pre-cleanup delete (expected if service doesn't exist)");
+    }
+
+    // Create the service.
     sm.create_service(
         &uri,
         &mssf_core::types::PartitionSchemeDescription::Singleton,

--- a/docs/design/TonicConnectorDesign.md
+++ b/docs/design/TonicConnectorDesign.md
@@ -1,6 +1,6 @@
 # Service Fabric Tonic Connector — Design
 
-Status: Implemented (v1). See [`mssf_util::tonic`](../../crates/libs/util/src/tonic).
+Status: Implemented. See [`mssf_util::tonic`](../../crates/libs/util/src/tonic).
 
 Owners: mssf-rs maintainers
 
@@ -121,8 +121,11 @@ see the signals it needs to act on:
                            v
 +---------------------------------------------------+
 |        ResolveStatusMiddleware<SwapChannel>        |
-|  - inspects gRPC trailers via http_body::Frame     |
-|  - on trailer header (default `mssf-status`):      |
+|  - inspects configured status header (default      |
+|    `mssf-status`) in BOTH:                         |
+|     * initial response headers (unary path)        |
+|     * http_body::Frame::trailers (streaming path)  |
+|  - on match:                                       |
 |      swap_channel.rebuild()  (non-blocking)        |
 |  - propagates response unchanged (no retry, no kill)|
 |  - Stateful dedup: see `Rebuild dedup`              |
@@ -162,8 +165,8 @@ Each failure mode is naturally observable at exactly one layer.
 | Failure mode | Observable at | Action |
 |---|---|---|
 | TCP RST / `GOAWAY` / hyper IO error | hyper pool eviction | next dial → `TargetConnector` re-resolves; failing call surfaces to caller's outer retry |
-| Trailer on response (success or error) | `Frame::trailers()` above the channel | `ResolveStatusMiddleware` calls `swap_channel.rebuild()`; response delivered unchanged |
-| Plain `Code::Unavailable` (no trailer) | gRPC response | propagated unchanged; **no rebuild** (could be a downstream flake, not a role change) |
+| `mssf-status` header on response (success or error) | `response.headers()` or `Frame::trailers()`, above the channel — see [Status signal wire format](#status-signal-wire-format) | `ResolveStatusMiddleware` calls `swap_channel.rebuild()`; response delivered unchanged |
+| Plain `Code::Unavailable` (no header) | gRPC response | propagated unchanged; **no rebuild** (could be a downstream flake, not a role change) |
 
 Cross-layer coupling is exactly one `Arc<SwapChannel>` clone held by
 the middleware so it can call `rebuild()`. The connector knows
@@ -171,16 +174,24 @@ nothing about channels; the channel knows nothing about middleware.
 
 ### Why each layer is the way it is
 
+
 - **Middleware above the channel.** Hyper does not expose gRPC
-  trailers to the connector; trailers live on `http_body::Frame`,
-  visible only above `tonic::Channel`. `ResolveStatusMiddleware` is
-  the only layer that can observe "the call completed at HTTP/2 but
-  the application told us we're talking to the wrong replica."
+  response metadata to the connector; both response headers and
+  body frames are visible only above `tonic::Channel`.
+  `ResolveStatusMiddleware` is the only layer that can observe
+  "the call completed at HTTP/2 but the application told us
+  we're talking to the wrong replica." That signal can ride on
+  the initial HEADERS frame (tonic's encoding for unary metadata)
+  or on an end-of-stream trailers frame (the only place a
+  streaming server can emit metadata via `Err(Status::with_metadata)`),
+  so the middleware inspects both — see
+  [Status signal wire format](#status-signal-wire-format).
 
   **Layer-ordering constraint:** the middleware MUST sit directly
-  above `SwapChannel`, with no body-transforming layers between
-  them — anything that consumes the response body before trailers
-  are read will hide them.
+  above `SwapChannel`. Anything that consumes the response body
+  before the middleware reads it will hide trailer frames
+  (initial-header inspection is unaffected because headers are
+  available on the response parts before the body is touched).
 - **`SwapChannel` as its own layer.** The middleware sees the
   trailer; the connector does the next dial. But hyper will keep
   multiplexing new requests onto the existing alive HTTP/2
@@ -249,7 +260,7 @@ All types are re-exported flat from
 | [`SwapChannel`](../../crates/libs/util/src/tonic/channel/swap.rs) | struct | `ArcSwap<tonic::Channel>` + rebuild |
 | [`TargetChannel`](../../crates/libs/util/src/tonic/channel/builder.rs) | type alias | `ResolveStatusMiddleware<SwapChannel>` |
 | `TargetChannelBuilder` | struct | Sugar that composes everything |
-| [`ResolveStatusMiddleware<S>`](../../crates/libs/util/src/tonic/middleware.rs) | struct | trailer-aware `Service` middleware |
+| [`ResolveStatusMiddleware<S>`](../../crates/libs/util/src/tonic/middleware.rs) | struct | status-header-aware `Service` middleware (inspects initial response headers + trailers frame) |
 
 Signatures, `where`-bounds, and rustdoc live next to the code. This
 doc only spells out behavior the impl can't express on its own.
@@ -371,9 +382,15 @@ Normal SF failover for stateful services with persistent replicas:
 - Existing TCP / HTTP/2 connections stay alive.
 - The server **completes** the in-flight request normally —
   success if the request was satisfiable as a secondary, or an
-  error otherwise — and attaches the trailer (default
-  `mssf-status`) to either to signal "the connection you used is
-  no longer the right one for next time."
+  error otherwise — and attaches the configured status header
+  (default `mssf-status`) to either response to signal "the
+  connection you used is no longer the right one for next time."
+  Servers attach it via the standard tonic APIs
+  (`Response::metadata_mut()` on `Ok`,
+  `Status::with_metadata(...)` on `Err`); whether the header
+  rides on initial response headers or on a trailers frame is a
+  wire-encoding detail the middleware handles transparently —
+  see [Status signal wire format](#status-signal-wire-format).
 
 Without the middleware + `SwapChannel` pair, hyper would happily
 keep multiplexing new requests onto the same alive HTTP/2
@@ -392,19 +409,46 @@ A SF gRPC service that wants graceful client recovery MUST:
 2. **Complete the request normally** — success if it can be
    satisfied (e.g. read on a secondary if allowed), or an error
    (typically `Code::Unavailable`) if it cannot.
-3. Attach the trailer (default `mssf-status`) to the response
-   (success or error) when the role state is no longer correct
-   for this client's intended target.
+3. Attach the configured status header (default `mssf-status`)
+   to the response (success or error) when the role state is no
+   longer correct for this client's intended target. Use the
+   standard tonic APIs — `Response::metadata_mut()` on the `Ok`
+   path, `Status::with_metadata(...)` on the `Err` path — the
+   middleware handles both wire placements.
 
 The server does **not** need to close the connection or send
 `GOAWAY` on role change. Client-side invalidation is the
 middleware's job.
 
-### Trailer wire format
+#### Worked example: gating a write on `ServicePartitionAccessStatus`
 
-The trailer header name is **configured at the middleware** (passed
+The reflection sample's `MyGreeter::write`
+([`crates/samples/reflection/src/grpc.rs`](../../crates/samples/reflection/src/grpc.rs))
+shows the minimum viable mapping from
+[`ServicePartitionAccessStatus`](../../crates/libs/core/src/runtime/stateful_types.rs)
+to gRPC response + `mssf-status` metadata:
+
+| `partition.get_write_status()` | gRPC response | `mssf-status` value |
+|---|---|---|
+| `Granted` | `Ok(reply)` | none |
+| `NotPrimary` | `Err(Status::unavailable("not primary"))` | `not-primary` |
+| `ReconfigurationPending` | `Err(Status::unavailable("reconfiguration pending"))` | `reconfiguration-pending` |
+| `NoWriteQuorum` | `Err(Status::unavailable("no write quorum"))` | none (transient — retry on same channel) |
+| `Invalid` | `Err(Status::internal(...))` | none |
+
+The reflection handler reads a required `mssf-partition-id`
+request metadata header to identify which partition the call
+targets (one process can host multiple partitions); see
+[`MyGreeter::write`](../../crates/samples/reflection/src/grpc.rs)
+for the parse logic. That header is a sample-specific convention,
+not part of the channel contract.
+
+### Status signal wire format
+
+The status header name is **configured at the middleware** (passed
 to `TargetChannelBuilder::trailer_header` or
-`ResolveStatusMiddleware::new`); the SDK convention is
+`ResolveStatusMiddleware::new` — the API method name is
+historical; v1.1 inspects both placements). The SDK convention is
 `mssf-status`. Values are ASCII opaque strings; the middleware
 does string equality only.
 
@@ -420,27 +464,68 @@ Any non-empty value is accepted; values are forward-compatible
 monotonic suffix (e.g. `not-primary:42`); the dedup will then
 treat each as a distinct event.
 
-Three signals the middleware distinguishes:
+#### Where the header lands on the wire
+
+The middleware inspects the configured header on **both**
+response-parts headers and any trailers frame, because tonic
+places it in different positions depending on RPC shape and
+outcome — pinned down by
+[`tests/mssf-tests/tests/tonic_server_trailers.rs::wire_level_placement_diagnostic`](../../tests/mssf-tests/tests/tonic_server_trailers.rs):
+
+| Server API used | RPC shape | Outcome | Wire placement |
+|---|---|---|---|
+| `Response::metadata_mut().insert(...)` | unary | `Ok` | **initial HEADERS frame**; trailers frame carries only `grpc-status: 0` |
+| `Status::with_metadata(...)` returned as `Err` | unary | `Err` | **trailers-only HEADERS frame** (single HEADERS with END_STREAM carrying `grpc-status`, `grpc-message`, and the user metadata; no DATA, no separate trailers frame) |
+| `Response::metadata_mut().insert(...)` | server/bidi-streaming | any | **initial HEADERS frame** |
+| Stream yields `Err(Status::with_metadata(...))` | server/bidi-streaming | `Err` after some `Ok` items | **real trailers frame** (`EncodeBody` writes `status.to_header_map()` as `Frame::trailers`) |
+| `Status::ok("")` synthesized on natural stream end | server/bidi-streaming | `Ok` | trailers frame carries only `grpc-status: 0`; user metadata never lands here |
+
+The upstream encoder is
+[`tonic-0.14.5/src/codec/encode.rs::EncodeState::trailers`](https://docs.rs/tonic/0.14.5/src/tonic/codec/encode.rs.html):
+the trailers frame is built **exclusively** from a `Status`, and
+for every non-error path that status is `Status::ok("")` with no
+user metadata. There is no public tonic API to attach arbitrary
+metadata to the trailers frame of a successful response.
+
+#### Three signals the middleware distinguishes
+
+Given the table above, "trailer present/absent" in the original
+v1 vocabulary really means "configured header present/absent in
+either location":
 
 | Signal | Meaning |
 |---|---|
-| trailer absent | "I served you and I'm still the right one" — resets dedup |
-| trailer present, value V | "switch for next time" — rebuild if V differs from last seen |
-| trailer present, **empty value** | dumb-server escape hatch: always rebuild, don't store |
+| header absent (from both headers and trailers frame) | "I served you and I'm still the right one" — resets dedup |
+| header present, value V (from either location) | "switch for next time" — rebuild if V differs from last seen |
+| header present, **empty value** | dumb-server escape hatch: always rebuild, don't store |
 
-If the trailer block contains multiple entries under the
-configured header, the first one wins. Server / client must agree
-on the header name; mismatch silently disables rebuild (no error,
-no log — the steady-state case is *supposed* to be silent).
+If the configured header appears in both the response headers
+and a trailers frame on the same response (uncommon but allowed
+by gRPC), the dedup state machine collapses identical values to
+one `rebuild()` call; distinct values fire two — both at most
+once per response. If a single block contains multiple entries
+under the configured header, the first one wins. Server / client
+must agree on the header name; mismatch silently disables rebuild
+(no error, no log — the steady-state case is *supposed* to be
+silent).
 
 ### Streaming RPCs
 
 The trailer arrives whenever the server **ends the stream**, not
 before — a direct consequence of the no-kill contract. If the
 server wants clients to switch mid-stream, it ends the stream with
-the trailer attached (typically with `Status::unavailable`). A
-server that keeps a stream open across a role change is declaring
-"this stream is still mine to serve." The client honors that.
+the header attached (typically by yielding
+`Err(Status::with_metadata(Code::Unavailable, "...", md))` where
+`md` carries `mssf-status: not-primary`; `EncodeBody` then writes
+it as a real `Frame::trailers`). A server that keeps a stream
+open across a role change is declaring "this stream is still mine
+to serve." The client honors that.
+
+For **unary** RPCs the contract is the same at the API level
+(use `Response::metadata_mut()` or `Status::with_metadata`), but
+the wire placement is HEADERS rather than trailers — see
+[Where the header lands on the wire](#where-the-header-lands-on-the-wire).
+The middleware handles both transparently.
 
 ## Rebuild dedup
 
@@ -448,6 +533,11 @@ The dedup state machine has one piece of state — `last_seen:
 Mutex<Option<String>>` — and four transitions. Implemented in
 [`middleware.rs::classify`](../../crates/libs/util/src/tonic/middleware.rs)
 and exhaustively unit-tested.
+
+In the table below "(no trailer)" is shorthand for "the
+configured status header was not observed on either the initial
+response headers or any trailers frame"; "`mssf-status: V`" means
+it was observed at either location with value `V`.
 
 ```
 state                       observed                         action
@@ -691,6 +781,20 @@ invalidation path that SF naming exposes via the trailer.
 
 A few small differences between this doc and what shipped:
 
+- **v1.0 middleware inspects only trailer frames; v1.1 will
+  inspect initial response headers too.** Necessary because
+  tonic places unary `Response::metadata_mut()` /
+  `Status::with_metadata` content in HEADERS frames, not in a
+  separate trailers frame — see
+  [Where the header lands on the wire](#where-the-header-lands-on-the-wire).
+  The dedup state machine doesn't change; the inspection just
+  runs against `response.headers()` before the body is returned,
+  in addition to the existing `Frame::is_trailers()` check.
+  Tripwire coverage already in place at
+  [`tests/mssf-tests/tests/tonic_server_trailers.rs`](../../tests/mssf-tests/tests/tonic_server_trailers.rs).
+  Builder method name `trailer_header(...)` stays as-is for v1.1
+  (rename is API churn deferred to a later major).
+
 - **Type erasure uses `BoxCloneSyncService`, not `BoxCloneService`.**
   `SwapChannel` is shared via `Arc<Inner>` between the user-facing
   service and the rebuild closure captured by the middleware, so
@@ -719,56 +823,29 @@ A few small differences between this doc and what shipped:
 
 ## Testing
 
-### Unit / integration tests (shipped)
+| Suite | Count | File | Scope |
+|---|---:|---|---|
+| Dedup state machine | 6 | [`middleware.rs`](../../crates/libs/util/src/tonic/middleware.rs) | Pure `classify()` cases |
+| Middleware E2E (scripted) | 13 | [`tonic_middleware.rs`](../../crates/libs/util/tests/tonic_middleware.rs) | Trailer-path + header-path dedup, concurrency |
+| Channel failover (mock) | 3 | [`tonic_failover.rs`](../../tests/mssf-tests/tests/tonic_failover.rs) | Two ephemeral HTTP/2 servers, resolver flip + reset |
+| Tonic-codegen wire shape | 4 | [`tonic_server_trailers.rs`](../../tests/mssf-tests/tests/tonic_server_trailers.rs) | Generated `TestSvcServer` proves header-path + trailer-path classification; one raw-HTTP/2 diagnostic |
+| Live cluster | 1 | [`reflection/tests/tonic_failover.rs`](../../crates/samples/reflection/tests/tonic_failover.rs) | `restart_replica` + concurrent writes against real onebox `ReflectionApp` |
 
-- 6 dedup state-machine tests in
-  [`middleware.rs`](../../crates/libs/util/src/tonic/middleware.rs).
-- 7 end-to-end middleware tests in
-  [`tonic_middleware.rs`](../../crates/libs/util/tests/tonic_middleware.rs)
-  using a scripted inner `Service` + scripted bodies with trailers:
-  trailer→rebuild, same-value dedup, distinct-value rebuilds,
-  no-trailer reset, empty-value escape hatch, empty-value twice,
-  unrelated-header ignored.
-- 3 e2e failover tests in
-  [`tests/mssf-tests/tests/tonic_failover.rs`](../../tests/mssf-tests/tests/tonic_failover.rs)
-  spinning up two real HTTP/2 servers on ephemeral ports with
-  graceful shutdown:
-  - `failover_via_trailer_and_resolver_flip` — A trailers always,
-    flip resolver to B between calls; assert routing landed
-    correctly and resolver call counts are exactly 2.
-  - `no_trailer_no_rebuild_pool_reused` — steady-state HTTP/2 pool
-    reuse, exactly 1 resolver call across 3 requests.
-  - `server_becomes_stable_after_one_trailer` — single server
-    starts unstable then quiesces; exercises the `Reset`
-    transition + same-target rebuild + steady state.
+The mock suites pin down everything that's deterministic
+(classification, dedup, resolver mechanics). The live suite
+covers what mocks can't:
+[`FabricTargetResolver`](../../crates/libs/util/src/tonic/naming/default.rs)
+against real SF naming, the `ReflectionUrl`-parsing
+[`primary_selector`](../../crates/samples/reflection/src/grpc.rs)
+against real endpoint strings, real role transitions, and
+end-to-end interaction with `get_write_status` from inside a
+real handler. It uses `restart_replica` rather than
+`move_primary` (`move_primary` is flaky on Linux onebox for
+persistent stateful services).
 
-### Deferred — live-cluster failover sample
-
-Originally planned as a stateful `ReflectionApp` with `MyGreeter`
-honoring the trailer contract, plus `move_primary` /
-`restart_replica` orchestration. Deferred — the e2e mock-server
-suite covers the channel layers, the dedup state machine, and the
-failover orchestration deterministically. The live-cluster test
-is most useful for validating
-[`FabricTargetResolver`](../../crates/libs/util/src/tonic/naming/default.rs)'s
-always-complain bookkeeping and address-parse selectors against
-real SF naming, neither of which is exercised by the mock tests.
-
-When it lands, the test plan is:
-
-1. Stateful service with target/min replicas (3,3,0); `MyGreeter`
-   gates on `ServicePartitionAccessStatus` and attaches
-   `mssf-status: not-primary` on writes from non-primaries.
-2. Build a `TargetChannel` for the service URI with a primary-only
-   selector.
-3. Clean failover (Case 2): `move_primary` so the former primary
-   stays up as a secondary. First call returns trailer; second
-   call lands on new primary without test-level retry.
-4. Process-restart failover (Case 1): `restart_replica`; next call
-   succeeds without test-level retry.
-5. In-flight survival under failover.
-6. TLS composition repeat once the `tonic_tls::Transport` adapter
-   ships.
+Future test work: in-flight survival under failover (open
+streaming RPC during a primary swap), and TLS composition repeat
+once the `tonic_tls::Transport` adapter ships.
 
 ## Open questions
 

--- a/tests/mssf-tests/Cargo.toml
+++ b/tests/mssf-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition.workspace = true
 publish = false
 
+[build-dependencies]
+tonic-prost-build.workspace = true
+
 [dev-dependencies]
 mssf-util = { workspace = true, default-features = true, features = ["tonic"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "sync"] }
@@ -14,6 +17,8 @@ http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 tonic.workspace = true
+tonic-prost.workspace = true
+prost.workspace = true
 tower.workspace = true
 arc-swap.workspace = true
 futures.workspace = true

--- a/tests/mssf-tests/build.rs
+++ b/tests/mssf-tests/build.rs
@@ -1,0 +1,11 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generated code is consumed by tests/tonic_server_trailers.rs
+    // via `tonic::include_proto!("testsvc")`.
+    tonic_prost_build::compile_protos("proto/testsvc.proto")?;
+    Ok(())
+}

--- a/tests/mssf-tests/proto/testsvc.proto
+++ b/tests/mssf-tests/proto/testsvc.proto
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+//
+// Minimal one-RPC service used by tests/tonic_server_trailers.rs to
+// pin down where tonic places response metadata on the wire.
+// Lives in this crate (not the reflection sample) because the
+// property under test is about tonic-prost code generation, not
+// Service Fabric.
+
+syntax = "proto3";
+
+package testsvc;
+
+service TestSvc {
+  rpc Ping (PingRequest) returns (PingReply);
+}
+
+message PingRequest {}
+message PingReply {}

--- a/tests/mssf-tests/tests/tonic_server_trailers.rs
+++ b/tests/mssf-tests/tests/tonic_server_trailers.rs
@@ -1,0 +1,528 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Pins down what a tonic-generated server, called through the
+//! tonic-generated client, looks like to
+//! [`ResolveStatusMiddleware`] — and where the metadata
+//! actually lives on the wire.
+//!
+//! ## Why this exists
+//!
+//! - [`crates/libs/util/tests/tonic_middleware.rs`](../../crates/libs/util/tests/tonic_middleware.rs)
+//!   uses scripted `http_body::Frame::trailers` and only proves
+//!   the middleware's dedup behaviour **given** a trailers frame.
+//! - [`tonic_failover.rs`](tonic_failover.rs) uses raw hyper
+//!   servers that emit a trailers frame by hand.
+//!
+//! Neither exercises the **tonic codegen path** a real adopter
+//! takes (`#[tonic::async_trait] impl Foo for MySvc` →
+//! `FooServer::new(MySvc)` served via
+//! `tonic::transport::Server`, called via `FooClient::new(...)`).
+//! That's what this file does: a `.proto` ships in
+//! [`proto/testsvc.proto`](../../tests/mssf-tests/proto/testsvc.proto)
+//! and [`build.rs`](../../tests/mssf-tests/build.rs) drives
+//! `tonic-prost-build` to emit `TestSvcServer<T>` /
+//! `TestSvcClient<T>`. The server is wired through
+//! `serve_with_incoming_shutdown` exactly like
+//! [`crates/samples/reflection/src/main.rs`](../../crates/samples/reflection/src/main.rs).
+//!
+//! ## Test layout
+//!
+//! Three tests use the **generated client** so the call site
+//! matches what every adopter will write:
+//!
+//! - [`ok_without_metadata_does_not_rebuild`]
+//! - [`ok_with_metadata_round_trips_and_middleware_catches_it`]
+//! - [`err_with_metadata_round_trips_and_middleware_catches_it`]
+//!
+//! One test uses a **raw HTTP/2 send** to capture body frames
+//! and prove *which* HTTP/2 frame carries each piece of
+//! metadata — that's the wire-level evidence behind why we
+//! must inspect *both* initial headers and the trailers frame.
+//! The generated client decodes metadata into typed accessors
+//! and erases this distinction, so we keep one raw-send test
+//! as the single source of truth:
+//!
+//! - [`wire_level_placement_diagnostic`]
+//!
+//! ## Finding (2026-05)
+//!
+//! Tonic 0.14 surfaces user metadata at the **client API
+//! level** in both paths — `Response::metadata()` on the `Ok`
+//! path and `Status::metadata()` on the `Err` path. **But**
+//! the on-the-wire placement is HEADERS, not trailers:
+//!
+//! - `Response::metadata_mut().insert(...)` on `Ok` → metadata
+//!   in the **initial HEADERS** frame; trailers frame carries
+//!   only `grpc-status: 0`.
+//! - `Status::with_metadata(...)` on `Err` → **trailers-only**
+//!   response: a single HEADERS frame (END_STREAM) carrying
+//!   `grpc-status`, `grpc-message`, **and** the user metadata.
+//!   No DATA, no separate trailers frame.
+//!
+//! [`ResolveStatusMiddleware`] therefore classifies the
+//! configured header on **both** the initial response
+//! `HeaderMap` and any trailers frame, firing at most once
+//! per response. Both `*_round_trips_and_middleware_catches_it`
+//! tests assert `counter == 1`.
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arc_swap::ArcSwap;
+use bytes::Bytes;
+use http::{HeaderName, Method, Request, Uri};
+use http_body::Body as _;
+use http_body_util::{BodyExt as _, Full};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tonic::body::Body;
+use tonic::transport::server::TcpIncoming;
+use tonic::transport::{Channel, Endpoint};
+use tonic::{Code, Status};
+use tower::{Service, ServiceExt as _};
+
+use mssf_util::tonic::ResolveStatusMiddleware;
+
+// ---------------------------------------------------------------
+// Generated tonic code (from proto/testsvc.proto via build.rs).
+// ---------------------------------------------------------------
+
+mod testsvc {
+    tonic::include_proto!("testsvc");
+}
+
+use testsvc::{
+    PingReply, PingRequest,
+    test_svc_client::TestSvcClient,
+    test_svc_server::{TestSvc, TestSvcServer},
+};
+
+/// Trailer header configured on the middleware. Mirrors the SDK
+/// convention from `TonicConnectorDesign.md`.
+const TRAILER: &str = "mssf-status";
+
+// ---------------------------------------------------------------
+// Server-side behaviour — switchable per test so a single server
+// can drive multiple variants in sequence.
+// ---------------------------------------------------------------
+
+/// What the unary handler should return for the next request.
+#[derive(Clone, Copy, Debug)]
+enum Behavior {
+    /// `Ok(Response::new(PingReply {}))` with no metadata.
+    /// Baseline "still the right one" case.
+    Ok,
+    /// `Ok(Response::new(PingReply {}))` with
+    /// `response.metadata_mut().insert(TRAILER, value)`. Tonic
+    /// emits this metadata in the **initial response headers**,
+    /// not in the trailers frame.
+    OkWithMeta(&'static str),
+    /// `Err(Status::with_metadata(Code::Unavailable, "...", md))`
+    /// where `md` carries `mssf-status: value`. Tonic emits this
+    /// as a **trailers-only** response (single HEADERS frame
+    /// with END_STREAM).
+    ErrWithMeta(&'static str),
+}
+
+/// Test implementation of the generated `TestSvc` trait.
+#[derive(Clone)]
+struct MyTestSvc {
+    behavior: Arc<ArcSwap<Behavior>>,
+    hits: Arc<AtomicUsize>,
+}
+
+#[tonic::async_trait]
+impl TestSvc for MyTestSvc {
+    async fn ping(
+        &self,
+        _req: tonic::Request<PingRequest>,
+    ) -> Result<tonic::Response<PingReply>, Status> {
+        self.hits.fetch_add(1, Ordering::SeqCst);
+        match **self.behavior.load() {
+            Behavior::Ok => Ok(tonic::Response::new(PingReply {})),
+            Behavior::OkWithMeta(v) => {
+                let mut r = tonic::Response::new(PingReply {});
+                r.metadata_mut().insert(TRAILER, v.parse().unwrap());
+                Ok(r)
+            }
+            Behavior::ErrWithMeta(v) => {
+                let mut md = tonic::metadata::MetadataMap::new();
+                md.insert(TRAILER, v.parse().unwrap());
+                Err(Status::with_metadata(Code::Unavailable, "not primary", md))
+            }
+        }
+    }
+}
+
+/// Spawn `tonic::transport::Server` on an ephemeral port
+/// serving the generated `TestSvcServer`. Same
+/// `serve_with_incoming_shutdown` pattern
+/// [`crates/samples/reflection/src/main.rs`](../../crates/samples/reflection/src/main.rs)
+/// uses in production.
+async fn spawn_server(
+    behavior: Arc<ArcSwap<Behavior>>,
+    hits: Arc<AtomicUsize>,
+) -> (SocketAddr, ServerHandle) {
+    let svc = MyTestSvc { behavior, hits };
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from(listener);
+    let cancel = CancellationToken::new();
+    let cancel_for_server = cancel.clone();
+    let task = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(TestSvcServer::new(svc))
+            .serve_with_incoming_shutdown(incoming, async move {
+                cancel_for_server.cancelled().await;
+            })
+            .await
+            .expect("tonic server task");
+    });
+    (
+        addr,
+        ServerHandle {
+            cancel,
+            task: Some(task),
+        },
+    )
+}
+
+struct ServerHandle {
+    cancel: CancellationToken,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ServerHandle {
+    async fn shutdown(mut self) {
+        self.cancel.cancel();
+        if let Some(t) = self.task.take() {
+            let _ = t.await;
+        }
+    }
+}
+
+impl Drop for ServerHandle {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(t) = self.task.take() {
+            t.abort();
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Client-side helpers
+// ---------------------------------------------------------------
+
+/// Counts how many times the middleware fires `rebuild`.
+#[derive(Clone, Default)]
+struct RebuildCounter(Arc<AtomicUsize>);
+impl RebuildCounter {
+    fn count(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+    fn fire(&self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+/// Build a tonic `Channel` pointed at `addr`, wrap it in
+/// `ResolveStatusMiddleware`, return both the middleware and the
+/// counter the test will assert on.
+fn build_middleware(addr: SocketAddr) -> (ResolveStatusMiddleware<Channel>, RebuildCounter) {
+    let endpoint = Endpoint::from_shared(format!("http://{addr}")).expect("valid endpoint");
+    let channel = endpoint.connect_lazy();
+    let counter = RebuildCounter::default();
+    let counter_for_rebuild = counter.clone();
+    let mw = ResolveStatusMiddleware::new(channel, HeaderName::from_static(TRAILER), move || {
+        counter_for_rebuild.fire()
+    });
+    (mw, counter)
+}
+
+/// Build a generated `TestSvcClient` whose transport is the
+/// middleware-wrapped channel. This is the realistic call site:
+/// adopters write `TestSvcClient::new(middleware_wrapped_channel)`
+/// and use the typed API.
+fn build_client(
+    addr: SocketAddr,
+) -> (
+    TestSvcClient<ResolveStatusMiddleware<Channel>>,
+    RebuildCounter,
+) {
+    let (mw, counter) = build_middleware(addr);
+    (TestSvcClient::new(mw), counter)
+}
+
+// ---------------------------------------------------------------
+// Tests using the generated client (the realistic call site)
+// ---------------------------------------------------------------
+
+/// `Ok` with no metadata: clean steady-state path. Generated
+/// client returns a `Response` with empty metadata; middleware
+/// sees a trailers frame carrying only `grpc-status: 0` and
+/// does not rebuild.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ok_without_metadata_does_not_rebuild() {
+    let behavior = Arc::new(ArcSwap::from_pointee(Behavior::Ok));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let (addr, srv) = spawn_server(behavior, hits.clone()).await;
+    let (mut client, counter) = build_client(addr);
+
+    let resp = client.ping(PingRequest {}).await.expect("ok response");
+    assert!(
+        resp.metadata().get(TRAILER).is_none(),
+        "no server metadata configured → client sees none",
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+    assert_eq!(counter.count(), 0);
+
+    drop(client);
+    srv.shutdown().await;
+}
+
+/// `Response::metadata_mut().insert(TRAILER, v)` on the server
+/// round-trips to the client via `Response::metadata()`, **and**
+/// the middleware observes it via the initial HEADERS frame.
+/// Tonic places this metadata in the initial HEADERS frame (not
+/// the trailers frame), so the middleware's initial-headers
+/// classification path — not its body-frame inspection — is
+/// what fires. See [`wire_level_placement_diagnostic`] for the
+/// wire-level evidence behind the placement claim.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ok_with_metadata_round_trips_and_middleware_catches_it() {
+    let behavior = Arc::new(ArcSwap::from_pointee(Behavior::OkWithMeta("not-primary")));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let (addr, srv) = spawn_server(behavior, hits.clone()).await;
+    let (mut client, counter) = build_client(addr);
+
+    let resp = client.ping(PingRequest {}).await.expect("ok response");
+
+    // Server → client API round-trip works.
+    assert_eq!(
+        resp.metadata()
+            .get(TRAILER)
+            .expect("client sees mssf-status via Response::metadata()")
+            .to_str()
+            .unwrap(),
+        "not-primary",
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+    // Middleware in between also catches it via initial HEADERS.
+    assert_eq!(
+        counter.count(),
+        1,
+        "middleware must inspect initial HEADERS to catch mssf-status set \
+         via Response::metadata_mut(); see wire_level_placement_diagnostic.",
+    );
+
+    drop(client);
+    srv.shutdown().await;
+}
+
+/// `Status::with_metadata(...)` on the server round-trips to
+/// the client via `Status::metadata()`, **and** the middleware
+/// catches it. Tonic emits a trailers-only HEADERS frame for
+/// this case (single HEADERS + END_STREAM carrying
+/// `grpc-status`, `grpc-message`, and the user metadata; no
+/// DATA frame, no separate trailers frame), which the
+/// middleware classifies via its initial-headers path. See
+/// [`wire_level_placement_diagnostic`].
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn err_with_metadata_round_trips_and_middleware_catches_it() {
+    let behavior = Arc::new(ArcSwap::from_pointee(Behavior::ErrWithMeta("not-primary")));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let (addr, srv) = spawn_server(behavior, hits.clone()).await;
+    let (mut client, counter) = build_client(addr);
+
+    let status = client
+        .ping(PingRequest {})
+        .await
+        .expect_err("server returned Err");
+
+    // Server → client API round-trip works.
+    assert_eq!(status.code(), Code::Unavailable);
+    assert_eq!(
+        status
+            .metadata()
+            .get(TRAILER)
+            .expect("client sees mssf-status via Status::metadata()")
+            .to_str()
+            .unwrap(),
+        "not-primary",
+    );
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+    // Middleware in between also catches it via initial HEADERS
+    // (trailers-only response).
+    assert_eq!(
+        counter.count(),
+        1,
+        "middleware must inspect initial HEADERS to catch mssf-status set \
+         via Status::with_metadata() in a trailers-only response; same \
+         path as ok_with_metadata_round_trips_and_middleware_catches_it.",
+    );
+
+    drop(client);
+    srv.shutdown().await;
+}
+
+// ---------------------------------------------------------------
+// Wire-level diagnostic — single source of truth for *why*
+// the tripwire tests above hold.
+// ---------------------------------------------------------------
+
+/// Frame the test captured off the wire — used by
+/// [`wire_level_placement_diagnostic`].
+#[derive(Debug)]
+#[allow(dead_code)] // `len` is captured for diagnostic prints only.
+enum CapturedFrame {
+    Data { len: usize },
+    Trailers(http::HeaderMap),
+}
+
+#[derive(Debug)]
+struct Captured {
+    headers: http::HeaderMap,
+    frames: Vec<CapturedFrame>,
+}
+
+impl Captured {
+    fn trailer_frame(&self) -> Option<&http::HeaderMap> {
+        self.frames.iter().find_map(|f| match f {
+            CapturedFrame::Trailers(h) => Some(h),
+            _ => None,
+        })
+    }
+}
+
+/// Send one valid (empty-message) gRPC request through the
+/// middleware-wrapped channel and capture the response headers
+/// + every body frame.
+///
+/// We bypass the generated client here precisely so we can see
+/// *which frame* each piece of response metadata lands on — the
+/// generated client decodes metadata into typed `metadata()`
+/// accessors and erases that information.
+async fn send_one_raw(mw: &mut ResolveStatusMiddleware<Channel>) -> Captured {
+    // gRPC framing for one empty `PingRequest`:
+    //   1 byte  compression flag (0 = uncompressed)
+    //   4 bytes big-endian length (0)
+    //   0 message bytes
+    // Total: 5 zero bytes.
+    let body =
+        Body::new(Full::new(Bytes::from_static(&[0u8; 5])).map_err(|i: Infallible| match i {}));
+    let req = Request::builder()
+        .method(Method::POST)
+        // Authority is overridden by the Channel; the path is
+        // what `TestSvcServer` routes on.
+        .uri(Uri::from_static("http://invalid.test/testsvc.TestSvc/Ping"))
+        .header("content-type", "application/grpc")
+        .header("te", "trailers")
+        .body(body)
+        .unwrap();
+    let svc = mw.ready().await.expect("middleware ready");
+    let resp = svc.call(req).await.expect("server responded");
+    let (parts, mut body) = resp.into_parts();
+
+    let mut frames = Vec::new();
+    use std::future::poll_fn;
+    loop {
+        let frame = poll_fn(|cx| Pin::new(&mut body).poll_frame(cx)).await;
+        match frame {
+            None => break,
+            Some(Ok(f)) => {
+                if let Some(map) = f.trailers_ref() {
+                    frames.push(CapturedFrame::Trailers(map.clone()));
+                } else if let Some(d) = f.data_ref() {
+                    frames.push(CapturedFrame::Data { len: d.len() });
+                }
+            }
+            Some(Err(_)) => break,
+        }
+    }
+    Captured {
+        headers: parts.headers,
+        frames,
+    }
+}
+
+/// Single wire-level test that captures HTTP/2 frames for both
+/// `OkWithMeta` and `ErrWithMeta` paths and asserts exactly
+/// where tonic puts the metadata. This is the source of truth
+/// for the placement claim that drives the middleware's
+/// inspect-initial-headers branch: tonic emits user metadata on
+/// the initial HEADERS frame for both `Ok` (alongside DATA +
+/// real trailers) and `Err` (trailers-only HEADERS, no DATA, no
+/// trailers frame). The corresponding
+/// `*_round_trips_and_middleware_catches_it` tests assert that
+/// the middleware classifies that initial-headers placement.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wire_level_placement_diagnostic() {
+    let behavior = Arc::new(ArcSwap::from_pointee(Behavior::OkWithMeta("not-primary")));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let (addr, srv) = spawn_server(behavior.clone(), hits.clone()).await;
+    let (mut mw, _counter) = build_middleware(addr);
+
+    // --- Ok + metadata: HEADERS carries mssf-status, trailers frame doesn't. ---
+    let captured = send_one_raw(&mut mw).await;
+    assert_eq!(
+        captured
+            .headers
+            .get(TRAILER)
+            .expect("Ok+meta: mssf-status in initial HEADERS")
+            .to_str()
+            .unwrap(),
+        "not-primary",
+        "tonic puts Response::metadata_mut() in initial HEADERS",
+    );
+    let trailers = captured
+        .trailer_frame()
+        .expect("Ok responses end with a trailers frame");
+    assert!(
+        trailers.get(TRAILER).is_none(),
+        "Ok+meta: mssf-status is NOT mirrored into the trailers frame",
+    );
+    assert_eq!(trailers.get("grpc-status").unwrap(), "0");
+
+    // --- Switch to Err + metadata: trailers-only mode (single HEADERS, END_STREAM). ---
+    behavior.store(Arc::new(Behavior::ErrWithMeta("not-primary")));
+    let captured = send_one_raw(&mut mw).await;
+    assert_eq!(
+        captured
+            .headers
+            .get(TRAILER)
+            .expect("Err+meta: mssf-status in trailers-only HEADERS")
+            .to_str()
+            .unwrap(),
+        "not-primary",
+    );
+    assert_eq!(captured.headers.get("grpc-status").unwrap(), "14");
+    assert!(
+        captured.headers.get("grpc-message").is_some(),
+        "trailers-only response carries grpc-message in HEADERS",
+    );
+    assert!(
+        captured.trailer_frame().is_none(),
+        "trailers-only response has no separate trailers frame",
+    );
+    assert!(
+        !captured
+            .frames
+            .iter()
+            .any(|f| matches!(f, CapturedFrame::Data { .. })),
+        "trailers-only response has no DATA frame",
+    );
+
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+    drop(mw);
+    srv.shutdown().await;
+}


### PR DESCRIPTION
- Extend ResolveStatusMiddleware to inspect both initial response headers and trailer frames for the mssf-status signal, firing at most once
- Add tracing (info/warn) to FabricTargetResolver and middleware rebuild
- Implement Write RPC in reflection sample with access-status gating
- Add live-cluster failover integration test (tonic_failover)
- Add tonic_server_trailers wire-shape verification tests
- Consolidate ReflectionTonicConnectorAdoption.md into TonicConnectorDesign.md