### PR TITLE
Update onebox linux to SF 11.5 rc version

### DIFF
--- a/.devcontainer/azl3/Dockerfile
+++ b/.devcontainer/azl3/Dockerfile
@@ -11,7 +11,7 @@ RUN tdnf install --noplugins --skipsignature -y \
 # install sf
 RUN mkdir -p /var/opt/microsoft/servicefabric/ && echo "Accepted" | tee /var/opt/microsoft/servicefabric/accepted-eula-ga
 
-ENV SF_VERSION=11.4.269.5
+ENV SF_VERSION=11.5.118.5
 RUN wget https://download.microsoft.com/download/3/1/F/31F3FEEB-F073-4E27-A98B-8E691FF74F40/ServiceFabric.AL.${SF_VERSION}.rpm
 RUN tdnf install -y ./ServiceFabric.AL.${SF_VERSION}.rpm
 RUN rm ServiceFabric.AL.${SF_VERSION}.rpm

--- a/.devcontainer/u22/Dockerfile
+++ b/.devcontainer/u22/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "servicefabric servicefabric/accepted-eula-ga select true" | debconf-se
   && echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true" | debconf-set-selections
 # RUN apt-get install -y servicefabricsdkcommon
 
-ENV SF_VERSION=11.4.268.4
+ENV SF_VERSION=11.5.111.4
 RUN wget https://download.microsoft.com/download/3/1/F/31F3FEEB-F073-4E27-A98B-8E691FF74F40/ServiceFabric.U22.${SF_VERSION}.deb
 RUN apt-get install -y ./ServiceFabric.U22.${SF_VERSION}.deb
 RUN rm ServiceFabric.U22.${SF_VERSION}.deb

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -234,8 +234,28 @@ jobs:
         if: failure()
         run: |
           mkdir -p /tmp/artifacts/executables
-          sudo chown $USER:$USER target/debug/deps/samples_reflection-*
-          sudo cp target/debug/deps/samples_reflection-* /tmp/artifacts/executables/ || { echo "Fail to copy known executable"; exit 1; }
+          # Reflection sample binary plus all of its integration test binaries.
+          # Test names mirror files under crates/samples/reflection/tests/*.rs
+          patterns=(
+            samples_reflection
+            concurrency
+            control_e2e
+            fail_lifecycle
+            failover
+            partition_admin
+            tonic_failover
+          )
+          for name in "${patterns[@]}"; do
+            files=$(find target/debug/deps -maxdepth 1 -type f -executable -name "${name}-*" ! -name "*.d" ! -name "*.rlib" ! -name "*.rmeta" || true)
+            if [ -z "$files" ]; then
+              echo "No binaries found for pattern ${name}-*"
+              continue
+            fi
+            for f in $files; do
+              sudo chown $USER:$USER "$f"
+              sudo cp "$f" /tmp/artifacts/executables/ || { echo "Fail to copy $f"; exit 1; }
+            done
+          done
 
       - name: Collect core dumps
         if: always()


### PR DESCRIPTION
It seems FabricClient drop issue is not yet fixed in this version, and we would need to wait for sf 12.0 release.
#184 