### PR TITLE
Bulk implementation for Self-ReconfiguringService in mssf_core and sample app bring-up

### DIFF
--- a/.devcontainer/onebox/ClusterManifest.SingleMachineFSS.xml
+++ b/.devcontainer/onebox/ClusterManifest.SingleMachineFSS.xml
@@ -130,6 +130,7 @@
     </Section>
     <Section Name="Management">
         <Parameter Name="ImageStoreConnectionString" Value="fabric:ImageStore" />
+        <Parameter Name="EnableSelfReconfiguringServices" Value="True" />
     </Section>
     <Section Name="NamingService">
       <Parameter Name="PartitionCount" Value="1" />

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,12 +69,14 @@ add_custom_target(format
     COMMAND ${cargo_exe} fmt -p samples_echomain
     COMMAND ${cargo_exe} fmt -p samples_echomain_stateful
     COMMAND ${cargo_exe} fmt -p samples_reflection
+    COMMAND ${cargo_exe} fmt -p dummy-self-reconfig
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_subdirectory(crates/samples/echomain)
 add_subdirectory(crates/samples/reflection)
 add_subdirectory(crates/samples/echomain-stateful)
+add_subdirectory(crates/samples/dummy-self-reconfig)
 add_subdirectory(crates/samples/no_default_features)
 
 if(WIN32) #linux is not tested

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dummy-self-reconfig"
+version = "0.0.1"
+dependencies = [
+ "mssf-core",
+ "mssf-util",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/libs/core/src/runtime/mod.rs
+++ b/crates/libs/core/src/runtime/mod.rs
@@ -35,9 +35,19 @@ pub use stateless_traits::{
     IStatelessServiceFactory, IStatelessServiceInstance, IStatelessServicePartition,
 };
 
+mod self_reconfiguring_traits;
+pub use self_reconfiguring_traits::{
+    ISelfReconfiguringServiceFactory, ISelfReconfiguringServiceInstance,
+    ISelfReconfiguringServicePartition,
+};
+
 pub mod stateless_bridge;
 mod stateless_proxy;
 pub use stateless_proxy::StatelessServicePartition;
+
+pub mod self_reconfiguring_bridge;
+mod self_reconfiguring_proxy;
+pub use self_reconfiguring_proxy::SelfReconfiguringServicePartition;
 pub mod store;
 
 pub mod store_proxy;

--- a/crates/libs/core/src/runtime/runtime_wrapper.rs
+++ b/crates/libs/core/src/runtime/runtime_wrapper.rs
@@ -1,13 +1,16 @@
 use crate::WString;
 /// safe wrapping for runtime
 use mssf_com::FabricRuntime::{
-    IFabricRuntime2, IFabricStatefulServiceFactory, IFabricStatelessServiceFactory,
+    IFabricRuntime2, IFabricSelfReconfiguringServiceFactory, IFabricStatefulServiceFactory,
+    IFabricStatelessServiceFactory,
 };
 
 use super::{
-    create_com_runtime, executor::Executor, stateful_bridge::StatefulServiceFactoryBridge,
-    stateful_traits::IStatefulServiceFactory, stateless_bridge::StatelessServiceFactoryBridge,
-    stateless_traits::IStatelessServiceFactory,
+    create_com_runtime, executor::Executor,
+    self_reconfiguring_bridge::SelfReconfiguringServiceFactoryBridge,
+    self_reconfiguring_traits::ISelfReconfiguringServiceFactory,
+    stateful_bridge::StatefulServiceFactoryBridge, stateful_traits::IStatefulServiceFactory,
+    stateless_bridge::StatelessServiceFactoryBridge, stateless_traits::IStatelessServiceFactory,
 };
 pub struct Runtime<E>
 where
@@ -52,6 +55,21 @@ where
         unsafe {
             self.com_impl
                 .RegisterStatefulServiceFactory(servicetypename.as_pcwstr(), &bridge)
+        }
+        .map_err(crate::Error::from)
+    }
+
+    pub fn register_self_reconfiguring_service_factory(
+        &self,
+        servicetypename: &WString,
+        factory: Box<dyn ISelfReconfiguringServiceFactory>,
+    ) -> crate::Result<()> {
+        let rt_cp = self.rt.clone();
+        let bridge: IFabricSelfReconfiguringServiceFactory =
+            SelfReconfiguringServiceFactoryBridge::create(factory, rt_cp).into();
+        unsafe {
+            self.com_impl
+                .RegisterSelfReconfiguringServiceFactory(servicetypename.as_pcwstr(), &bridge)
         }
         .map_err(crate::Error::from)
     }

--- a/crates/libs/core/src/runtime/self_reconfiguring_bridge.rs
+++ b/crates/libs/core/src/runtime/self_reconfiguring_bridge.rs
@@ -1,0 +1,240 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+// windows::core::implement macro generates snake case types.
+#![allow(non_camel_case_types)]
+
+use std::sync::Arc;
+
+use crate::{
+    ErrorCode, runtime::SelfReconfiguringServicePartition, strings::StringResult,
+    sync::BridgeContext, types::Uri,
+};
+use mssf_com::{
+    FabricCommon::IFabricStringResult,
+    FabricRuntime::{
+        IFabricSelfReconfiguringConfigurationChangeRequest, IFabricSelfReconfiguringServiceFactory,
+        IFabricSelfReconfiguringServiceFactory_Impl, IFabricSelfReconfiguringServiceInstance,
+        IFabricSelfReconfiguringServiceInstance_Impl, IFabricSelfReconfiguringServicePartition,
+    },
+    FabricTypes::{
+        FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST,
+        FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE, FABRIC_URI,
+    },
+};
+use windows_core::{WString, implement};
+
+use crate::runtime::{
+    executor::Executor,
+    {ISelfReconfiguringServiceFactory, ISelfReconfiguringServiceInstance},
+};
+use crate::types::{
+    SelfReconfiguringConfigurationChangeRequest, SelfReconfiguringConfigurationRequest,
+    SelfReconfiguringOpenMode,
+};
+
+#[implement(IFabricSelfReconfiguringServiceFactory)]
+pub struct SelfReconfiguringServiceFactoryBridge<E>
+where
+    E: Executor + 'static,
+{
+    inner: Box<dyn ISelfReconfiguringServiceFactory>,
+    rt: E,
+}
+
+impl<E> SelfReconfiguringServiceFactoryBridge<E>
+where
+    E: Executor,
+{
+    pub fn create(
+        factory: Box<dyn ISelfReconfiguringServiceFactory>,
+        rt: E,
+    ) -> SelfReconfiguringServiceFactoryBridge<E> {
+        SelfReconfiguringServiceFactoryBridge { inner: factory, rt }
+    }
+}
+
+impl<E> IFabricSelfReconfiguringServiceFactory_Impl
+    for SelfReconfiguringServiceFactoryBridge_Impl<E>
+where
+    E: Executor,
+{
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn CreateInstance(
+        &self,
+        servicetypename: &crate::PCWSTR,
+        servicename: FABRIC_URI,
+        initializationdatalength: u32,
+        initializationdata: *const u8,
+        partitionid: &crate::GUID,
+        instanceid: i64,
+    ) -> crate::WinResult<IFabricSelfReconfiguringServiceInstance> {
+        let h_servicename = Uri::from(servicename);
+        let h_servicetypename = WString::from(*servicetypename);
+        let data = unsafe {
+            if !initializationdata.is_null() {
+                std::slice::from_raw_parts(initializationdata, initializationdatalength as usize)
+            } else {
+                &[]
+            }
+        };
+
+        let instance = self.inner.create_instance(
+            h_servicetypename,
+            h_servicename,
+            data,
+            *partitionid,
+            instanceid,
+        )?;
+        let rt = self.rt.clone();
+        let instance_bridge = IFabricSelfReconfiguringServiceInstanceBridge::create(instance, rt);
+
+        Ok(instance_bridge.into())
+    }
+}
+
+// bridge from safe service instance to com
+#[implement(IFabricSelfReconfiguringServiceInstance)]
+pub(crate) struct IFabricSelfReconfiguringServiceInstanceBridge<E>
+where
+    E: Executor,
+{
+    inner: Arc<Box<dyn ISelfReconfiguringServiceInstance>>,
+    rt: E,
+}
+
+impl<E> IFabricSelfReconfiguringServiceInstanceBridge<E>
+where
+    E: Executor,
+{
+    pub fn create(
+        instance: Box<dyn ISelfReconfiguringServiceInstance>,
+        rt: E,
+    ) -> IFabricSelfReconfiguringServiceInstanceBridge<E> {
+        IFabricSelfReconfiguringServiceInstanceBridge {
+            inner: Arc::new(instance),
+            rt,
+        }
+    }
+}
+
+impl<E> IFabricSelfReconfiguringServiceInstance_Impl
+    for IFabricSelfReconfiguringServiceInstanceBridge_Impl<E>
+where
+    E: Executor,
+{
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn BeginOpen(
+        &self,
+        openmode: FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE,
+        partition: windows_core::Ref<IFabricSelfReconfiguringServicePartition>,
+        callback: windows_core::Ref<super::IFabricAsyncOperationCallback>,
+    ) -> crate::WinResult<super::IFabricAsyncOperationContext> {
+        let partition_cp = partition.unwrap().clone();
+        let partition_bridge = SelfReconfiguringServicePartition::new(partition_cp);
+        let open_mode = SelfReconfiguringOpenMode::from(openmode);
+        let inner = self.inner.clone();
+        let (ctx, token) = BridgeContext::make(callback);
+        ctx.spawn(&self.rt, async move {
+            inner
+                .open(Arc::new(partition_bridge), open_mode, token)
+                .await
+                .map(|s| IFabricStringResult::from(StringResult::new(s)))
+                .map_err(crate::WinError::from)
+        })
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn EndOpen(
+        &self,
+        context: windows_core::Ref<super::IFabricAsyncOperationContext>,
+    ) -> crate::WinResult<IFabricStringResult> {
+        BridgeContext::result(context)?
+    }
+
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn RequestConfiguration(
+        &self,
+        configurationrequest: *const FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST,
+    ) -> crate::WinResult<()> {
+        if configurationrequest.is_null() {
+            return Err(ErrorCode::E_POINTER.into());
+        }
+        let request =
+            SelfReconfiguringConfigurationRequest::from(unsafe { &*configurationrequest });
+        self.inner
+            .request_configuration(request)
+            .map_err(crate::WinError::from)
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn RequestConfigurationChange(
+        &self,
+        configurationchangerequest: windows_core::Ref<
+            IFabricSelfReconfiguringConfigurationChangeRequest,
+        >,
+    ) -> crate::WinResult<()> {
+        let com = configurationchangerequest.ok()?;
+        let raw = unsafe { com.get_ConfigurationChangeRequest() };
+        if raw.is_null() {
+            return Err(ErrorCode::E_POINTER.into());
+        }
+        let change = SelfReconfiguringConfigurationChangeRequest::from(unsafe { &*raw });
+        self.inner
+            .request_configuration_change(change)
+            .map_err(crate::WinError::from)
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn BeginClose(
+        &self,
+        callback: windows_core::Ref<super::IFabricAsyncOperationCallback>,
+    ) -> crate::WinResult<super::IFabricAsyncOperationContext> {
+        let inner = self.inner.clone();
+        let (ctx, token) = BridgeContext::make(callback);
+        ctx.spawn(&self.rt, async move {
+            inner.close(token).await.map_err(crate::WinError::from)
+        })
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"), err)
+    )]
+    fn EndClose(
+        &self,
+        context: windows_core::Ref<super::IFabricAsyncOperationContext>,
+    ) -> crate::WinResult<()> {
+        BridgeContext::result(context)?
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, ret(level = "debug"))
+    )]
+    fn Abort(&self) {
+        self.inner.abort()
+    }
+}

--- a/crates/libs/core/src/runtime/self_reconfiguring_proxy.rs
+++ b/crates/libs/core/src/runtime/self_reconfiguring_proxy.rs
@@ -1,0 +1,82 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use crate::ErrorCode;
+use crate::types::{
+    FaultType, HealthInformation, LoadMetric, LoadMetricListRef, MoveCost,
+    SelfReconfiguringConfigurationReport, ServicePartitionInformation,
+};
+use mssf_com::FabricRuntime::IFabricSelfReconfiguringServicePartition;
+
+/// Wrapper for the `IFabricSelfReconfiguringServicePartition` COM interface.
+///
+/// Unlike the stateless partition, this interface has no versioned successor, so
+/// the base interface is wrapped directly.
+#[derive(Debug, Clone)]
+pub struct SelfReconfiguringServicePartition {
+    com_impl: IFabricSelfReconfiguringServicePartition,
+}
+
+impl SelfReconfiguringServicePartition {
+    pub fn new(
+        com_impl: IFabricSelfReconfiguringServicePartition,
+    ) -> SelfReconfiguringServicePartition {
+        SelfReconfiguringServicePartition { com_impl }
+    }
+
+    pub fn get_com(&self) -> &IFabricSelfReconfiguringServicePartition {
+        &self.com_impl
+    }
+}
+
+impl crate::runtime::ISelfReconfiguringServicePartition for SelfReconfiguringServicePartition {
+    fn get_partition_info(&self) -> crate::Result<ServicePartitionInformation> {
+        // Treat a null partition info pointer as an error rather than panicking,
+        // following the stateful partition proxy pattern.
+        unsafe { self.com_impl.GetPartitionInfo()?.as_ref() }
+            .ok_or(ErrorCode::E_POINTER.into())
+            .map(ServicePartitionInformation::from)
+    }
+
+    fn report_load(&self, metrics: &[LoadMetric]) -> crate::Result<()> {
+        let metrics_ref = LoadMetricListRef::from_slice(metrics);
+        let raw = metrics_ref.as_raw_slice();
+        unsafe { self.com_impl.ReportLoad(raw) }.map_err(crate::Error::from)
+    }
+
+    fn report_fault(&self, fault_type: FaultType) -> crate::Result<()> {
+        unsafe { self.com_impl.ReportFault(fault_type.into()) }.map_err(crate::Error::from)
+    }
+
+    fn report_move_cost(&self, move_cost: MoveCost) -> crate::Result<()> {
+        unsafe { self.com_impl.ReportMoveCost(move_cost.into()) }.map_err(crate::Error::from)
+    }
+
+    fn report_instance_health(&self, healthinfo: &HealthInformation) -> crate::Result<()> {
+        let healthinfo_ref = &healthinfo.into();
+        unsafe {
+            self.com_impl
+                .ReportInstanceHealth(healthinfo_ref, std::ptr::null())
+        }
+        .map_err(crate::Error::from)
+    }
+
+    fn report_partition_health(&self, healthinfo: &HealthInformation) -> crate::Result<()> {
+        let healthinfo_ref = &healthinfo.into();
+        unsafe {
+            self.com_impl
+                .ReportPartitionHealth(healthinfo_ref, std::ptr::null())
+        }
+        .map_err(crate::Error::from)
+    }
+
+    fn report_configuration(
+        &self,
+        report: &SelfReconfiguringConfigurationReport,
+    ) -> crate::Result<()> {
+        let view = report.get_view();
+        unsafe { self.com_impl.ReportConfiguration(view.get_raw()) }.map_err(crate::Error::from)
+    }
+}

--- a/crates/libs/core/src/runtime/self_reconfiguring_traits.rs
+++ b/crates/libs/core/src/runtime/self_reconfiguring_traits.rs
@@ -32,22 +32,17 @@ pub trait ISelfReconfiguringServiceFactory: Send + Sync + 'static {
     ) -> crate::Result<Box<dyn ISelfReconfiguringServiceInstance>>;
 }
 
