### PR TITLE
[core] Support SF Last Error Message

### DIFF
--- a/crates/libs/core/src/client/health_client.rs
+++ b/crates/libs/core/src/client/health_client.rs
@@ -208,7 +208,7 @@ impl HealthClient {
         desc: &FABRIC_NODE_HEALTH_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricNodeHealthResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricNodeHealthResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -225,7 +225,7 @@ impl HealthClient {
         desc: &FABRIC_CLUSTER_HEALTH_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<mssf_com::FabricClient::IFabricClusterHealthResult>> {
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricClusterHealthResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -242,8 +242,7 @@ impl HealthClient {
         desc: &mssf_com::FabricTypes::FABRIC_APPLICATION_HEALTH_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<mssf_com::FabricClient::IFabricApplicationHealthResult>>
-    {
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricApplicationHealthResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -259,8 +258,7 @@ impl HealthClient {
         desc: &mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<mssf_com::FabricClient::IFabricPartitionHealthResult>>
-    {
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricPartitionHealthResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -276,7 +274,7 @@ impl HealthClient {
         desc: &mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<mssf_com::FabricClient::IFabricServiceHealthResult>> {
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricServiceHealthResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -292,7 +290,7 @@ impl HealthClient {
         desc: &mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<mssf_com::FabricClient::IFabricReplicaHealthResult>> {
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricReplicaHealthResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(

--- a/crates/libs/core/src/client/property_client.rs
+++ b/crates/libs/core/src/client/property_client.rs
@@ -44,7 +44,7 @@ impl PropertyManagementClient {
         name: &Uri,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -61,7 +61,7 @@ impl PropertyManagementClient {
         name: &Uri,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -78,7 +78,7 @@ impl PropertyManagementClient {
         name: &Uri,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<u8>> {
+    ) -> FabricReceiver<crate::Result<u8>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -97,7 +97,7 @@ impl PropertyManagementClient {
         recursive: bool,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricNameEnumerationResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricNameEnumerationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -122,7 +122,7 @@ impl PropertyManagementClient {
         data: &[u8],
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -147,7 +147,7 @@ impl PropertyManagementClient {
         data: i64,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -172,7 +172,7 @@ impl PropertyManagementClient {
         data: f64,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -197,7 +197,7 @@ impl PropertyManagementClient {
         data: &WString,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -222,7 +222,7 @@ impl PropertyManagementClient {
         data: &windows_core::GUID,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -246,7 +246,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -269,7 +269,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricPropertyMetadataResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricPropertyMetadataResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -292,7 +292,7 @@ impl PropertyManagementClient {
         property_name: &WString,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricPropertyValueResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricPropertyValueResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -318,7 +318,7 @@ impl PropertyManagementClient {
         batch: &[FABRIC_PROPERTY_BATCH_OPERATION],
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<(u32, IFabricPropertyBatchResult)>> {
+    ) -> FabricReceiver<crate::Result<(u32, IFabricPropertyBatchResult)>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -344,7 +344,7 @@ impl PropertyManagementClient {
         prev: Option<&IFabricPropertyEnumerationResult>,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricPropertyEnumerationResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricPropertyEnumerationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -370,7 +370,7 @@ impl PropertyManagementClient {
         property_operation: &FABRIC_PUT_CUSTOM_PROPERTY_OPERATION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -442,7 +442,6 @@ impl PropertyManagementClient {
             cancellation_token,
         )
         .await?
-        .map_err(|e| e.into())
         .map(|exist| exist != 0)
     }
 
@@ -466,7 +465,6 @@ impl PropertyManagementClient {
             cancellation_token,
         )
         .await?
-        .map_err(|e| e.into())
         .map(NameEnumerationResult::from_com)
     }
 
@@ -603,7 +601,6 @@ impl PropertyManagementClient {
             cancellation_token,
         )
         .await?
-        .map_err(|e| e.into())
         .map(PropertyMetadataResult::from_com)
     }
 
@@ -622,7 +619,6 @@ impl PropertyManagementClient {
             cancellation_token,
         )
         .await?
-        .map_err(|e| e.into())
         .map(PropertyValueResult::from_com)
     }
 }

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -49,7 +49,7 @@ impl QueryClient {
         query_description: &FABRIC_NODE_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricGetNodeListResult2>> {
+    ) -> FabricReceiver<crate::Result<IFabricGetNodeListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
 
@@ -67,7 +67,7 @@ impl QueryClient {
         query_description: &FABRIC_APPLICATION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricGetApplicationListResult2>> {
+    ) -> FabricReceiver<crate::Result<IFabricGetApplicationListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -84,8 +84,7 @@ impl QueryClient {
         desc: &FABRIC_SERVICE_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<mssf_com::FabricClient::IFabricGetServiceListResult2>>
-    {
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricGetServiceListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -102,7 +101,7 @@ impl QueryClient {
         desc: &FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricGetPartitionListResult2>> {
+    ) -> FabricReceiver<crate::Result<IFabricGetPartitionListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -119,7 +118,7 @@ impl QueryClient {
         desc: &FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricGetReplicaListResult2>> {
+    ) -> FabricReceiver<crate::Result<IFabricGetReplicaListResult2>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -136,7 +135,7 @@ impl QueryClient {
         desc: &FABRIC_PARTITION_LOAD_INFORMATION_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricGetPartitionLoadInformationResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricGetPartitionLoadInformationResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -153,7 +152,7 @@ impl QueryClient {
         desc: &FABRIC_DEPLOYED_SERVICE_REPLICA_DETAIL_QUERY_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricGetDeployedServiceReplicaDetailResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricGetDeployedServiceReplicaDetailResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(

--- a/crates/libs/core/src/client/svc_mgmt_client.rs
+++ b/crates/libs/core/src/client/svc_mgmt_client.rs
@@ -57,7 +57,7 @@ impl ServiceManagementClient {
         previous_result: Option<&IFabricResolvedServicePartitionResult>, // This is different from generated code
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<IFabricResolvedServicePartitionResult>> {
+    ) -> FabricReceiver<crate::Result<IFabricResolvedServicePartitionResult>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -81,7 +81,7 @@ impl ServiceManagementClient {
         desc: &FABRIC_RESTART_REPLICA_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -98,7 +98,7 @@ impl ServiceManagementClient {
         desc: &FABRIC_REMOVE_REPLICA_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -115,7 +115,7 @@ impl ServiceManagementClient {
         desc: &FABRIC_SERVICE_NOTIFICATION_FILTER_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<i64>> {
+    ) -> FabricReceiver<crate::Result<i64>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -132,7 +132,7 @@ impl ServiceManagementClient {
         filterid: i64,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -153,7 +153,7 @@ impl ServiceManagementClient {
         desc: &FABRIC_SERVICE_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -171,7 +171,7 @@ impl ServiceManagementClient {
         desc: &FABRIC_SERVICE_UPDATE_DESCRIPTION,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -188,7 +188,7 @@ impl ServiceManagementClient {
         name: FABRIC_URI,
         timeout_milliseconds: u32,
         cancellation_token: Option<BoxedCancelToken>,
-    ) -> FabricReceiver<crate::WinResult<()>> {
+    ) -> FabricReceiver<crate::Result<()>> {
         let com1 = &self.com;
         let com2 = self.com.clone();
         fabric_begin_end_proxy(
@@ -261,7 +261,6 @@ impl ServiceManagementClient {
             self.restart_replica_internal(&raw, timeout.as_millis() as u32, cancellation_token)
         }
         .await?
-        .map_err(crate::Error::from)
     }
 
     /// This API gives a running replica the chance to cleanup its state and be gracefully shutdown.
@@ -280,7 +279,6 @@ impl ServiceManagementClient {
             self.remove_replica_internal(&raw, timeout.as_millis() as u32, cancellation_token)
         }
         .await?
-        .map_err(crate::Error::from)
     }
 
     /// Remarks:
@@ -330,7 +328,6 @@ impl ServiceManagementClient {
             cancellation_token,
         )
         .await?
-        .map_err(crate::Error::from)
     }
 
     pub async fn create_service(
@@ -345,7 +342,6 @@ impl ServiceManagementClient {
             self.create_service_internal(&ffi_raw, timeout.as_millis() as u32, cancellation_token)
         }
         .await?
-        .map_err(crate::Error::from)
     }
 
     pub async fn update_service(
@@ -366,7 +362,6 @@ impl ServiceManagementClient {
             )
         }
         .await?
-        .map_err(crate::Error::from)
     }
 
     pub async fn delete_service(
@@ -381,7 +376,6 @@ impl ServiceManagementClient {
             cancellation_token,
         )
         .await?
-        .map_err(crate::Error::from)
     }
 }
 

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -99,17 +99,37 @@ async fn test_fabric_client() {
                     // FABRIC_E_SERVICE_OFFLINE is the expected result.
                     // TODO: Investigate the ci.
                     assert!(
-                        e.0 == crate::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0)
-                            || e.0
+                        e.code() == crate::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0)
+                            || e.code()
                                 == crate::HRESULT(
                                     mssf_com::FabricTypes::FABRIC_E_SERVICE_OFFLINE.0
                                 )
                     );
                 } else {
-                    assert_eq!(e.0, crate::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0));
+                    assert_eq!(e.code(), crate::HRESULT(FABRIC_E_SERVICE_DOES_NOT_EXIST.0));
                     println!("EchoApp not provisioned. Skip validate.")
                 }
             }
+        }
+    }
+
+    // Test property client with error
+    {
+        let pc = c.get_property_manager();
+        // Create a name that is invalide to force error, and check the error message is propagated.
+        {
+            let err = pc
+                .create_name(&Uri::from("fabric:/bad?x=1"), timeout, None)
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.try_as_fabric_error_code().unwrap(),
+                ErrorCode::FABRIC_E_INVALID_NAME_URI
+            );
+            assert_eq!(
+                err.to_string(),
+                "FABRIC_E_INVALID_NAME_URI (-2147017794): The name 'fabric:/bad?x=1' is invalid: character '?' is not supported."
+            );
         }
     }
 }

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -116,7 +116,7 @@ async fn test_fabric_client() {
     // Test property client with error
     {
         let pc = c.get_property_manager();
-        // Create a name that is invalide to force error, and check the error message is propagated.
+        // Create a name that is invalid to force error, and check the error message is propagated.
         {
             let err = pc
                 .create_name(&Uri::from("fabric:/bad?x=1"), timeout, None)

--- a/crates/libs/core/src/error/errorcode.rs
+++ b/crates/libs/core/src/error/errorcode.rs
@@ -35,10 +35,15 @@ const E_DIR_NOT_EMPTY: FABRIC_ERROR_CODE = FABRIC_ERROR_CODE(
 const E_NOT_FOUND: FABRIC_ERROR_CODE =
     FABRIC_ERROR_CODE(HRESULT::from_win32(windows_core::Win32::Foundation::ERROR_NOT_FOUND.0).0);
 
+// Internal error codes used by SF.
+// TODO: Add the complete list from dotnet and cpp code.
+const FABRIC_INTERNAL_E_CANNOT_CONNECT: FABRIC_ERROR_CODE = FABRIC_ERROR_CODE(0x80071CC0u32 as i32);
+
 /// Hepler macro to define fabric error code.
 /// SF uses win32 hresult code together with the custom fabric error code.
 /// This enum helps passing errors between Rust and SF API, and is easy to debug.
-/// code1 list are windows errors, lit is a dummy string literal, code list are fabric errors.
+/// code1 list are errors defined in this current file, lit is a dummy string literal,
+/// code list are fabric errors defined in FabricTypes.rs.
 /// The macro defines windows errors first, then followed by fabric errors.
 // Need to match cs impl:
 // https://github.com/microsoft/service-fabric/blob/19791eb97c8d876517daa030e5a403f4bcad25b1/src/prod/src/managed/Api/src/System/Fabric/Interop/NativeTypes.cs#L57
@@ -80,7 +85,7 @@ macro_rules! define_fabric_error_code{
 
 impl From<ErrorCode> for crate::Error {
     fn from(value: ErrorCode) -> Self {
-        crate::Error(HRESULT(value as i32))
+        crate::Error::from_hresult(HRESULT(value as i32))
     }
 }
 
@@ -142,6 +147,8 @@ define_fabric_error_code!(
     E_FILE_EXISTS,
     E_DIR_NOT_EMPTY,
     E_NOT_FOUND,
+    // Internal errors
+    FABRIC_INTERNAL_E_CANNOT_CONNECT,
     ("Literal for breaking up first error chunk and the fabric errors"),
     FABRIC_E_COMMUNICATION_ERROR,
     FABRIC_E_INVALID_ADDRESS,

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -139,14 +139,16 @@ impl From<core::num::TryFromIntError> for Error {
 // Get last error message from current thread from SF.
 // Call this after an SF API call failure.
 fn get_last_error_message() -> Option<WString> {
-    // The call returns error only when input result ptr is null:
+    // The call returns error only when input COM holder ptr is null:
     // https://github.com/microsoft/service-fabric/blob/ddfed33de371857f8fdb92287a8e0497297c8ccf/src/prod/src/retail/native/FabricCommon/FabricCommon.cpp#L233
-    let msg = crate::api::API_TABLE
-        .fabric_get_last_error_message()
-        .expect("failed to get error message");
-    // If message is not set, the returned string should be empty.
+    // Our COM layer always provides a valid pointer, so we can safely ignore here.
+    let msg = crate::api::API_TABLE.fabric_get_last_error_message().ok()?;
+    // If message is not set, the returned string is be empty c string from cpp side.
+    // We convert null or empty string to None, and non-empty string to Some.
     let smsg = crate::strings::StringResult::from(&msg).into_inner();
-    match smsg.is_empty() {
+    // Intetional check len instead of is_empty because WString can be Nul and not empty.
+    #[allow(clippy::len_zero)]
+    match smsg.len() == 0 {
         true => None,
         false => Some(smsg),
     }

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -209,13 +209,22 @@ mod test {
         // In this call SF does not set the last error message.
         let err = crate::runtime::create_com_runtime().unwrap_err();
         let err_thread = Error::from_thread(err.code());
-        assert_eq!(
-            err_thread.code(),
-            ErrorCode::FABRIC_INTERNAL_E_CANNOT_CONNECT.into()
-        );
-        assert_eq!(
-            format!("{err_thread}"),
-            "FABRIC_INTERNAL_E_CANNOT_CONNECT (-2147017536)"
-        );
+        match err_thread.try_as_fabric_error_code().unwrap() {
+            // When onebox is not running on the same machine.
+            ErrorCode::FABRIC_INTERNAL_E_CANNOT_CONNECT => {
+                assert_eq!(
+                    format!("{err_thread}"),
+                    "FABRIC_INTERNAL_E_CANNOT_CONNECT (-2147017536)"
+                );
+            }
+            // When onebox is running. Test is not spawned by SF.
+            ErrorCode::FABRIC_E_CONNECTION_DENIED => {
+                assert_eq!(
+                    format!("{err_thread}"),
+                    "FABRIC_E_CONNECTION_DENIED (-2147017661)"
+                );
+            }
+            c => panic!("unexpected error code {c}"),
+        }
     }
 }

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -76,7 +76,7 @@ impl From<Error> for HRESULT {
 
 impl From<crate::WinError> for Error {
     fn from(error: crate::WinError) -> Self {
-        Self::from_thread(error.code())
+        Self::from_hresult(error.code())
     }
 }
 

--- a/crates/libs/core/src/error/mod.rs
+++ b/crates/libs/core/src/error/mod.rs
@@ -8,6 +8,7 @@ use mssf_com::FabricTypes::FABRIC_ERROR_CODE;
 
 mod errorcode;
 pub use errorcode::ErrorCode;
+use windows_core::WString;
 
 /// Result containing mssf Error.
 pub type Result<T> = core::result::Result<T, Error>;
@@ -18,69 +19,94 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// All safe code uses this Error, and bridge and proxy code needs to
 /// convert this Error into/from WinError.
 #[derive(Clone, PartialEq)]
-pub struct Error(pub super::HRESULT);
+pub struct Error {
+    code: super::HRESULT,
+    msg: Option<WString>,
+}
 
 impl Error {
-    pub fn new(code: HRESULT) -> Self {
-        Self(code)
+    pub fn new(code: HRESULT, msg: Option<WString>) -> Self {
+        Self { code, msg }
+    }
+
+    /// Create error from HRESULT code only, with no message.
+    pub fn from_hresult(code: HRESULT) -> Self {
+        Self::new(code, None)
     }
 
     /// Convert to fabric error code if possible.
     pub fn try_as_fabric_error_code(&self) -> std::result::Result<ErrorCode, &str> {
-        ErrorCode::try_from(FABRIC_ERROR_CODE(self.0.0))
+        ErrorCode::try_from(FABRIC_ERROR_CODE(self.code.0))
+    }
+
+    /// Create error from current thread last error code and message.
+    pub fn from_thread(code: HRESULT) -> Self {
+        let msg = get_last_error_message();
+        Self::new(code, msg)
+    }
+
+    pub fn code(&self) -> HRESULT {
+        self.code
     }
 }
 
 impl From<HRESULT> for Error {
     fn from(value: HRESULT) -> Self {
-        Self::new(value)
+        Self::from_hresult(value)
     }
 }
 
 impl From<FABRIC_ERROR_CODE> for Error {
     fn from(value: FABRIC_ERROR_CODE) -> Self {
-        Self::new(HRESULT(value.0))
+        Self::from_hresult(HRESULT(value.0))
     }
 }
 
 impl From<Error> for super::WinError {
     fn from(val: Error) -> Self {
-        super::WinError::from_hresult(val.0)
+        super::WinError::from_hresult(val.code)
     }
 }
 
 impl From<Error> for HRESULT {
     fn from(value: Error) -> Self {
-        value.0
+        value.code
     }
 }
 
 impl From<crate::WinError> for Error {
     fn from(error: crate::WinError) -> Self {
-        Self(error.into())
+        Self::from_thread(error.code())
     }
 }
 
 impl core::fmt::Debug for Error {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut debug = fmt.debug_struct("FabricError");
-        let str_code = ErrorCode::try_from(FABRIC_ERROR_CODE(self.0.0)).ok();
-        debug.field("code", &self.0.0);
-        match str_code {
-            Some(c) => debug.field("message", &c),
-            None => debug.field("message", &"unknown fabric error"),
+        let code_str = ErrorCode::try_from(FABRIC_ERROR_CODE(self.code.0)).ok();
+        debug.field("code", &self.code.0);
+        match code_str {
+            Some(c) => debug.field("code_str", &c),
+            None => debug.field("code_str", &"unknown fabric error"),
         };
-
+        match &self.msg {
+            Some(m) => debug.field("message", m),
+            None => debug.field("message", &"none"),
+        };
         debug.finish()
     }
 }
 
 impl core::fmt::Display for Error {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let str_code = ErrorCode::try_from(FABRIC_ERROR_CODE(self.0.0)).ok();
+        let str_code = ErrorCode::try_from(FABRIC_ERROR_CODE(self.code.0)).ok();
         match str_code {
-            Some(c) => core::write!(fmt, "{} ({})", c, self.0.0),
-            None => core::write!(fmt, "{}", self.0.0),
+            Some(c) => core::write!(fmt, "{} ({})", c, self.code.0),
+            None => core::write!(fmt, "{}", self.code.0),
+        }?;
+        match &self.msg {
+            Some(m) => core::write!(fmt, ": {m}"),
+            None => Ok(()),
         }
     }
 }
@@ -110,6 +136,22 @@ impl From<core::num::TryFromIntError> for Error {
     }
 }
 
+// Get last error message from current thread from SF.
+// Call this after an SF API call failure.
+fn get_last_error_message() -> Option<WString> {
+    // The call returns error only when input result ptr is null:
+    // https://github.com/microsoft/service-fabric/blob/ddfed33de371857f8fdb92287a8e0497297c8ccf/src/prod/src/retail/native/FabricCommon/FabricCommon.cpp#L233
+    let msg = crate::api::API_TABLE
+        .fabric_get_last_error_message()
+        .expect("failed to get error message");
+    // If message is not set, the returned string should be empty.
+    let smsg = crate::strings::StringResult::from(&msg).into_inner();
+    match smsg.is_empty() {
+        true => None,
+        false => Some(smsg),
+    }
+}
+
 #[cfg(test)]
 mod test {
 
@@ -124,7 +166,7 @@ mod test {
         // check debug string
         assert_eq!(
             format!("{fe:?}"),
-            "FabricError { code: -2147017733, message: FABRIC_E_CODE_PACKAGE_NOT_FOUND }"
+            "FabricError { code: -2147017733, code_str: FABRIC_E_CODE_PACKAGE_NOT_FOUND, message: \"none\" }"
         );
         // check display string
         assert_eq!(
@@ -155,7 +197,23 @@ mod test {
         assert_eq!(format!("{fe}"), "-2146893052");
         assert_eq!(
             format!("{fe:?}"),
-            "FabricError { code: -2146893052, message: \"unknown fabric error\" }"
+            "FabricError { code: -2146893052, code_str: \"unknown fabric error\", message: \"none\" }"
+        );
+    }
+
+    #[test]
+    fn test_error_from_thread() {
+        // Call an obvious failing API to get error from thread.
+        // In this call SF does not set the last error message.
+        let err = crate::runtime::create_com_runtime().unwrap_err();
+        let err_thread = Error::from_thread(err.code());
+        assert_eq!(
+            err_thread.code(),
+            ErrorCode::FABRIC_INTERNAL_E_CANNOT_CONNECT.into()
+        );
+        assert_eq!(
+            format!("{err_thread}"),
+            "FABRIC_INTERNAL_E_CANNOT_CONNECT (-2147017536)"
         );
     }
 }

--- a/crates/libs/core/src/runtime/node_context.rs
+++ b/crates/libs/core/src/runtime/node_context.rs
@@ -16,7 +16,7 @@ use crate::types::NodeId;
 pub fn get_com_node_context(
     timeout_milliseconds: u32,
     cancellation_token: Option<BoxedCancelToken>,
-) -> crate::sync::FabricReceiver<crate::WinResult<IFabricNodeContextResult2>> {
+) -> crate::sync::FabricReceiver<crate::Result<IFabricNodeContextResult2>> {
     fabric_begin_end_proxy(
         move |callback| {
             crate::API_TABLE.fabric_begin_get_node_context(timeout_milliseconds, callback)

--- a/crates/libs/core/src/runtime/stateful_proxy.rs
+++ b/crates/libs/core/src/runtime/stateful_proxy.rs
@@ -113,7 +113,7 @@ impl IStatefulServiceReplica for StatefulServiceReplicaProxy {
             move |ctx| unsafe { com2.EndClose(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",
@@ -164,7 +164,7 @@ impl IReplicator for ReplicatorProxy {
             move |ctx| unsafe { com2.EndClose(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",
@@ -186,7 +186,7 @@ impl IReplicator for ReplicatorProxy {
             move |ctx| unsafe { com2.EndChangeRole(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",
@@ -205,7 +205,7 @@ impl IReplicator for ReplicatorProxy {
             move |ctx| unsafe { com2.EndUpdateEpoch(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",
@@ -296,7 +296,7 @@ impl IPrimaryReplicator for PrimaryReplicatorProxy {
             move |ctx| unsafe { com2.EndOnDataLoss(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",
@@ -331,7 +331,7 @@ impl IPrimaryReplicator for PrimaryReplicatorProxy {
             move |ctx| unsafe { com2.EndWaitForCatchUpQuorum(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",
@@ -367,7 +367,7 @@ impl IPrimaryReplicator for PrimaryReplicatorProxy {
             move |ctx| unsafe { com2.EndBuildReplica(ctx) },
             Some(cancellation_token),
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
     #[cfg_attr(
         feature = "tracing",

--- a/crates/libs/core/src/runtime/store_proxy.rs
+++ b/crates/libs/core/src/runtime/store_proxy.rs
@@ -121,7 +121,7 @@ impl TransactionProxy {
             move |ctx| unsafe { com2.EndCommit(ctx) },
             cancellation_token,
         );
-        rx.await?.map_err(crate::Error::from)
+        rx.await?
     }
 
     pub fn rollback(&self) {

--- a/crates/libs/core/src/sync/proxy.rs
+++ b/crates/libs/core/src/sync/proxy.rs
@@ -24,7 +24,7 @@ use super::{FabricReceiver, oneshot_channel};
 /// the begin and end closure needs to be manually written.
 ///
 /// Begin closure is initiated/called, and FabricReceiver is returned to the user. FabricSender
-/// is supposed to send the async result obtaind from the end closure to the user.
+/// is supposed to send the async result obtained from the end closure to the user.
 /// End closure is wrapped in an awaitable callback (together with a FabricSender),
 /// and such callback is passed to SF begin api and is invoked when
 /// the (begin) initiated operation completes.
@@ -45,7 +45,7 @@ pub fn fabric_begin_end_proxy<BEGIN, END, T>(
     begin: BEGIN,
     end: END,
     token: Option<BoxedCancelToken>,
-) -> FabricReceiver<crate::WinResult<T>>
+) -> FabricReceiver<crate::Result<T>>
 where
     BEGIN: FnOnce(
         Option<&IFabricAsyncOperationCallback>,
@@ -56,7 +56,10 @@ where
     let (tx, mut rx) = oneshot_channel(token);
 
     let callback = crate::sync::AwaitableCallback::new_interface(move |ctx| {
-        let res = end(ctx.as_ref());
+        let res = end(ctx.as_ref()).map_err(|e| {
+            // Capture the thread error message here right after the end call.
+            crate::Error::from_thread(e.code())
+        });
         tx.send(res);
     });
     let ctx = begin(Some(&callback));
@@ -67,6 +70,8 @@ where
             rx
         }
         Err(e) => {
+            // Capture the thread error message here right after the begin call.
+            let e = crate::Error::from_thread(e.code());
             let (tx2, rx2) = oneshot_channel(None);
             tx2.send(Err(e));
             rx2

--- a/crates/libs/util/src/tokio/tests.rs
+++ b/crates/libs/util/src/tokio/tests.rs
@@ -256,6 +256,7 @@ mod proxy_test {
                 token,
             )
             .await?
+            .map_err(|e| mssf_core::WinError::from_hresult(e.code()))
         }
 
         async fn set_data_delay(
@@ -272,6 +273,7 @@ mod proxy_test {
                 token,
             )
             .await?
+            .map_err(|e| mssf_core::WinError::from_hresult(e.code()))
         }
     }
 


### PR DESCRIPTION
SF sets the thread local error message on SF API call error, and user can use FabricGetLastErrorMessage to get the message.
In dotnet, all SF calls COM api calls retrieves the error message via FabricGetLastErrorMessage.
We implement the same logic here in mssf following dotnet: mssf_core::Error type adds an error message field and is populated after COM api call. This PR only enables this for all async Begin/End api pair, and future PR will enable all apis to capture last error message.

For example:
```rust
            let err = property_client
                .create_name(&Uri::from("fabric:/bad?x=1"), timeout, None)
                .await
                .unwrap_err();
            assert_eq!(
                err.to_string(),
                "FABRIC_E_INVALID_NAME_URI (-2147017794): The name 'fabric:/bad?x=1' is invalid: character '?' is not supported."
            );
```

`The name 'fabric:/bad?x=1' is invalid: character '?' is not supported.` This is the last error message and is very useful for debugging, that is never exposed in mssf before.
