### PR TITLE
release: bump mssf-core to 0.8.1 and mssf-util to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-util"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ windows-core = "0.62"
 mssf-com = { version = "0.6", path = "./crates/libs/com", default-features = false }
 mssf-core = { version = "0.8", path = "./crates/libs/core", default-features = false }
 mssf-pal = { version = "0.5", path = "./crates/libs/pal", default-features = true }
-mssf-util = { version = "0.8", path = "./crates/libs/util", default-features = true }
+mssf-util = { version = "0.9", path = "./crates/libs/util", default-features = true }

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true

--- a/crates/libs/util/Cargo.toml
+++ b/crates/libs/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-util"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true


### PR DESCRIPTION
- mssf-core 0.8.0 -> 0.8.1 (additive: new delete_service2 + DeleteServiceDescription, delete_service deprecated)
- mssf-util 0.8.0 -> 0.9.0 (breaking: monitoring HealthEntity -> ProducerEvent, HealthDataProducer::new sender type changed, get_iteration removed)