-/// Defines behavior that governs the lifecycle and configuration participation of
-/// a self-reconfiguring service instance, such as startup, configuration changes,
-/// and shutdown.
-///
-/// Unlike a stateless instance, a self-reconfiguring instance additionally
-/// receives configuration requests and configuration-change requests from Service
-/// Fabric and reports its resulting configuration through its partition.
+/// Safe abstraction over the `IFabricSelfReconfiguringServiceInstance` COM
+/// interface that an author implements. Each method corresponds to a method on
+/// that COM interface; `open` and `close` are asynchronous (COM Begin/End), the
+/// rest are synchronous.
 #[async_trait::async_trait]
 pub trait ISelfReconfiguringServiceInstance: Send + Sync + 'static {
-    /// Opens an initialized service instance so that it can be contacted by
-    /// clients. The returned string is the address of this service instance,
-    /// which is associated with the service name via Service Fabric naming and
-    /// returned to clients that resolve the service.
+    /// Opens an initialized service instance. The returned string is the address
+    /// of this service instance, which is associated with the service name via
+    /// Service Fabric naming and returned to clients that resolve the service.
     ///
-    /// The `open_mode` indicates whether the instance is being opened as new or
-    /// existing.
+    /// `open_mode` is the open mode supplied by Service Fabric.
     async fn open(
         &self,
         partition: Arc<dyn ISelfReconfiguringServicePartition>,
@@ -55,20 +50,16 @@ pub trait ISelfReconfiguringServiceInstance: Send + Sync + 'static {
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<WString>;
 
-    /// Notifies the instance of a configuration request from Service Fabric.
-    ///
-    /// This is a synchronous notification; the instance should act on the request
-    /// and report the resulting configuration through its partition.
+    /// Synchronous notification of a configuration request from Service Fabric
+    /// (COM `RequestConfiguration`).
     fn request_configuration(
         &self,
         request: SelfReconfiguringConfigurationRequest,
     ) -> crate::Result<()>;
 
-    /// Notifies the instance of a configuration-change request from Service
-    /// Fabric, carrying the set of per-instance changes.
-    ///
-    /// This is a synchronous notification; the instance should act on the request
-    /// and report the resulting configuration through its partition.
+    /// Synchronous notification of a configuration-change request from Service
+    /// Fabric, carrying the set of per-instance changes (COM
+    /// `RequestConfigurationChange`).
     fn request_configuration_change(
         &self,
         change: SelfReconfiguringConfigurationChangeRequest,
@@ -84,7 +75,8 @@ pub trait ISelfReconfiguringServiceInstance: Send + Sync + 'static {
     fn abort(&self);
 }
 
-/// Abstraction for the `IFabricSelfReconfiguringServicePartition` interface.
+/// Safe abstraction over the `IFabricSelfReconfiguringServicePartition` COM
+/// interface. Each method corresponds to a synchronous method on that interface.
 pub trait ISelfReconfiguringServicePartition: Send + Sync + 'static {
     /// Provides access to the `ServicePartitionInformation` of the service, which
     /// contains the partition type and ID.
@@ -114,7 +106,7 @@ pub trait ISelfReconfiguringServicePartition: Send + Sync + 'static {
         health_info: &crate::types::HealthInformation,
     ) -> crate::Result<()>;
 
