### PR TITLE
bumping versions for util and core crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-util"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true

--- a/crates/libs/util/Cargo.toml
+++ b/crates/libs/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-util"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true


### PR DESCRIPTION
Bumping versions for util and core crates

util-0.9.1 adds functionality for retrieving information on in flight upgrades

core-0.8.2 adds new types, and client to support the above functionality