### PR TITLE
[util] Split health producer into separate cluster/node and application loops

### DIFF
--- a/crates/libs/util/src/monitoring/entities.rs
+++ b/crates/libs/util/src/monitoring/entities.rs
@@ -9,15 +9,32 @@ use mssf_core::types::{
     ServicePartitionQueryResultItem, ServiceQueryResultItem, ServiceReplicaQueryResultItem, Uri,
 };
 
-/// Health entities produced by HealthDataProducer.
+/// Events produced by HealthDataProducer.
+///
+/// Most variants carry a health entity; `IterationComplete` is a control
+/// marker signalling that a producer loop finished an iteration.
 #[derive(Debug, Clone)]
-pub enum HealthEntity {
+pub enum ProducerEvent {
     Node(NodeHealthEntity),
     Cluster(ClusterHealthEntity),
     Application(ApplicationHealthEntity),
     Partition(PartitionHealthEntity),
     Service(ServiceHealthEntity),
     Replica(ReplicaHealthEntity),
+    /// Marker emitted at the end of a producer loop iteration. Allows a
+    /// consumer to detect that a loop has produced a full set of data for the
+    /// current iteration.
+    IterationComplete(LoopKind),
+}
+
+/// Identifies which producer loop an [`ProducerEvent::IterationComplete`] marker
+/// belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopKind {
+    /// The cluster and node health loop.
+    ClusterNode,
+    /// The application (and services, partitions, replicas) health loop.
+    Application,
 }
 
 /// There is no info for cluster name in FabricClient.