-    /// Reports the instance's resulting configuration back to Service Fabric.
+    /// Reports configuration through the partition (COM `ReportConfiguration`).
     fn report_configuration(
         &self,
         report: &SelfReconfiguringConfigurationReport,

--- a/crates/libs/core/src/runtime/self_reconfiguring_traits.rs
+++ b/crates/libs/core/src/runtime/self_reconfiguring_traits.rs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+// self_reconfiguring contains the rs definition of the traits that a user needs
+// to implement for a self-reconfiguring service.
+
+use std::sync::Arc;
+
+use crate::WString;
+use crate::runtime::executor::BoxedCancelToken;
+use crate::types::{
+    SelfReconfiguringConfigurationChangeRequest, SelfReconfiguringConfigurationReport,
+    SelfReconfiguringConfigurationRequest, SelfReconfiguringOpenMode, ServicePartitionInformation,
+};
+
+/// Represents a self-reconfiguring service factory that is responsible for
+/// creating instances of a specific type of self-reconfiguring service.
+/// Self-reconfiguring service factories are registered with the FabricRuntime by
+/// service hosts via `Runtime::register_self_reconfiguring_service_factory()`.
+pub trait ISelfReconfiguringServiceFactory: Send + Sync + 'static {
+    /// Creates a self-reconfiguring service instance for a particular service.
+    /// This method is called by Service Fabric.
+    fn create_instance(
+        &self,
+        servicetypename: WString,
+        servicename: crate::types::Uri,
+        initializationdata: &[u8],
+        partitionid: crate::GUID,
+        instanceid: i64,
+    ) -> crate::Result<Box<dyn ISelfReconfiguringServiceInstance>>;
+}
+
+/// Defines behavior that governs the lifecycle and configuration participation of
+/// a self-reconfiguring service instance, such as startup, configuration changes,
+/// and shutdown.
+///
+/// Unlike a stateless instance, a self-reconfiguring instance additionally
+/// receives configuration requests and configuration-change requests from Service
+/// Fabric and reports its resulting configuration through its partition.
+#[async_trait::async_trait]
+pub trait ISelfReconfiguringServiceInstance: Send + Sync + 'static {
+    /// Opens an initialized service instance so that it can be contacted by
+    /// clients. The returned string is the address of this service instance,
+    /// which is associated with the service name via Service Fabric naming and
+    /// returned to clients that resolve the service.
+    ///
+    /// The `open_mode` indicates whether the instance is being opened as new or
+    /// existing.
+    async fn open(
+        &self,
+        partition: Arc<dyn ISelfReconfiguringServicePartition>,
+        open_mode: SelfReconfiguringOpenMode,
+        cancellation_token: BoxedCancelToken,
+    ) -> crate::Result<WString>;
+
+    /// Notifies the instance of a configuration request from Service Fabric.
+    ///
+    /// This is a synchronous notification; the instance should act on the request
+    /// and report the resulting configuration through its partition.
+    fn request_configuration(
+        &self,
+        request: SelfReconfiguringConfigurationRequest,
+    ) -> crate::Result<()>;
+
+    /// Notifies the instance of a configuration-change request from Service
+    /// Fabric, carrying the set of per-instance changes.
+    ///
+    /// This is a synchronous notification; the instance should act on the request
+    /// and report the resulting configuration through its partition.
+    fn request_configuration_change(
+        &self,
+        change: SelfReconfiguringConfigurationChangeRequest,
+    ) -> crate::Result<()>;
+
+    /// Closes this service instance gracefully when the service instance is being
+    /// shut down.
+    async fn close(&self, cancellation_token: BoxedCancelToken) -> crate::Result<()>;
+
+    /// Terminates this instance ungracefully with this synchronous method call.
+    /// When the service instance receives this method, it should immediately
+    /// release and clean up all references and return.
+    fn abort(&self);
+}
+
+/// Abstraction for the `IFabricSelfReconfiguringServicePartition` interface.
+pub trait ISelfReconfiguringServicePartition: Send + Sync + 'static {
+    /// Provides access to the `ServicePartitionInformation` of the service, which
+    /// contains the partition type and ID.
+    fn get_partition_info(&self) -> crate::Result<ServicePartitionInformation>;
+
+    /// Reports load for the current instance in the partition.
+    fn report_load(&self, metrics: &[crate::types::LoadMetric]) -> crate::Result<()>;
+
+    /// Enables the instance to report a fault to the runtime and indicates that it
+    /// has encountered an error from which it cannot recover and must either be
+    /// restarted or removed.
+    fn report_fault(&self, fault_type: crate::types::FaultType) -> crate::Result<()>;
+
+    /// Reports the move cost for an instance.
+    fn report_move_cost(&self, move_cost: crate::types::MoveCost) -> crate::Result<()>;
+
+    /// Reports health on the current self-reconfiguring service instance of the
+    /// partition.
+    fn report_instance_health(
+        &self,
+        health_info: &crate::types::HealthInformation,
+    ) -> crate::Result<()>;
+
+    /// Reports current partition health.
+    fn report_partition_health(
+        &self,
+        health_info: &crate::types::HealthInformation,
+    ) -> crate::Result<()>;
+
+    /// Reports the instance's resulting configuration back to Service Fabric.
+    fn report_configuration(
+        &self,
+        report: &SelfReconfiguringConfigurationReport,
+    ) -> crate::Result<()>;
+}

--- a/crates/libs/core/src/runtime/self_reconfiguring_traits.rs
+++ b/crates/libs/core/src/runtime/self_reconfiguring_traits.rs
@@ -50,16 +50,13 @@ pub trait ISelfReconfiguringServiceInstance: Send + Sync + 'static {
         cancellation_token: BoxedCancelToken,
     ) -> crate::Result<WString>;
 
-    /// Synchronous notification of a configuration request from Service Fabric
-    /// (COM `RequestConfiguration`).
+    /// Public documentation for this interface is TBD.
     fn request_configuration(
         &self,
         request: SelfReconfiguringConfigurationRequest,
     ) -> crate::Result<()>;
 
-    /// Synchronous notification of a configuration-change request from Service
-    /// Fabric, carrying the set of per-instance changes (COM
-    /// `RequestConfigurationChange`).
+    /// Public documentation for this interface is TBD.
     fn request_configuration_change(
         &self,
         change: SelfReconfiguringConfigurationChangeRequest,
@@ -106,7 +103,7 @@ pub trait ISelfReconfiguringServicePartition: Send + Sync + 'static {
         health_info: &crate::types::HealthInformation,
     ) -> crate::Result<()>;
 
-    /// Reports configuration through the partition (COM `ReportConfiguration`).
+    /// Public documentation for this interface is TBD.
     fn report_configuration(
         &self,
         report: &SelfReconfiguringConfigurationReport,

--- a/crates/libs/core/src/types/mod.rs
+++ b/crates/libs/core/src/types/mod.rs
@@ -9,7 +9,7 @@ pub use common::*;
 mod client;
 pub use client::*;
 mod runtime;
-pub use runtime::{EndpointResourceDescription, health::*, stateful::*, store::*};
+pub use runtime::{EndpointResourceDescription, health::*, self_reconfiguring::*, stateful::*, store::*};
 
 #[cfg(test)]
 mod mockifabricclientsettings;

--- a/crates/libs/core/src/types/mod.rs
+++ b/crates/libs/core/src/types/mod.rs
@@ -9,7 +9,9 @@ pub use common::*;
 mod client;
 pub use client::*;
 mod runtime;
-pub use runtime::{EndpointResourceDescription, health::*, self_reconfiguring::*, stateful::*, store::*};
+pub use runtime::{
+    EndpointResourceDescription, health::*, self_reconfiguring::*, stateful::*, store::*,
+};
 
 #[cfg(test)]
 mod mockifabricclientsettings;

--- a/crates/libs/core/src/types/runtime/mod.rs
+++ b/crates/libs/core/src/types/runtime/mod.rs
@@ -6,6 +6,7 @@
 // Runtime related types.
 
 pub mod health;
+pub mod self_reconfiguring;
 pub mod stateful;
 pub mod store;
 

--- a/crates/libs/core/src/types/runtime/self_reconfiguring.rs
+++ b/crates/libs/core/src/types/runtime/self_reconfiguring.rs
@@ -17,7 +17,8 @@ use std::marker::PhantomData;
 use crate::WString;
 use mssf_com::FabricTypes::{
     FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST,
-    FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT, FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID,
+    FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT,
+    FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID,
     FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST,
     FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID,
     FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE,
@@ -28,8 +29,9 @@ use mssf_com::FabricTypes::{
     FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_EXISTING,
     FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_INVALID,
     FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_NEW, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE,
-    FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
-    FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_NONE, FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_NONE,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
     FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_DEACTIVATED,
     FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_INVALID,
 };
@@ -58,7 +60,9 @@ impl From<FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE> for SelfReconfiguringOpe
 impl From<SelfReconfiguringOpenMode> for FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE {
     fn from(val: SelfReconfiguringOpenMode) -> Self {
         match val {
-            SelfReconfiguringOpenMode::Invalid => FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_INVALID,
+            SelfReconfiguringOpenMode::Invalid => {
+                FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_INVALID
+            }
             SelfReconfiguringOpenMode::New => FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_NEW,
             SelfReconfiguringOpenMode::Existing => {
                 FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_EXISTING
@@ -79,7 +83,9 @@ pub enum SelfReconfiguringInstanceRole {
 impl From<&FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE> for SelfReconfiguringInstanceRole {
     fn from(r: &FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE) -> Self {
         match *r {
-            FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL => SelfReconfiguringInstanceRole::Initial,
+            FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL => {
+                SelfReconfiguringInstanceRole::Initial
+            }
             FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER => SelfReconfiguringInstanceRole::Member,
             _ => SelfReconfiguringInstanceRole::None,
         }
@@ -90,7 +96,9 @@ impl From<&SelfReconfiguringInstanceRole> for FABRIC_SELF_RECONFIGURING_INSTANCE
     fn from(val: &SelfReconfiguringInstanceRole) -> Self {
         match *val {
             SelfReconfiguringInstanceRole::None => FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_NONE,
-            SelfReconfiguringInstanceRole::Initial => FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL,
+            SelfReconfiguringInstanceRole::Initial => {
+                FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL
+            }
             SelfReconfiguringInstanceRole::Member => FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
         }
     }
@@ -415,7 +423,9 @@ mod tests {
 
     #[test]
     fn report_id_round_trip() {
-        let id = SelfReconfiguringConfigurationReportId { sequence_number: 99 };
+        let id = SelfReconfiguringConfigurationReportId {
+            sequence_number: 99,
+        };
         let raw: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID = (&id).into();
         assert_eq!(SelfReconfiguringConfigurationReportId::from(&raw), id);
     }

--- a/crates/libs/core/src/types/runtime/self_reconfiguring.rs
+++ b/crates/libs/core/src/types/runtime/self_reconfiguring.rs
@@ -1,0 +1,596 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Safe wrappers for the `FABRIC_SELF_RECONFIGURING_*` value types.
+//!
+//! Conversions are provided in the direction(s) each type is used by the
+//! self-reconfiguring service surface: inbound (COM -> safe) for values the
+//! Service Fabric runtime pushes to an instance (configuration request and
+//! configuration-change request), outbound (safe -> COM) for values the author
+//! produces (configuration report), and both directions for the simple enums
+//! and identifier values that appear on both paths.
+
+use std::marker::PhantomData;
+
+use crate::WString;
+use mssf_com::FabricTypes::{
+    FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST,
+    FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT, FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID,
+    FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST,
+    FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION_LIST,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_EXISTING,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_INVALID,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_NEW, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_NONE, FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_DEACTIVATED,
+    FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_INVALID,
+};
+
+/// Whether a self-reconfiguring instance is being opened as new or existing.
+/// Safe wrapper for `FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfReconfiguringOpenMode {
+    Invalid,
+    New,
+    Existing,
+}
+
+impl From<FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE> for SelfReconfiguringOpenMode {
+    fn from(e: FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE) -> Self {
+        match e {
+            FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_NEW => SelfReconfiguringOpenMode::New,
+            FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_EXISTING => {
+                SelfReconfiguringOpenMode::Existing
+            }
+            _ => SelfReconfiguringOpenMode::Invalid,
+        }
+    }
+}
+
+impl From<SelfReconfiguringOpenMode> for FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE {
+    fn from(val: SelfReconfiguringOpenMode) -> Self {
+        match val {
+            SelfReconfiguringOpenMode::Invalid => FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_INVALID,
+            SelfReconfiguringOpenMode::New => FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_NEW,
+            SelfReconfiguringOpenMode::Existing => {
+                FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE_EXISTING
+            }
+        }
+    }
+}
+
+/// Role of a self-reconfiguring instance within the configuration.
+/// Safe wrapper for `FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfReconfiguringInstanceRole {
+    None,
+    Initial,
+    Member,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE> for SelfReconfiguringInstanceRole {
+    fn from(r: &FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE) -> Self {
+        match *r {
+            FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL => SelfReconfiguringInstanceRole::Initial,
+            FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER => SelfReconfiguringInstanceRole::Member,
+            _ => SelfReconfiguringInstanceRole::None,
+        }
+    }
+}
+
+impl From<&SelfReconfiguringInstanceRole> for FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE {
+    fn from(val: &SelfReconfiguringInstanceRole) -> Self {
+        match *val {
+            SelfReconfiguringInstanceRole::None => FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_NONE,
+            SelfReconfiguringInstanceRole::Initial => FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL,
+            SelfReconfiguringInstanceRole::Member => FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
+        }
+    }
+}
+
+/// Activation state of a self-reconfiguring instance.
+/// Safe wrapper for `FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfReconfiguringInstanceActivationState {
+    Invalid,
+    Activated,
+    Deactivated,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE>
+    for SelfReconfiguringInstanceActivationState
+{
+    fn from(s: &FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE) -> Self {
+        match *s {
+            FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED => {
+                SelfReconfiguringInstanceActivationState::Activated
+            }
+            FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_DEACTIVATED => {
+                SelfReconfiguringInstanceActivationState::Deactivated
+            }
+            _ => SelfReconfiguringInstanceActivationState::Invalid,
+        }
+    }
+}
+
+impl From<&SelfReconfiguringInstanceActivationState>
+    for FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE
+{
+    fn from(val: &SelfReconfiguringInstanceActivationState) -> Self {
+        match *val {
+            SelfReconfiguringInstanceActivationState::Invalid => {
+                FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_INVALID
+            }
+            SelfReconfiguringInstanceActivationState::Activated => {
+                FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED
+            }
+            SelfReconfiguringInstanceActivationState::Deactivated => {
+                FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_DEACTIVATED
+            }
+        }
+    }
+}
+
+/// Identifier of a configuration request.
+/// Safe wrapper for `FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelfReconfiguringConfigurationRequestId {
+    pub generation_number: i64,
+    pub sequence_number: i64,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID>
+    for SelfReconfiguringConfigurationRequestId
+{
+    fn from(r: &FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID) -> Self {
+        Self {
+            generation_number: r.GenerationNumber,
+            sequence_number: r.SequenceNumber,
+        }
+    }
+}
+
+impl From<&SelfReconfiguringConfigurationRequestId>
+    for FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID
+{
+    fn from(val: &SelfReconfiguringConfigurationRequestId) -> Self {
+        Self {
+            GenerationNumber: val.generation_number,
+            SequenceNumber: val.sequence_number,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// Identifier of a configuration report.
+/// Safe wrapper for `FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelfReconfiguringConfigurationReportId {
+    pub sequence_number: i64,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID>
+    for SelfReconfiguringConfigurationReportId
+{
+    fn from(r: &FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID) -> Self {
+        Self {
+            sequence_number: r.SequenceNumber,
+        }
+    }
+}
+
+impl From<&SelfReconfiguringConfigurationReportId>
+    for FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID
+{
+    fn from(val: &SelfReconfiguringConfigurationReportId) -> Self {
+        Self {
+            SequenceNumber: val.sequence_number,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// A configuration request pushed to the instance by Service Fabric.
+/// Inbound safe wrapper for `FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelfReconfiguringConfigurationRequest {
+    pub request_id: SelfReconfiguringConfigurationRequestId,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST>
+    for SelfReconfiguringConfigurationRequest
+{
+    fn from(r: &FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST) -> Self {
+        Self {
+            request_id: SelfReconfiguringConfigurationRequestId::from(&r.RequestId),
+        }
+    }
+}
+
+/// A requested change to a single instance's role/activation state.
+/// Inbound safe wrapper for `FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceChangeRequest {
+    pub instance_id: i64,
+    pub role: SelfReconfiguringInstanceRole,
+    pub requested_role: SelfReconfiguringInstanceRole,
+    pub activation_state: SelfReconfiguringInstanceActivationState,
+    pub requested_activation_state: SelfReconfiguringInstanceActivationState,
+    /// The endpoints string; empty when none was supplied.
+    pub endpoints: WString,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST> for InstanceChangeRequest {
+    fn from(r: &FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST) -> Self {
+        let endpoints = if r.Endpoints.is_null() {
+            WString::default()
+        } else {
+            WString::from(r.Endpoints)
+        };
+        Self {
+            instance_id: r.InstanceId,
+            role: SelfReconfiguringInstanceRole::from(&r.Role),
+            requested_role: SelfReconfiguringInstanceRole::from(&r.RequestedRole),
+            activation_state: SelfReconfiguringInstanceActivationState::from(&r.ActivationState),
+            requested_activation_state: SelfReconfiguringInstanceActivationState::from(
+                &r.RequestedActivationState,
+            ),
+            endpoints,
+        }
+    }
+}
+
+/// A configuration-change request pushed to the instance by Service Fabric.
+/// Inbound safe wrapper for `FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelfReconfiguringConfigurationChangeRequest {
+    pub request_id: SelfReconfiguringConfigurationRequestId,
+    pub instances: Vec<InstanceChangeRequest>,
+}
+
+impl From<&FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST>
+    for SelfReconfiguringConfigurationChangeRequest
+{
+    fn from(r: &FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST) -> Self {
+        let mut instances = Vec::new();
+        if !r.Instances.is_null() {
+            let list = unsafe { &*r.Instances };
+            if !list.Items.is_null() {
+                for i in 0..list.Count {
+                    let item = unsafe { &*list.Items.offset(i as isize) };
+                    instances.push(InstanceChangeRequest::from(item));
+                }
+            }
+        }
+        Self {
+            request_id: SelfReconfiguringConfigurationRequestId::from(&r.RequestId),
+            instances,
+        }
+    }
+}
+
+/// The reported state of a single instance.
+/// Outbound safe wrapper for `FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceInformation {
+    pub instance_id: i64,
+    pub role: SelfReconfiguringInstanceRole,
+    pub activation_state: SelfReconfiguringInstanceActivationState,
+}
+
+impl From<&InstanceInformation> for FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION {
+    fn from(val: &InstanceInformation) -> Self {
+        Self {
+            InstanceId: val.instance_id,
+            Role: (&val.role).into(),
+            ActivationState: (&val.activation_state).into(),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// The configuration an instance reports back to Service Fabric.
+/// Outbound safe wrapper for `FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelfReconfiguringConfigurationReport {
+    pub request_id: SelfReconfiguringConfigurationRequestId,
+    pub report_id: SelfReconfiguringConfigurationReportId,
+    pub instances: Vec<InstanceInformation>,
+}
+
+impl SelfReconfiguringConfigurationReport {
+    /// Lowers this report into a view holding the raw COM representation.
+    ///
+    /// The returned view owns the raw instance items (heap `Vec`), the raw
+    /// instance-information list (heap `Box`), and the raw report struct, so the
+    /// nested pointers inside the report remain valid for the lifetime of the
+    /// view. The view borrows `self` and is used only for the duration of a
+    /// single Service Fabric API call.
+    pub fn get_view(&self) -> SelfReconfiguringConfigurationReportView<'_> {
+        let items = self
+            .instances
+            .iter()
+            .map(FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION::from)
+            .collect::<Vec<_>>();
+
+        let list = Box::new(FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION_LIST {
+            Count: items.len() as u32,
+            Items: items.as_ptr(),
+        });
+
+        let raw = FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT {
+            RequestId: (&self.request_id).into(),
+            ReportId: (&self.report_id).into(),
+            Instances: list.as_ref() as *const _,
+            Reserved: std::ptr::null_mut(),
+        };
+
+        SelfReconfiguringConfigurationReportView {
+            _items: items,
+            _list: list,
+            raw,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Holds the raw COM representation of a [`SelfReconfiguringConfigurationReport`].
+///
+/// Not movable in spirit: the raw report contains pointers into the heap data
+/// owned by this view. It has the same lifetime as the report it was created
+/// from.
+pub struct SelfReconfiguringConfigurationReportView<'a> {
+    _items: Vec<FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION>,
+    _list: Box<FABRIC_SELF_RECONFIGURING_INSTANCE_INFORMATION_LIST>,
+    raw: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT,
+    _phantom: PhantomData<&'a SelfReconfiguringConfigurationReport>,
+}
+
+impl SelfReconfiguringConfigurationReportView<'_> {
+    /// Returns the raw report that can be passed to the Service Fabric COM API.
+    pub fn get_raw(&self) -> &FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT {
+        &self.raw
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PCWSTR;
+    use mssf_com::FabricTypes::FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST_LIST;
+
+    #[test]
+    fn open_mode_round_trip() {
+        for m in [
+            SelfReconfiguringOpenMode::Invalid,
+            SelfReconfiguringOpenMode::New,
+            SelfReconfiguringOpenMode::Existing,
+        ] {
+            let raw: FABRIC_SELF_RECONFIGURING_INSTANCE_OPEN_MODE = m.into();
+            assert_eq!(SelfReconfiguringOpenMode::from(raw), m);
+        }
+    }
+
+    #[test]
+    fn instance_role_round_trip() {
+        for r in [
+            SelfReconfiguringInstanceRole::None,
+            SelfReconfiguringInstanceRole::Initial,
+            SelfReconfiguringInstanceRole::Member,
+        ] {
+            let raw: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE = (&r).into();
+            assert_eq!(SelfReconfiguringInstanceRole::from(&raw), r);
+        }
+    }
+
+    #[test]
+    fn activation_state_round_trip() {
+        for s in [
+            SelfReconfiguringInstanceActivationState::Invalid,
+            SelfReconfiguringInstanceActivationState::Activated,
+            SelfReconfiguringInstanceActivationState::Deactivated,
+        ] {
+            let raw: FABRIC_SELF_RECONFIGURING_INSTANCE_ACTIVATION_STATE = (&s).into();
+            assert_eq!(SelfReconfiguringInstanceActivationState::from(&raw), s);
+        }
+    }
+
+    #[test]
+    fn request_id_round_trip() {
+        let id = SelfReconfiguringConfigurationRequestId {
+            generation_number: 7,
+            sequence_number: 42,
+        };
+        let raw: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID = (&id).into();
+        assert_eq!(SelfReconfiguringConfigurationRequestId::from(&raw), id);
+    }
+
+    #[test]
+    fn report_id_round_trip() {
+        let id = SelfReconfiguringConfigurationReportId { sequence_number: 99 };
+        let raw: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REPORT_ID = (&id).into();
+        assert_eq!(SelfReconfiguringConfigurationReportId::from(&raw), id);
+    }
+
+    #[test]
+    fn configuration_request_inbound() {
+        let raw = FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST {
+            RequestId: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID {
+                GenerationNumber: 1,
+                SequenceNumber: 2,
+                Reserved: std::ptr::null_mut(),
+            },
+            Reserved: std::ptr::null_mut(),
+        };
+        let safe = SelfReconfiguringConfigurationRequest::from(&raw);
+        assert_eq!(safe.request_id.generation_number, 1);
+        assert_eq!(safe.request_id.sequence_number, 2);
+    }
+
+    #[test]
+    fn change_request_inbound_empty() {
+        let raw = FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST {
+            RequestId: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID::default(),
+            Instances: std::ptr::null(),
+            Reserved: std::ptr::null_mut(),
+        };
+        let safe = SelfReconfiguringConfigurationChangeRequest::from(&raw);
+        assert!(safe.instances.is_empty());
+    }
+
+    #[test]
+    fn change_request_inbound_single_item() {
+        let endpoints = WString::from("localhost:4321");
+        let item = FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST {
+            InstanceId: 12,
+            Role: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_NONE,
+            RequestedRole: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL,
+            ActivationState: FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_DEACTIVATED,
+            RequestedActivationState: FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
+            Endpoints: PCWSTR(endpoints.as_ptr()),
+            Reserved: std::ptr::null_mut(),
+        };
+        let list = FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST_LIST {
+            Count: 1,
+            Items: &item,
+        };
+        let raw = FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST {
+            RequestId: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID::default(),
+            Instances: &list,
+            Reserved: std::ptr::null_mut(),
+        };
+
+        let safe = SelfReconfiguringConfigurationChangeRequest::from(&raw);
+        assert_eq!(safe.instances.len(), 1);
+        assert_eq!(safe.instances[0].instance_id, 12);
+        assert_eq!(
+            safe.instances[0].requested_role,
+            SelfReconfiguringInstanceRole::Initial
+        );
+        assert_eq!(safe.instances[0].endpoints, WString::from("localhost:4321"));
+    }
+
+    #[test]
+    fn change_request_inbound_items() {
+        let endpoints = WString::from("localhost:1234");
+        let items = [
+            FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST {
+                InstanceId: 10,
+                Role: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL,
+                RequestedRole: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
+                ActivationState: FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_DEACTIVATED,
+                RequestedActivationState: FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
+                Endpoints: PCWSTR(endpoints.as_ptr()),
+                Reserved: std::ptr::null_mut(),
+            },
+            // Second item with a null endpoints pointer.
+            FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST {
+                InstanceId: 11,
+                Role: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
+                RequestedRole: FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER,
+                ActivationState: FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
+                RequestedActivationState: FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED,
+                Endpoints: PCWSTR::null(),
+                Reserved: std::ptr::null_mut(),
+            },
+        ];
+        let list = FABRIC_SELF_RECONFIGURING_INSTANCE_CHANGE_REQUEST_LIST {
+            Count: items.len() as u32,
+            Items: items.as_ptr(),
+        };
+        let raw = FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST {
+            RequestId: FABRIC_SELF_RECONFIGURING_CONFIGURATION_REQUEST_ID {
+                GenerationNumber: 3,
+                SequenceNumber: 4,
+                Reserved: std::ptr::null_mut(),
+            },
+            Instances: &list,
+            Reserved: std::ptr::null_mut(),
+        };
+
+        let safe = SelfReconfiguringConfigurationChangeRequest::from(&raw);
+        assert_eq!(safe.request_id.generation_number, 3);
+        assert_eq!(safe.instances.len(), 2);
+
+        let first = &safe.instances[0];
+        assert_eq!(first.instance_id, 10);
+        assert_eq!(first.role, SelfReconfiguringInstanceRole::Initial);
+        assert_eq!(first.requested_role, SelfReconfiguringInstanceRole::Member);
+        assert_eq!(
+            first.activation_state,
+            SelfReconfiguringInstanceActivationState::Deactivated
+        );
+        assert_eq!(first.endpoints, WString::from("localhost:1234"));
+
+        let second = &safe.instances[1];
+        assert_eq!(second.instance_id, 11);
+        assert_eq!(second.endpoints, WString::default());
+    }
+
+    #[test]
+    fn report_outbound_empty() {
+        let report = SelfReconfiguringConfigurationReport {
+            request_id: SelfReconfiguringConfigurationRequestId {
+                generation_number: 1,
+                sequence_number: 2,
+            },
+            report_id: SelfReconfiguringConfigurationReportId { sequence_number: 5 },
+            instances: vec![],
+        };
+        let view = report.get_view();
+        let raw = view.get_raw();
+        assert_eq!(raw.RequestId.GenerationNumber, 1);
+        assert_eq!(raw.ReportId.SequenceNumber, 5);
+        let list = unsafe { &*raw.Instances };
+        assert_eq!(list.Count, 0);
+    }
+
+    #[test]
+    fn report_outbound_items() {
+        let report = SelfReconfiguringConfigurationReport {
+            request_id: SelfReconfiguringConfigurationRequestId {
+                generation_number: 8,
+                sequence_number: 9,
+            },
+            report_id: SelfReconfiguringConfigurationReportId {
+                sequence_number: 10,
+            },
+            instances: vec![
+                InstanceInformation {
+                    instance_id: 100,
+                    role: SelfReconfiguringInstanceRole::Member,
+                    activation_state: SelfReconfiguringInstanceActivationState::Activated,
+                },
+                InstanceInformation {
+                    instance_id: 101,
+                    role: SelfReconfiguringInstanceRole::Initial,
+                    activation_state: SelfReconfiguringInstanceActivationState::Deactivated,
+                },
+            ],
+        };
+        let view = report.get_view();
+        let raw = view.get_raw();
+        let list = unsafe { &*raw.Instances };
+        assert_eq!(list.Count, 2);
+
+        let first = unsafe { &*list.Items.offset(0) };
+        assert_eq!(first.InstanceId, 100);
+        assert_eq!(first.Role, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_MEMBER);
+        assert_eq!(
+            first.ActivationState,
+            FABRIC_SELF_RECONFIGURING_INSTANCE_STATE_ACTIVATED
+        );
+
+        let second = unsafe { &*list.Items.offset(1) };
+        assert_eq!(second.InstanceId, 101);
+        assert_eq!(second.Role, FABRIC_SELF_RECONFIGURING_INSTANCE_ROLE_INITIAL);
+    }
+}

--- a/crates/libs/core/src/types/runtime/self_reconfiguring.rs
+++ b/crates/libs/core/src/types/runtime/self_reconfiguring.rs
@@ -268,16 +268,9 @@ impl From<&FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST>
     for SelfReconfiguringConfigurationChangeRequest
 {
     fn from(r: &FABRIC_SELF_RECONFIGURING_CONFIGURATION_CHANGE_REQUEST) -> Self {
-        let mut instances = Vec::new();
-        if !r.Instances.is_null() {
-            let list = unsafe { &*r.Instances };
-            if !list.Items.is_null() {
-                for i in 0..list.Count {
-                    let item = unsafe { &*list.Items.offset(i as isize) };
-                    instances.push(InstanceChangeRequest::from(item));
-                }
-            }
-        }
+        let instances = unsafe { r.Instances.as_ref() }
+            .map(|list| crate::iter::vec_from_raw_com(list.Count as usize, list.Items))
+            .unwrap_or_default();
         Self {
             request_id: SelfReconfiguringConfigurationRequestId::from(&r.RequestId),
             instances,

--- a/crates/samples/dummy-self-reconfig/CMakeLists.txt
+++ b/crates/samples/dummy-self-reconfig/CMakeLists.txt
@@ -1,0 +1,14 @@
+# copy files to build folder to form a code package.
+
+add_custom_target(build_rust_sample_dummy_self_reconfig ALL
+    COMMAND ${cargo_exe} build -p dummy-self-reconfig
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS build_fabric_rust_pal
+)
+include(PackageSF)
+add_sf_pkg(
+    TARGET build_rust_sample_dummy_self_reconfig
+    EXECUTABLE ${CMAKE_SOURCE_DIR}/target/debug/dummy-self-reconfig
+    MANIFEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/manifests
+    OUT_DIR ${CMAKE_BINARY_DIR}/sf_apps/dummy-self-reconfig
+)

--- a/crates/samples/dummy-self-reconfig/Cargo.toml
+++ b/crates/samples/dummy-self-reconfig/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dummy-self-reconfig"
+version = "0.0.1"
+edition.workspace = true
+publish = false
+
+[[bin]]
+name = "dummy-self-reconfig"
+path = "src/main.rs"
+
+[dependencies]
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tokio.workspace = true
+mssf-core = { workspace = true, default-features = true }
+mssf-util = { workspace = true, default-features = true }

--- a/crates/samples/dummy-self-reconfig/manifests/ApplicationManifest.xml
+++ b/crates/samples/dummy-self-reconfig/manifests/ApplicationManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ApplicationManifest
+  ApplicationTypeName="DummySelfReconfigAppType"
+  ApplicationTypeVersion="1.0"
+  xmlns="http://schemas.microsoft.com/2011/01/fabric"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Description>Dummy Self-Reconfiguring Test Application implemented with mssf_core.</Description>
+  <Parameters>
+    <Parameter Name="DummySelfReconfigService_InstanceCount" DefaultValue="3" />
+    <Parameter Name="DummySelfReconfigService_PlacementConstraints" DefaultValue="" />
+  </Parameters>
+  <ServiceManifestImport>
+    <ServiceManifestRef ServiceManifestName="DummySelfReconfigServicePackage" ServiceManifestVersion="1.0" />
+  </ServiceManifestImport>
+  <ServiceTemplates>
+    <SelfReconfiguringService ServiceTypeName="DummySelfReconfigServiceType" InstanceCount="[DummySelfReconfigService_InstanceCount]" MinInstanceCount="[DummySelfReconfigService_InstanceCount]">
+      <SingletonPartition />
+      <PlacementConstraints>[DummySelfReconfigService_PlacementConstraints]</PlacementConstraints>
+    </SelfReconfiguringService>
+  </ServiceTemplates>
+  <DefaultServices>
+    <Service Name="DummySelfReconfigService" ServicePackageActivationMode="ExclusiveProcess">
+      <SelfReconfiguringService ServiceTypeName="DummySelfReconfigServiceType" InstanceCount="[DummySelfReconfigService_InstanceCount]" MinInstanceCount="[DummySelfReconfigService_InstanceCount]">
+        <SingletonPartition />
+        <PlacementConstraints>[DummySelfReconfigService_PlacementConstraints]</PlacementConstraints>
+      </SelfReconfiguringService>
+    </Service>
+  </DefaultServices>
+</ApplicationManifest>

--- a/crates/samples/dummy-self-reconfig/manifests/DummySelfReconfigServicePackage/ServiceManifest.xml
+++ b/crates/samples/dummy-self-reconfig/manifests/DummySelfReconfigServicePackage/ServiceManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ServiceManifest Name="DummySelfReconfigServicePackage" Version="1.0" xmlns="http://schemas.microsoft.com/2011/01/fabric" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Description>A dummy self-reconfiguring test service implemented with mssf_core.</Description>
+  <ServiceTypes>
+    <SelfReconfiguringServiceType ServiceTypeName="DummySelfReconfigServiceType" />
+  </ServiceTypes>
+  <CodePackage Name="Code" Version="1.0">
+    <EntryPoint>
+      <ExeHost>
+        <Program>dummy-self-reconfig.exe</Program>
+        <ConsoleRedirection FileRetentionCount="5" FileMaxSizeInKb="2048"/>
+      </ExeHost>
+    </EntryPoint>
+    <EnvironmentVariables>
+      <EnvironmentVariable Name="RUST_LOG" Value="info"/>
+    </EnvironmentVariables>
+  </CodePackage>
+</ServiceManifest>

--- a/crates/samples/dummy-self-reconfig/src/factory.rs
+++ b/crates/samples/dummy-self-reconfig/src/factory.rs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Self-reconfiguring service factory.
+
+use mssf_core::runtime::{ISelfReconfiguringServiceFactory, ISelfReconfiguringServiceInstance};
+use mssf_core::{GUID, WString};
+use tracing::info;
+
+use crate::instance::SelfReconfigInstance;
+
+/// Factory that creates [`SelfReconfigInstance`]s. Registered with the runtime
+/// via `Runtime::register_self_reconfiguring_service_factory`.
+pub struct SelfReconfigFactory;
+
+impl ISelfReconfiguringServiceFactory for SelfReconfigFactory {
+    fn create_instance(
+        &self,
+        servicetypename: WString,
+        servicename: mssf_core::types::Uri,
+        _initializationdata: &[u8],
+        partitionid: GUID,
+        instanceid: i64,
+    ) -> mssf_core::Result<Box<dyn ISelfReconfiguringServiceInstance>> {
+        info!(
+            "CreateInstance: type={servicetypename:?} name={servicename:?} partition={partitionid:?} instance={instanceid}"
+        );
+        Ok(Box::new(SelfReconfigInstance::new(instanceid)))
+    }
+}

--- a/crates/samples/dummy-self-reconfig/src/instance.rs
+++ b/crates/samples/dummy-self-reconfig/src/instance.rs
@@ -1,0 +1,251 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! Self-reconfiguring service instance.
+//!
+//! The "business logic" is modeled on the internal Service Fabric
+//! `SelfReconfigTestService` C++ sample: the instance with the lowest instance
+//! id is elected leader, and only the leader reports the configuration back to
+//! Service Fabric.
+
+use std::sync::{Arc, Mutex};
+
+use mssf_core::runtime::executor::BoxedCancelToken;
+use mssf_core::runtime::{ISelfReconfiguringServiceInstance, ISelfReconfiguringServicePartition};
+use mssf_core::types::{
+    AUTO_SEQUENCE_NUMBER, HealthInformation, HealthState, InstanceChangeRequest,
+    InstanceInformation, SelfReconfiguringConfigurationChangeRequest,
+    SelfReconfiguringConfigurationReport, SelfReconfiguringConfigurationReportId,
+    SelfReconfiguringConfigurationRequest, SelfReconfiguringConfigurationRequestId,
+    SelfReconfiguringInstanceActivationState, SelfReconfiguringOpenMode,
+};
+use mssf_core::{ErrorCode, WString, async_trait};
+use tracing::info;
+
+/// Mutable state of an instance, guarded by a mutex because the configuration
+/// callbacks are synchronous and mutate it concurrently with `open`.
+struct InstanceState {
+    /// Highest request id seen so far; `{0, 0}` means none yet.
+    request_id: SelfReconfiguringConfigurationRequestId,
+    is_leader: bool,
+    /// The last configuration the instance was told about, reported back when
+    /// Service Fabric asks for the current configuration.
+    last_seen: Vec<InstanceInformation>,
+    partition: Option<Arc<dyn ISelfReconfiguringServicePartition>>,
+}
+
+pub struct SelfReconfigInstance {
+    instance_id: i64,
+    state: Mutex<InstanceState>,
+}
+
+impl SelfReconfigInstance {
+    pub fn new(instance_id: i64) -> Self {
+        Self {
+            instance_id,
+            state: Mutex::new(InstanceState {
+                request_id: SelfReconfiguringConfigurationRequestId {
+                    generation_number: 0,
+                    sequence_number: 0,
+                },
+                is_leader: false,
+                last_seen: Vec::new(),
+                partition: None,
+            }),
+        }
+    }
+}
+
+/// Outcome of validating an incoming request id against the highest one seen.
+enum RequestIdCheck {
+    /// Proceed with processing the request.
+    Proceed,
+    /// The request was already processed (same sequence number); report success
+    /// without doing any work.
+    AlreadyProcessed,
+}
+
+/// Validates a request id, mirroring the C++ sample: generation and sequence
+/// numbers must be positive and non-decreasing relative to the highest seen.
+fn validate_request_id(
+    stored: &SelfReconfiguringConfigurationRequestId,
+    incoming: &SelfReconfiguringConfigurationRequestId,
+) -> mssf_core::Result<RequestIdCheck> {
+    if incoming.generation_number <= 0 || incoming.sequence_number <= 0 {
+        return Err(ErrorCode::E_INVALIDARG.into());
+    }
+    if stored.generation_number != 0 && incoming.generation_number < stored.generation_number {
+        return Err(ErrorCode::E_INVALIDARG.into());
+    }
+    if stored.sequence_number != 0 && incoming.sequence_number < stored.sequence_number {
+        return Err(ErrorCode::E_INVALIDARG.into());
+    }
+    if stored.sequence_number != 0 && incoming.sequence_number == stored.sequence_number {
+        return Ok(RequestIdCheck::AlreadyProcessed);
+    }
+    Ok(RequestIdCheck::Proceed)
+}
+
+/// Builds a configuration report whose report id reuses the request's sequence
+/// number (a shortcut from the reference sample, which has no way to generate
+/// its own report ids).
+fn build_report(
+    request_id: SelfReconfiguringConfigurationRequestId,
+    instances: Vec<InstanceInformation>,
+) -> SelfReconfiguringConfigurationReport {
+    SelfReconfiguringConfigurationReport {
+        request_id,
+        report_id: SelfReconfiguringConfigurationReportId {
+            sequence_number: request_id.sequence_number,
+        },
+        instances,
+    }
+}
+
+/// Elects the leader instance id, mirroring the C++ sample exactly: the leader
+/// is the lowest instance id; if that instance is being deactivated, the leader
+/// becomes the first instance (in list order) that is not being deactivated.
+/// Returns `None` when every instance is being deactivated. `instances` must be
+/// non-empty.
+fn elect_leader(instances: &[InstanceChangeRequest]) -> Option<i64> {
+    let mut leader_index = 0usize;
+    let mut leader_id = instances[0].instance_id;
+    for (i, inst) in instances.iter().enumerate() {
+        if leader_id > inst.instance_id {
+            leader_id = inst.instance_id;
+            leader_index = i;
+        }
+    }
+
+    let deactivated = SelfReconfiguringInstanceActivationState::Deactivated;
+    if instances[leader_index].requested_activation_state == deactivated {
+        for (i, inst) in instances.iter().enumerate() {
+            if i != leader_index && inst.requested_activation_state != deactivated {
+                return Some(inst.instance_id);
+            }
+        }
+        return None;
+    }
+    Some(leader_id)
+}
+
+#[async_trait]
+impl ISelfReconfiguringServiceInstance for SelfReconfigInstance {
+    async fn open(
+        &self,
+        partition: Arc<dyn ISelfReconfiguringServicePartition>,
+        open_mode: SelfReconfiguringOpenMode,
+        _cancellation_token: BoxedCancelToken,
+    ) -> mssf_core::Result<WString> {
+        info!("open: instance={} mode={open_mode:?}", self.instance_id);
+        {
+            let mut st = self.state.lock().unwrap();
+            st.partition = Some(partition.clone());
+        }
+
+        let info = HealthInformation {
+            source_id: WString::from("SelfReconfigOpen"),
+            property: WString::from("Open"),
+            time_to_live_seconds: u32::MAX,
+            state: HealthState::Ok,
+            description: WString::from("Self reconfiguring test service opened."),
+            sequence_number: AUTO_SEQUENCE_NUMBER,
+            remove_when_expired: false,
+        };
+        partition.report_instance_health(&info)?;
+
+        Ok(WString::from(format!("address_{}", self.instance_id)))
+    }
+
+    fn request_configuration(
+        &self,
+        request: SelfReconfiguringConfigurationRequest,
+    ) -> mssf_core::Result<()> {
+        info!("request_configuration: instance={}", self.instance_id);
+        let (report, partition) = {
+            let mut st = self.state.lock().unwrap();
+            match validate_request_id(&st.request_id, &request.request_id)? {
+                RequestIdCheck::AlreadyProcessed => return Ok(()),
+                RequestIdCheck::Proceed => {}
+            }
+            st.request_id = request.request_id;
+            if !st.is_leader {
+                return Ok(());
+            }
+            let report = build_report(request.request_id, st.last_seen.clone());
+            (report, st.partition.clone())
+        };
+
+        match partition {
+            Some(p) => p.report_configuration(&report),
+            None => Err(ErrorCode::E_POINTER.into()),
+        }
+    }
+
+    fn request_configuration_change(
+        &self,
+        change: SelfReconfiguringConfigurationChangeRequest,
+    ) -> mssf_core::Result<()> {
+        info!(
+            "request_configuration_change: instance={} instances={}",
+            self.instance_id,
+            change.instances.len()
+        );
+        let (report, partition) = {
+            let mut st = self.state.lock().unwrap();
+            match validate_request_id(&st.request_id, &change.request_id)? {
+                RequestIdCheck::AlreadyProcessed => return Ok(()),
+                RequestIdCheck::Proceed => {}
+            }
+            if change.instances.is_empty() {
+                return Err(ErrorCode::E_INVALIDARG.into());
+            }
+
+            // Record the requested configuration so it can be reported back when
+            // Service Fabric later calls request_configuration.
+            st.last_seen = change
+                .instances
+                .iter()
+                .map(|i| InstanceInformation {
+                    instance_id: i.instance_id,
+                    role: i.requested_role,
+                    activation_state: i.requested_activation_state,
+                })
+                .collect();
+
+            let leader_id = match elect_leader(&change.instances) {
+                Some(id) => id,
+                None => {
+                    info!("all instances deactivated; no leader elected");
+                    return Ok(());
+                }
+            };
+
+            if self.instance_id != leader_id {
+                st.is_leader = false;
+                return Ok(());
+            }
+            st.is_leader = true;
+            st.request_id = change.request_id;
+
+            let report = build_report(change.request_id, st.last_seen.clone());
+            (report, st.partition.clone())
+        };
+
+        match partition {
+            Some(p) => p.report_configuration(&report),
+            None => Err(ErrorCode::E_POINTER.into()),
+        }
+    }
+
+    async fn close(&self, _cancellation_token: BoxedCancelToken) -> mssf_core::Result<()> {
+        info!("close: instance={}", self.instance_id);
+        Ok(())
+    }
+
+    fn abort(&self) {
+        info!("abort: instance={}", self.instance_id);
+    }
+}

--- a/crates/samples/dummy-self-reconfig/src/instance.rs
+++ b/crates/samples/dummy-self-reconfig/src/instance.rs
@@ -3,12 +3,11 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-//! Self-reconfiguring service instance.
-//!
-//! The "business logic" is modeled on the internal Service Fabric
-//! `SelfReconfigTestService` C++ sample: the instance with the lowest instance
-//! id is elected leader, and only the leader reports the configuration back to
-//! Service Fabric.
+//! Self-reconfiguring service instance - equivalent of a "replica" in the traditional
+//! stateful service model, but instead its membership and configuration is entirely managed
+//! by the implementation itself and not rely on Service Fabric's built-in failover
+//! management. It would still listen to the configuration change requests from Service
+//! Fabric and report the current configuration back to Service Fabric.
 
 use std::sync::{Arc, Mutex};
 
@@ -29,6 +28,8 @@ use tracing::info;
 struct InstanceState {
     /// Highest request id seen so far; `{0, 0}` means none yet.
     request_id: SelfReconfiguringConfigurationRequestId,
+    /// Whether this instance is the leader, which is the only instance that
+    /// reports configuration back to Service Fabric.
     is_leader: bool,
     /// The last configuration the instance was told about, reported back when
     /// Service Fabric asks for the current configuration.
@@ -104,11 +105,8 @@ fn build_report(
     }
 }
 
-/// Elects the leader instance id, mirroring the C++ sample exactly: the leader
-/// is the lowest instance id; if that instance is being deactivated, the leader
-/// becomes the first instance (in list order) that is not being deactivated.
-/// Returns `None` when every instance is being deactivated. `instances` must be
-/// non-empty.
+/// Dummy leader election: pick the instance with the lowest instance id, unless it is deactivated,
+/// in which case pick the next lowest.
 fn elect_leader(instances: &[InstanceChangeRequest]) -> Option<i64> {
     let mut leader_index = 0usize;
     let mut leader_id = instances[0].instance_id;

--- a/crates/samples/dummy-self-reconfig/src/main.rs
+++ b/crates/samples/dummy-self-reconfig/src/main.rs
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_core::WString;
+use mssf_core::runtime::Runtime;
+use mssf_util::tokio::TokioExecutor;
+use tracing::info;
+
+mod factory;
+mod instance;
+
+use factory::SelfReconfigFactory;
+
+/// Service type name, matching the `<SelfReconfiguringServiceType>` declared in
+/// the service manifest.
+const SERVICE_TYPE_NAME: &str = "DummySelfReconfigServiceType";
+
+fn main() -> mssf_core::Result<()> {
+    tracing_subscriber::fmt().init();
+    info!("dummy-self-reconfig host start");
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let executor = TokioExecutor::new(rt.handle().clone());
+    let runtime = Runtime::create(executor.clone())?;
+
+    runtime.register_self_reconfiguring_service_factory(
+        &WString::from(SERVICE_TYPE_NAME),
+        Box::new(SelfReconfigFactory),
+    )?;
+    info!("registered self-reconfiguring service factory for {SERVICE_TYPE_NAME}");
+
+    // Keep the host process alive until Ctrl+C / SIGTERM.
+    executor.block_until_ctrlc();
+    info!("dummy-self-reconfig host exiting");
+    Ok(())
+}

--- a/onebox/windows/ClusterManifestTemplate.json
+++ b/onebox/windows/ClusterManifestTemplate.json
@@ -227,6 +227,10 @@
           {
             "name": "EnableDeploymentAtDataRoot",
             "value": "true"
+          },
+          {
+            "name": "EnableSelfReconfiguringServices",
+            "value": "true"
           }
         ]
       },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # cargo + rustup will use this to consistently build the project
 # with the same version across all checkouts and environments
 [toolchain]
-channel = "1.96.1"
+channel = "ms-prod-1.95.0"
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # cargo + rustup will use this to consistently build the project
 # with the same version across all checkouts and environments
 [toolchain]
-channel = "ms-prod-1.95.0"
+channel = "1.96.1"
 profile = "default"


### PR DESCRIPTION
Following the existing patterns for stateful and stateless core bindings, implement the core bindings for self-reconfiguring service.

Implement a dummy self-reconfiguring service that does a dummy leader election on the smallest instance id. Deployed and validated manually in a local SF Onebox with self-reconfiguring service feature switch enabled.