--- a/crates/libs/util/src/monitoring/mod.rs
+++ b/crates/libs/util/src/monitoring/mod.rs
@@ -106,15 +106,20 @@ mod tests {
         // Wait at least 1 iteration bit and then stop the producer
         let max_iteration = 30;
         for _ in 0..max_iteration {
-            if producer.get_iteration() > 0 {
+            if producer.get_app_iteration() > 0 && producer.get_node_iteration() > 0 {
                 break;
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         assert_ne!(
-            producer.get_iteration(),
+            producer.get_app_iteration(),
             0,
-            "Producer did not run any iteration"
+            "Producer did not run any application iteration"
+        );
+        assert_ne!(
+            producer.get_node_iteration(),
+            0,
+            "Producer did not run any node iteration"
         );
         drop(producer); // this is required for consumer to finish.
         token.cancel();

--- a/crates/libs/util/src/monitoring/mod.rs
+++ b/crates/libs/util/src/monitoring/mod.rs
@@ -6,22 +6,23 @@
 mod producer;
 pub use producer::HealthDataProducer;
 mod entities;
-pub use entities::{HealthEntity, NodeHealthEntity};
+pub use entities::{LoopKind, NodeHealthEntity, ProducerEvent};
 
 #[cfg(test)]
 mod tests {
 
-    use std::{sync::Arc, time::Duration};
+    use std::time::Duration;
 
     use mssf_core::{WString, client::FabricClient};
     use tokio::sync::mpsc;
 
     use crate::monitoring::{
-        HealthDataProducer, HealthEntity, NodeHealthEntity, entities::ClusterHealthEntity,
+        HealthDataProducer, LoopKind, NodeHealthEntity, ProducerEvent,
+        entities::ClusterHealthEntity,
     };
 
     pub struct MockHealthDataConsumer {
-        receiver: mpsc::UnboundedReceiver<HealthEntity>,
+        receiver: mpsc::UnboundedReceiver<ProducerEvent>,
     }
 
     pub struct HealthDataCollection {
@@ -34,12 +35,21 @@ mod tests {
     }
 
     impl MockHealthDataConsumer {
-        pub fn new(receiver: mpsc::UnboundedReceiver<HealthEntity>) -> Self {
+        pub fn new(receiver: mpsc::UnboundedReceiver<ProducerEvent>) -> Self {
             MockHealthDataConsumer { receiver }
         }
 
-        /// Producer must close.
-        pub async fn get_all_data(&mut self) -> HealthDataCollection {
+        /// Collect exactly one iteration worth of health data.
+        ///
+        /// Each producer loop emits an [`HealthEntity::IterationComplete`]
+        /// marker once it has produced a full set of data for the current
+        /// iteration. We wait until *both* loops (cluster/node and application)
+        /// have signalled completion, then cancel the producer (via `token`)
+        /// and return the collected data.
+        pub async fn get_all_data(
+            &mut self,
+            token: &mssf_core::runtime::executor::BoxedCancelToken,
+        ) -> HealthDataCollection {
             let mut data = HealthDataCollection {
                 node_health_entities: Vec::new(),
                 cluster_health_entity: Vec::new(),
@@ -48,26 +58,38 @@ mod tests {
                 service_health_entities: Vec::new(),
                 replica_health_entities: Vec::new(),
             };
+            let mut cluster_node_done = false;
+            let mut application_done = false;
             while let Some(entity) = self.receiver.recv().await {
                 match entity {
-                    HealthEntity::Node(node_entity) => {
+                    ProducerEvent::Node(node_entity) => {
                         data.node_health_entities.push(node_entity);
                     }
-                    HealthEntity::Cluster(cluster_entity) => {
+                    ProducerEvent::Cluster(cluster_entity) => {
                         data.cluster_health_entity.push(cluster_entity);
                     }
-                    HealthEntity::Application(application_entity) => {
+                    ProducerEvent::Application(application_entity) => {
                         data.application_health_entities.push(application_entity);
                     }
-                    HealthEntity::Partition(partition_entity) => {
+                    ProducerEvent::Partition(partition_entity) => {
                         data.partition_health_entities.push(partition_entity);
                     }
-                    HealthEntity::Service(service_entity) => {
+                    ProducerEvent::Service(service_entity) => {
                         data.service_health_entities.push(service_entity);
                     }
-                    HealthEntity::Replica(replica_entity) => {
+                    ProducerEvent::Replica(replica_entity) => {
                         data.replica_health_entities.push(replica_entity);
                     }
+                    ProducerEvent::IterationComplete(kind) => match kind {
+                        LoopKind::ClusterNode => cluster_node_done = true,
+                        LoopKind::Application => application_done = true,
+                    },
+                }
+                if cluster_node_done && application_done {
+                    // Both loops have produced a full iteration. Stop the
+                    // producer and finish.
+                    token.cancel();
+                    break;
                 }
             }
             data
@@ -78,7 +100,7 @@ mod tests {
         fc: FabricClient,
     ) -> (HealthDataProducer, MockHealthDataConsumer) {
         let (sender, receiver) = mpsc::unbounded_channel();
-        let producer = HealthDataProducer::new(fc, Duration::from_secs(30), sender);
+        let producer = HealthDataProducer::new(fc, Duration::from_secs(3), sender);
         let consumer = MockHealthDataConsumer::new(receiver);
         (producer, consumer)
     }
@@ -97,36 +119,15 @@ mod tests {
         let token = mssf_core::sync::SimpleCancelToken::new_boxed();
         // Simulate producing health data
         let token_clone = token.clone();
-        let producer = Arc::new(producer);
-        let producer_clone = producer.clone();
         let ph = tokio::spawn(async move {
-            producer_clone.run_loop(token_clone).await;
+            producer.run_loop(token_clone).await;
         });
 
-        // Wait at least 1 iteration bit and then stop the producer
-        let max_iteration = 30;
-        for _ in 0..max_iteration {
-            if producer.get_app_iteration() > 0 && producer.get_node_iteration() > 0 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-        assert_ne!(
-            producer.get_app_iteration(),
-            0,
-            "Producer did not run any application iteration"
-        );
-        assert_ne!(
-            producer.get_node_iteration(),
-            0,
-            "Producer did not run any node iteration"
-        );
-        drop(producer); // this is required for consumer to finish.
-        token.cancel();
+        // Consume the health data. The consumer stops the producer once it has
+        // observed one full iteration (signalled by the second cluster entity).
+        let data = consumer.get_all_data(&token).await;
         ph.await.unwrap();
 
-        // Consume the health data
-        let data = consumer.get_all_data().await;
         // check cluster health entity
         assert_eq!(
             data.cluster_health_entity.len(),

--- a/crates/libs/util/src/monitoring/producer.rs
+++ b/crates/libs/util/src/monitoring/producer.rs
@@ -3,7 +3,10 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use crate::monitoring::{HealthEntity, NodeHealthEntity, entities::ClusterHealthEntity};
+use crate::monitoring::{
+    NodeHealthEntity, ProducerEvent,
+    entities::{ClusterHealthEntity, LoopKind},
+};
 use ::tokio::sync::mpsc;
 use mssf_core::{
     client::FabricClient,
@@ -21,11 +24,7 @@ use std::time::Duration;
 pub struct HealthDataProducer {
     fc: FabricClient,
     interval: Duration,
-    sender: mpsc::UnboundedSender<HealthEntity>,
-    /// Number of completed cluster + node loop iterations.
-    node_iteration: std::sync::atomic::AtomicU64,
-    /// Number of completed application loop iterations.
-    app_iteration: std::sync::atomic::AtomicU64,
+    sender: mpsc::UnboundedSender<ProducerEvent>,
 }
 
 /// Default timeout for FabricClient operations.
@@ -39,19 +38,17 @@ impl HealthDataProducer {
     pub fn new(
         fc: FabricClient,
         interval: Duration,
-        sender: mpsc::UnboundedSender<HealthEntity>,
+        sender: mpsc::UnboundedSender<ProducerEvent>,
     ) -> Self {
         HealthDataProducer {
             fc,
             interval,
             sender,
-            node_iteration: std::sync::atomic::AtomicU64::new(0),
-            app_iteration: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
-    fn send_entity(&self, entity: HealthEntity) -> Result<(), Action> {
-        self.sender.send(entity).map_err(|_| {
+    fn send_event(&self, event: ProducerEvent) -> Result<(), Action> {
+        self.sender.send(event).map_err(|_| {
             tracing::error!("Receiver dropped, cannot send more data.");
             Action::Stop
         })
@@ -67,18 +64,17 @@ impl HealthDataProducer {
     ) -> Result<(), Action> {
         // Get cluster health information.
         if let Some(entity) = self.produce_cluster_health_entity(token.clone()).await {
-            self.send_entity(entity)?;
+            self.send_event(entity)?;
         }
         // Get node information.
         if let Ok(nodes) = self.get_all_nodes(token.clone()).await {
             for node in nodes {
                 if let Some(entity) = self.produce_node_health_entity(token.clone(), node).await {
-                    self.send_entity(entity)?;
+                    self.send_event(entity)?;
                 }
             }
         }
-        self.node_iteration
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.send_event(ProducerEvent::IterationComplete(LoopKind::ClusterNode))?;
         Ok(())
     }
 
@@ -99,7 +95,7 @@ impl HealthDataProducer {
                     .produce_application_health_entity(token.clone(), app)
                     .await
                 {
-                    self.send_entity(entity)?;
+                    self.send_event(entity)?;
                 }
 
                 // Get service information for the application.
@@ -113,7 +109,7 @@ impl HealthDataProducer {
                         if let Some(entity) =
                             self.produce_service_health_entity(token.clone(), svc).await
                         {
-                            self.send_entity(entity)?;
+                            self.send_event(entity)?;
                         }
 
                         // Get partition information for the service.
@@ -133,7 +129,7 @@ impl HealthDataProducer {
                                     )
                                     .await
                                 {
-                                    self.send_entity(entity)?;
+                                    self.send_event(entity)?;
                                 }
                                 // Get replica information for the partition.
                                 if let Ok(replicas) = self
@@ -152,7 +148,7 @@ impl HealthDataProducer {
                                             )
                                             .await
                                         {
-                                            self.send_entity(entity)?;
+                                            self.send_event(entity)?;
                                         }
                                     }
                                 }
@@ -162,8 +158,7 @@ impl HealthDataProducer {
                 }
             }
         }
-        self.app_iteration
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.send_event(ProducerEvent::IterationComplete(LoopKind::Application))?;
         Ok(())
     }
 
@@ -230,25 +225,13 @@ impl HealthDataProducer {
         }
         tracing::info!("Health data {name} producer loop exited.");
     }
-
-    /// Number of completed application loop iterations.
-    ///
-    /// The application loop is the slowest, so a non-zero value implies the
-    /// faster cluster/node loop has also produced data.
-    pub fn get_app_iteration(&self) -> u64 {
-        self.app_iteration
-            .load(std::sync::atomic::Ordering::Relaxed)
-    }
-
-    /// Number of completed cluster/node loop iterations.
-    pub fn get_node_iteration(&self) -> u64 {
-        self.node_iteration
-            .load(std::sync::atomic::Ordering::Relaxed)
-    }
 }
 
 impl HealthDataProducer {
-    async fn produce_cluster_health_entity(&self, token: BoxedCancelToken) -> Option<HealthEntity> {
+    async fn produce_cluster_health_entity(
+        &self,
+        token: BoxedCancelToken,
+    ) -> Option<ProducerEvent> {
         // Ignore nodes and app health because we retrieve them separately.
         // Technically we can get everything in one call, but the payload might be too large,
         // and we want to get other entities not present in the cluster health.
@@ -271,7 +254,7 @@ impl HealthDataProducer {
                 tracing::error!("Failed to get cluster health: {}", err);
             })
             .ok()?;
-        Some(HealthEntity::Cluster(ClusterHealthEntity {
+        Some(ProducerEvent::Cluster(ClusterHealthEntity {
             health: cluster_healths,
         }))
     }
@@ -281,7 +264,7 @@ impl HealthDataProducer {
         &self,
         token: BoxedCancelToken,
         node: NodeQueryResultItem,
-    ) -> Option<HealthEntity> {
+    ) -> Option<ProducerEvent> {
         // Logic to get node health goes here.
 
         let desc = NodeHealthQueryDescription {
@@ -301,7 +284,7 @@ impl HealthDataProducer {
                 tracing::error!("Failed to get node health: {}", err);
             })
             .ok()?;
-        Some(HealthEntity::Node(NodeHealthEntity {
+        Some(ProducerEvent::Node(NodeHealthEntity {
             node,
             health: node_healths,
         }))
@@ -311,7 +294,7 @@ impl HealthDataProducer {
         &self,
         token: BoxedCancelToken,
         app: mssf_core::types::ApplicationQueryResultItem,
-    ) -> Option<HealthEntity> {
+    ) -> Option<ProducerEvent> {
         let desc = mssf_core::types::ApplicationHealthQueryDescription {
             application_name: app.application_name.clone(),
             ..Default::default()
@@ -325,7 +308,7 @@ impl HealthDataProducer {
                 tracing::error!("Failed to get application health: {}", err);
             })
             .ok()?;
-        Some(HealthEntity::Application(
+        Some(ProducerEvent::Application(
             crate::monitoring::entities::ApplicationHealthEntity {
                 application: app,
                 health: app_health,
@@ -337,7 +320,7 @@ impl HealthDataProducer {
         &self,
         token: BoxedCancelToken,
         svc: mssf_core::types::ServiceQueryResultItem,
-    ) -> Option<HealthEntity> {
+    ) -> Option<ProducerEvent> {
         let svc_name = svc.get_service_name().clone();
         let desc = mssf_core::types::ServiceHealthQueryDescription {
             service_name: svc_name,
@@ -352,7 +335,7 @@ impl HealthDataProducer {
                 tracing::error!("Failed to get service health: {}", err);
             })
             .ok()?;
-        Some(HealthEntity::Service(
+        Some(ProducerEvent::Service(
             crate::monitoring::entities::ServiceHealthEntity {
                 health: svc_health,
                 service: svc,
@@ -366,7 +349,7 @@ impl HealthDataProducer {
         part: mssf_core::types::ServicePartitionQueryResultItem,
         service_name: Uri,
         application_name: Uri,
-    ) -> Option<HealthEntity> {
+    ) -> Option<ProducerEvent> {
         let partition_id = part.get_partition_id();
         let desc = mssf_core::types::PartitionHealthQueryDescription {
             partition_id,
@@ -381,7 +364,7 @@ impl HealthDataProducer {
                 tracing::error!("Failed to get partition health: {}", err);
             })
             .ok()?;
-        Some(HealthEntity::Partition(
+        Some(ProducerEvent::Partition(
             crate::monitoring::entities::PartitionHealthEntity {
                 health: part_health,
                 partition: part,
@@ -398,7 +381,7 @@ impl HealthDataProducer {
         replica: mssf_core::types::ServiceReplicaQueryResultItem,
         service_name: Uri,
         application_name: Uri,
-    ) -> Option<HealthEntity> {
+    ) -> Option<ProducerEvent> {
         let desc = mssf_core::types::ReplicaHealthQueryDescription {
             partition_id,
             replica_id_or_instance_id: replica.get_replica_or_instance_id(),
@@ -413,7 +396,7 @@ impl HealthDataProducer {
                 tracing::error!("Failed to get replica health: {}", err);
             })
             .ok()?;
-        Some(HealthEntity::Replica(
+        Some(ProducerEvent::Replica(
             crate::monitoring::entities::ReplicaHealthEntity {
                 health: replica_health,
                 replica,

--- a/crates/libs/util/src/monitoring/producer.rs
+++ b/crates/libs/util/src/monitoring/producer.rs
@@ -22,7 +22,10 @@ pub struct HealthDataProducer {
     fc: FabricClient,
     interval: Duration,
     sender: mpsc::UnboundedSender<HealthEntity>,
-    iteration: std::sync::atomic::AtomicU64,
+    /// Number of completed cluster + node loop iterations.
+    node_iteration: std::sync::atomic::AtomicU64,
+    /// Number of completed application loop iterations.
+    app_iteration: std::sync::atomic::AtomicU64,
 }
 
 /// Default timeout for FabricClient operations.
@@ -42,7 +45,8 @@ impl HealthDataProducer {
             fc,
             interval,
             sender,
-            iteration: std::sync::atomic::AtomicU64::new(0),
+            node_iteration: std::sync::atomic::AtomicU64::new(0),
+            app_iteration: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -53,8 +57,14 @@ impl HealthDataProducer {
         })
     }
 
-    /// Run once to produce health data.
-    pub(crate) async fn run_once(&self, token: BoxedCancelToken) -> Result<(), Action> {
+    /// Run once to produce cluster and node health data.
+    ///
+    /// Kept separate from application health so that the (potentially slow)
+    /// application traversal does not delay cluster/node reporting.
+    pub(crate) async fn run_once_cluster_and_nodes(
+        &self,
+        token: BoxedCancelToken,
+    ) -> Result<(), Action> {
         // Get cluster health information.
         if let Some(entity) = self.produce_cluster_health_entity(token.clone()).await {
             self.send_entity(entity)?;
@@ -67,6 +77,20 @@ impl HealthDataProducer {
                 }
             }
         }
+        self.node_iteration
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Run once to produce application health data, including the services,
+    /// partitions, and replicas underneath each application.
+    ///
+    /// This traversal can be slow on large clusters, so it runs in its own
+    /// loop independent of cluster/node reporting.
+    pub(crate) async fn run_once_applications(
+        &self,
+        token: BoxedCancelToken,
+    ) -> Result<(), Action> {
         // Get application information.
         if let Ok(apps) = self.get_all_applications(token.clone()).await {
             for app in apps {
@@ -138,23 +162,50 @@ impl HealthDataProducer {
                 }
             }
         }
-        self.iteration
+        self.app_iteration
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
 
-    /// Run a loop to produce health data.
+    /// Run both the cluster/node loop and the application loop concurrently.
+    ///
+    /// The two loops are independent: a slow application traversal will not
+    /// delay cluster/node reporting, and vice versa.
     pub async fn run_loop(&self, token: BoxedCancelToken) {
+        tokio::join!(
+            self.run_cluster_node_loop(token.clone()),
+            self.run_application_loop(token.clone()),
+        );
+        tracing::info!("Health data producer loops exited.");
+    }
+
+    /// Run a loop to produce cluster and node health data.
+    pub async fn run_cluster_node_loop(&self, token: BoxedCancelToken) {
+        self.run_interval_loop(token, "cluster/node", |token| {
+            self.run_once_cluster_and_nodes(token)
+        })
+        .await;
+    }
+
+    /// Run a loop to produce application health data.
+    pub async fn run_application_loop(&self, token: BoxedCancelToken) {
+        self.run_interval_loop(token, "application", |token| {
+            self.run_once_applications(token)
+        })
+        .await;
+    }
+
+    /// Drive `run_once` on `self.interval`, honoring cancellation.
+    async fn run_interval_loop<F, Fut>(&self, token: BoxedCancelToken, name: &str, mut run_once: F)
+    where
+        F: FnMut(BoxedCancelToken) -> Fut,
+        Fut: std::future::Future<Output = Result<(), Action>>,
+    {
         loop {
             let start_time = ::tokio::time::Instant::now();
-            match self.run_once(token.clone()).await {
-                Err(Action::Stop) => {
-                    tracing::info!("Health data producer stopped.");
-                    break;
-                }
-                _ => {
-                    // continue the loop
-                }
+            if let Err(Action::Stop) = run_once(token.clone()).await {
+                tracing::info!("Health data {name} producer stopped.");
+                break;
             }
 
             // remaining time
@@ -165,7 +216,7 @@ impl HealthDataProducer {
 
                 tokio::select! {
                     _ = token.wait() => {
-                        tracing::info!("Cancellation requested, exiting health data producer loop.");
+                        tracing::info!("Cancellation requested, exiting health data {name} producer loop.");
                         break;
                     }
                     _ = tokio::time::sleep(wait_duration) => {}
@@ -173,15 +224,26 @@ impl HealthDataProducer {
             }
 
             if token.is_cancelled() {
-                tracing::info!("Cancellation requested, exiting health data producer loop.");
+                tracing::info!("Cancellation requested, exiting health data {name} producer loop.");
                 break;
             }
         }
-        tracing::info!("Health data producer loop exited.");
+        tracing::info!("Health data {name} producer loop exited.");
     }
 
-    pub fn get_iteration(&self) -> u64 {
-        self.iteration.load(std::sync::atomic::Ordering::Relaxed)
+    /// Number of completed application loop iterations.
+    ///
+    /// The application loop is the slowest, so a non-zero value implies the
+    /// faster cluster/node loop has also produced data.
+    pub fn get_app_iteration(&self) -> u64 {
+        self.app_iteration
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Number of completed cluster/node loop iterations.
+    pub fn get_node_iteration(&self) -> u64 {
+        self.node_iteration
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
The application traversal (services, partitions, replicas) can be slow on large clusters and was delaying cluster/node health reporting. Run the two as independent loops concurrently so neither blocks the other. Track iterations separately via get_app_iteration and get_node_iteration.

Changed the health entity producer to emit loop completion events. Consumers should be responsible to collect stats.