### PR TITLE
Add health store query support for DeployedApplication / DeployedServicePackage, as well as query filter support for Partition / Replica Health States

### DIFF
--- a/crates/libs/core/src/client/health_client.rs
+++ b/crates/libs/core/src/client/health_client.rs
@@ -301,6 +301,43 @@ impl HealthClient {
             cancellation_token,
         )
     }
+
+    fn get_deployed_application_health_internal(
+        &self,
+        desc: &mssf_com::FabricTypes::FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> FabricReceiver<crate::Result<mssf_com::FabricClient::IFabricDeployedApplicationHealthResult>>
+    {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginGetDeployedApplicationHealth2(desc, timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndGetDeployedApplicationHealth2(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn get_deployed_service_package_health_internal(
+        &self,
+        desc: &mssf_com::FabricTypes::FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> FabricReceiver<
+        crate::Result<mssf_com::FabricClient::IFabricDeployedServicePackageHealthResult>,
+    > {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginGetDeployedServicePackageHealth2(desc, timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndGetDeployedServicePackageHealth2(ctx) },
+            cancellation_token,
+        )
+    }
 }
 
 impl HealthClient {
@@ -420,5 +457,45 @@ impl HealthClient {
         }
         .await??;
         Ok(crate::types::ReplicaHealthResult::from(&com))
+    }
+
+    /// Gets the health of a deployed application.
+    pub async fn get_deployed_application_health(
+        &self,
+        desc: &crate::types::DeployedApplicationHealthQueryDescription,
+        timeout: Duration,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> crate::Result<crate::types::DeployedApplicationHealth> {
+        let com = {
+            let mut pool = BoxPool::new();
+            let desc_raw = desc.get_raw_with_pool(&mut pool);
+            self.get_deployed_application_health_internal(
+                &desc_raw,
+                timeout.as_millis() as u32,
+                cancellation_token,
+            )
+        }
+        .await??;
+        Ok(crate::types::DeployedApplicationHealth::from(&com))
+    }
+
+    /// Gets the health of a deployed service package.
+    pub async fn get_deployed_service_package_health(
+        &self,
+        desc: &crate::types::DeployedServicePackageHealthQueryDescription,
+        timeout: Duration,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> crate::Result<crate::types::DeployedServicePackageHealth> {
+        let com = {
+            let mut pool = BoxPool::new();
+            let desc_raw = desc.get_raw_with_pool(&mut pool);
+            self.get_deployed_service_package_health_internal(
+                &desc_raw,
+                timeout.as_millis() as u32,
+                cancellation_token,
+            )
+        }
+        .await??;
+        Ok(crate::types::DeployedServicePackageHealth::from(&com))
     }
 }

--- a/crates/libs/core/src/client/tests.rs
+++ b/crates/libs/core/src/client/tests.rs
@@ -74,6 +74,54 @@ async fn test_fabric_client() {
         }
     }
 
+    // test deployed application / deployed service package health.
+    // There is no "list deployed applications" query yet, so this just
+    // exercises the new HealthClient APIs against the first node using a
+    // well-known app name; a not-found style error is expected and fine when
+    // EchoApp isn't provisioned in this environment.
+    {
+        let hc = c.get_health_manager();
+        let nodes = qc
+            .get_node_list(&NodeQueryDescription::default(), timeout, None)
+            .await
+            .unwrap();
+        if let Some(node) = nodes.nodes.first() {
+            let app_desc = crate::types::DeployedApplicationHealthQueryDescription {
+                application_name: Uri::from("fabric:/EchoApp"),
+                node_name: node.name.clone(),
+                ..Default::default()
+            };
+            match hc
+                .get_deployed_application_health(&app_desc, timeout, None)
+                .await
+            {
+                Ok(health) => {
+                    println!("Deployed application health: {health:?}");
+                    let pkg_desc = crate::types::DeployedServicePackageHealthQueryDescription {
+                        application_name: Uri::from("fabric:/EchoApp"),
+                        node_name: node.name.clone(),
+                        service_manifest_name: WString::from("EchoServicePkg"),
+                        ..Default::default()
+                    };
+                    match hc
+                        .get_deployed_service_package_health(&pkg_desc, timeout, None)
+                        .await
+                    {
+                        Ok(pkg_health) => {
+                            println!("Deployed service package health: {pkg_health:?}")
+                        }
+                        Err(e) => println!(
+                            "Deployed service package health not available (expected if the service manifest name doesn't match): {e:?}"
+                        ),
+                    }
+                }
+                Err(e) => println!(
+                    "Deployed application health not available (expected if EchoApp isn't deployed on this node): {e:?}"
+                ),
+            }
+        }
+    }
+
     let smgr = c.get_service_manager();
     // test resolve echo app
     {

--- a/crates/libs/core/src/types/client/deployed_application.rs
+++ b/crates/libs/core/src/types/client/deployed_application.rs
@@ -1,0 +1,152 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::FabricClient::IFabricDeployedApplicationHealthResult;
+use mssf_com::FabricTypes::{
+    FABRIC_DEPLOYED_APPLICATION_HEALTH, FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION,
+    FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION_EX1,
+};
+use windows_core::WString;
+
+use crate::mem::{BoxPool, GetRaw, GetRawWithBoxPool};
+use crate::types::{
+    ApplicationHealthPolicy, DeployedServicePackageHealthState,
+    DeployedServicePackageHealthStatesFilter, HealthEventsFilter, HealthState, Uri,
+};
+
+/// FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION
+#[derive(Debug, Clone, Default)]
+pub struct DeployedApplicationHealthQueryDescription {
+    pub application_name: Uri,
+    pub node_name: WString,
+    pub health_policy: Option<ApplicationHealthPolicy>,
+    pub events_filter: Option<HealthEventsFilter>,
+    pub deployed_service_packages_filter: Option<DeployedServicePackageHealthStatesFilter>,
+}
+
+impl GetRawWithBoxPool<FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION>
+    for DeployedApplicationHealthQueryDescription
+{
+    fn get_raw_with_pool(
+        &self,
+        pool: &mut BoxPool,
+    ) -> FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION {
+        let health_policy = self
+            .health_policy
+            .as_ref()
+            .map(|p| {
+                let b = Box::new(p.get_raw_with_pool(pool));
+                pool.push(b)
+            })
+            .unwrap_or_default();
+
+        let events_filter = self
+            .events_filter
+            .as_ref()
+            .map(|f| {
+                let b = Box::new(f.get_raw());
+                pool.push(b)
+            })
+            .unwrap_or_default();
+
+        let deployed_service_packages_filter = self
+            .deployed_service_packages_filter
+            .as_ref()
+            .map(|f| {
+                let b = Box::new(f.get_raw());
+                pool.push(b)
+            })
+            .unwrap_or_default();
+
+        // HealthStatisticsFilter is not yet exposed on the Rust wrapper (see Phase 6 of
+        // docs/design/HealthQueryCompleteness.md); always request full statistics.
+        let ex1 = pool.push(Box::new(
+            FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION_EX1 {
+                HealthStatisticsFilter: std::ptr::null(),
+                Reserved: std::ptr::null_mut(),
+            },
+        ));
+
+        FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION {
+            ApplicationName: self.application_name.as_raw(),
+            NodeName: self.node_name.as_pcwstr(),
+            HealthPolicy: health_policy,
+            EventsFilter: events_filter,
+            DeployedServicePackagesFilter: deployed_service_packages_filter,
+            Reserved: ex1 as *mut _,
+        }
+    }
+}
+
+/// IFabricDeployedApplicationHealthResult and FABRIC_DEPLOYED_APPLICATION_HEALTH
+#[derive(Debug, Clone)]
+pub struct DeployedApplicationHealth {
+    pub application_name: Uri,
+    pub node_name: WString,
+    pub aggregated_health_state: HealthState,
+    pub health_events: Vec<crate::types::HealthEvent>,
+    pub deployed_service_package_health_states: Vec<DeployedServicePackageHealthState>,
+}
+
+impl From<&IFabricDeployedApplicationHealthResult> for DeployedApplicationHealth {
+    fn from(value: &IFabricDeployedApplicationHealthResult) -> Self {
+        let raw = unsafe { value.get_DeployedApplicationHealth().as_ref().unwrap() };
+        raw.into()
+    }
+}
+
+impl From<&FABRIC_DEPLOYED_APPLICATION_HEALTH> for DeployedApplicationHealth {
+    fn from(value: &FABRIC_DEPLOYED_APPLICATION_HEALTH) -> Self {
+        let health_events = unsafe { value.HealthEvents.as_ref() }.map_or(vec![], |list| {
+            crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+        });
+        let deployed_service_package_health_states =
+            unsafe { value.DeployedServicePackageHealthStates.as_ref() }.map_or(vec![], |list| {
+                crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+            });
+        Self {
+            application_name: Uri::from(value.ApplicationName),
+            node_name: WString::from(value.NodeName),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+            health_events,
+            deployed_service_package_health_states,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::HealthStateFilterFlags;
+
+    #[test]
+    fn test_deployed_application_health_query_description_raw() {
+        let desc = DeployedApplicationHealthQueryDescription {
+            application_name: Uri::from("fabric:/App1"),
+            node_name: WString::from("Node1"),
+            health_policy: None,
+            events_filter: Some(HealthEventsFilter {
+                health_state_filter: HealthStateFilterFlags::WARNING,
+            }),
+            deployed_service_packages_filter: Some(DeployedServicePackageHealthStatesFilter {
+                health_state_filter: HealthStateFilterFlags::ERROR,
+            }),
+        };
+        let mut pool = BoxPool::new();
+        let raw = desc.get_raw_with_pool(&mut pool);
+        assert_eq!(WString::from(raw.NodeName), WString::from("Node1"));
+        assert!(!raw.EventsFilter.is_null());
+        assert_eq!(
+            unsafe { (*raw.EventsFilter).HealthStateFilter },
+            HealthStateFilterFlags::WARNING.bits() as u32
+        );
+        assert!(!raw.DeployedServicePackagesFilter.is_null());
+        assert_eq!(
+            unsafe { (*raw.DeployedServicePackagesFilter).HealthStateFilter },
+            HealthStateFilterFlags::ERROR.bits() as u32
+        );
+        assert!(!raw.Reserved.is_null());
+    }
+}

--- a/crates/libs/core/src/types/client/deployed_application.rs
+++ b/crates/libs/core/src/types/client/deployed_application.rs
@@ -60,8 +60,7 @@ impl GetRawWithBoxPool<FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION>
             })
             .unwrap_or_default();
 
-        // HealthStatisticsFilter is not yet exposed on the Rust wrapper (see Phase 6 of
-        // docs/design/HealthQueryCompleteness.md); always request full statistics.
+        // HealthStatisticsFilter is not yet exposed on the Rust wrapper; always request full statistics.
         let ex1 = pool.push(Box::new(
             FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION_EX1 {
                 HealthStatisticsFilter: std::ptr::null(),

--- a/crates/libs/core/src/types/client/deployed_service_package.rs
+++ b/crates/libs/core/src/types/client/deployed_service_package.rs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use mssf_com::FabricClient::IFabricDeployedServicePackageHealthResult;
+use mssf_com::FabricTypes::{
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH,
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION,
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION_EX1,
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATE,
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATES_FILTER,
+};
+use windows_core::{PCWSTR, WString};
+
+use crate::mem::{BoxPool, GetRaw, GetRawWithBoxPool};
+use crate::types::{
+    ApplicationHealthPolicy, HealthEventsFilter, HealthState, HealthStateFilterFlags, Uri,
+};
+
+/// FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATES_FILTER
+#[derive(Debug, Clone)]
+pub struct DeployedServicePackageHealthStatesFilter {
+    pub health_state_filter: HealthStateFilterFlags,
+}
+
+impl GetRaw<FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATES_FILTER>
+    for DeployedServicePackageHealthStatesFilter
+{
+    fn get_raw(&self) -> FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATES_FILTER {
+        FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATES_FILTER {
+            HealthStateFilter: self.health_state_filter.bits() as u32,
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct DeployedServicePackageHealthState {
+    pub application_name: Uri,
+    pub service_manifest_name: WString,
+    pub node_name: WString,
+    pub aggregated_health_state: HealthState,
+}
+
+impl From<&FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATE> for DeployedServicePackageHealthState {
+    fn from(value: &FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATE) -> Self {
+        Self {
+            application_name: Uri::from(value.ApplicationName),
+            service_manifest_name: WString::from(value.ServiceManifestName),
+            node_name: WString::from(value.NodeName),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+        }
+    }
+}
+
+/// FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION
+#[derive(Debug, Clone, Default)]
+pub struct DeployedServicePackageHealthQueryDescription {
+    pub application_name: Uri,
+    pub node_name: WString,
+    pub service_manifest_name: WString,
+    pub health_policy: Option<ApplicationHealthPolicy>,
+    pub events_filter: Option<HealthEventsFilter>,
+    /// FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION_EX1::ServicePackageActivationId
+    pub service_package_activation_id: Option<WString>,
+}
+
+impl GetRawWithBoxPool<FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION>
+    for DeployedServicePackageHealthQueryDescription
+{
+    fn get_raw_with_pool(
+        &self,
+        pool: &mut BoxPool,
+    ) -> FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION {
+        let health_policy = self
+            .health_policy
+            .as_ref()
+            .map(|p| {
+                let b = Box::new(p.get_raw_with_pool(pool));
+                pool.push(b)
+            })
+            .unwrap_or_default();
+
+        let events_filter = self
+            .events_filter
+            .as_ref()
+            .map(|f| {
+                let b = Box::new(f.get_raw());
+                pool.push(b)
+            })
+            .unwrap_or_default();
+
+        let ex1 = pool.push(Box::new(
+            FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION_EX1 {
+                ServicePackageActivationId: self
+                    .service_package_activation_id
+                    .as_ref()
+                    .map_or(PCWSTR::null(), |s| s.as_pcwstr()),
+                Reserved: std::ptr::null_mut(),
+            },
+        ));
+
+        FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION {
+            ApplicationName: self.application_name.as_raw(),
+            NodeName: self.node_name.as_pcwstr(),
+            ServiceManifestName: self.service_manifest_name.as_pcwstr(),
+            HealthPolicy: health_policy,
+            EventsFilter: events_filter,
+            Reserved: ex1 as *mut _,
+        }
+    }
+}
+
+/// IFabricDeployedServicePackageHealthResult and FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH
+#[derive(Debug, Clone)]
+pub struct DeployedServicePackageHealth {
+    pub application_name: Uri,
+    pub service_manifest_name: WString,
+    pub node_name: WString,
+    pub aggregated_health_state: HealthState,
+    pub health_events: Vec<crate::types::HealthEvent>,
+}
+
+impl From<&IFabricDeployedServicePackageHealthResult> for DeployedServicePackageHealth {
+    fn from(value: &IFabricDeployedServicePackageHealthResult) -> Self {
+        let raw = unsafe { value.get_DeployedServicePackageHealth().as_ref().unwrap() };
+        raw.into()
+    }
+}
+
+impl From<&FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH> for DeployedServicePackageHealth {
+    fn from(value: &FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH) -> Self {
+        let health_events = unsafe { value.HealthEvents.as_ref() }.map_or(vec![], |list| {
+            crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+        });
+        Self {
+            application_name: Uri::from(value.ApplicationName),
+            service_manifest_name: WString::from(value.ServiceManifestName),
+            node_name: WString::from(value.NodeName),
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+            health_events,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::HealthStateFilterFlags;
+
+    #[test]
+    fn test_deployed_service_package_health_query_description_raw() {
+        let desc = DeployedServicePackageHealthQueryDescription {
+            application_name: Uri::from("fabric:/App1"),
+            node_name: WString::from("Node1"),
+            service_manifest_name: WString::from("Pkg1"),
+            health_policy: None,
+            events_filter: Some(HealthEventsFilter {
+                health_state_filter: HealthStateFilterFlags::ERROR,
+            }),
+            service_package_activation_id: Some(WString::from("activation-1")),
+        };
+        let mut pool = BoxPool::new();
+        let raw = desc.get_raw_with_pool(&mut pool);
+        assert_eq!(WString::from(raw.NodeName), WString::from("Node1"));
+        assert_eq!(
+            WString::from(raw.ServiceManifestName),
+            WString::from("Pkg1")
+        );
+        assert!(!raw.EventsFilter.is_null());
+        assert_eq!(
+            unsafe { (*raw.EventsFilter).HealthStateFilter },
+            HealthStateFilterFlags::ERROR.bits() as u32
+        );
+        let ex1 = unsafe {
+            (raw.Reserved as *const FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION_EX1)
+                .as_ref()
+                .unwrap()
+        };
+        assert_eq!(
+            WString::from(ex1.ServicePackageActivationId),
+            WString::from("activation-1")
+        );
+    }
+
+    #[test]
+    fn test_deployed_service_package_health_states_filter_raw() {
+        let filter = DeployedServicePackageHealthStatesFilter {
+            health_state_filter: HealthStateFilterFlags::WARNING,
+        };
+        let raw = filter.get_raw();
+        assert_eq!(
+            raw.HealthStateFilter,
+            HealthStateFilterFlags::WARNING.bits() as u32
+        );
+    }
+}

--- a/crates/libs/core/src/types/client/mod.rs
+++ b/crates/libs/core/src/types/client/mod.rs
@@ -62,6 +62,11 @@ pub use application_upgrade::{
     ApplicationUpgradeProgress, ApplicationUpgradeState, UpgradeDomainState, UpgradeDomainStatus,
 };
 
+mod deployed_service_package;
+pub use deployed_service_package::*;
+mod deployed_application;
+pub use deployed_application::*;
+
 // FABRIC_SERVICE_NOTIFICATION_FILTER_FLAGS
 bitflags::bitflags! {
     #[derive(Debug, Clone)]

--- a/crates/libs/core/src/types/client/partition.rs
+++ b/crates/libs/core/src/types/client/partition.rs
@@ -267,8 +267,8 @@ pub struct PartitionHealthQueryDescription {
     pub partition_id: GUID,
     pub health_policy: Option<super::ApplicationHealthPolicy>,
     pub events_filter: Option<super::HealthEventsFilter>,
+    pub replicas_filter: Option<super::ReplicaHealthStatesFilter>,
     // TODO: other fields
-    // pub replicas_filter: Option<super::ReplicaHealthStatesFilter>,
     // pub health_statistics_filter: Option<super::HealthStatisticsFilter>,
 }
 
@@ -297,6 +297,15 @@ impl crate::mem::GetRawWithBoxPool<mssf_com::FabricTypes::FABRIC_PARTITION_HEALT
             })
             .unwrap_or_default();
 
+        let replicas_filter = self
+            .replicas_filter
+            .as_ref()
+            .map(|f| {
+                let b = Box::new(f.get_raw());
+                pool.push(b)
+            })
+            .unwrap_or_default();
+
         let ex1 = pool.push(Box::new(
             mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_QUERY_DESCRIPTION_EX1 {
                 Reserved: std::ptr::null_mut(),
@@ -308,7 +317,7 @@ impl crate::mem::GetRawWithBoxPool<mssf_com::FabricTypes::FABRIC_PARTITION_HEALT
             EventsFilter: events_filter,
             HealthPolicy: health_policy,
             PartitionId: self.partition_id,
-            ReplicasFilter: std::ptr::null_mut(),
+            ReplicasFilter: replicas_filter,
             Reserved: ex1 as *mut _,
         }
     }
@@ -354,5 +363,57 @@ impl GetRaw<mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATES_FILTER>
             HealthStateFilter: self.health_state_filter.bits() as u32,
             Reserved: std::ptr::null_mut(),
         }
+    }
+}
+
+// FABRIC_PARTITION_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct PartitionHealthState {
+    pub partition_id: GUID,
+    pub aggregated_health_state: HealthState,
+}
+
+impl From<&mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATE> for PartitionHealthState {
+    fn from(value: &mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATE) -> Self {
+        Self {
+            partition_id: value.PartitionId,
+            aggregated_health_state: (&value.AggregatedHealthState).into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mem::{BoxPool, GetRawWithBoxPool};
+    use crate::types::ReplicaHealthStatesFilter;
+
+    #[test]
+    fn test_partition_health_query_description_replicas_filter_raw() {
+        let desc = PartitionHealthQueryDescription {
+            partition_id: GUID::zeroed(),
+            replicas_filter: Some(ReplicaHealthStatesFilter {
+                health_state_filter: HealthStateFilterFlags::ERROR,
+            }),
+            ..Default::default()
+        };
+        let mut pool = BoxPool::new();
+        let raw = desc.get_raw_with_pool(&mut pool);
+        assert!(!raw.ReplicasFilter.is_null());
+        assert_eq!(
+            unsafe { (*raw.ReplicasFilter).HealthStateFilter },
+            HealthStateFilterFlags::ERROR.bits() as u32
+        );
+    }
+
+    #[test]
+    fn test_partition_health_query_description_no_replicas_filter_raw() {
+        let desc = PartitionHealthQueryDescription {
+            partition_id: GUID::zeroed(),
+            ..Default::default()
+        };
+        let mut pool = BoxPool::new();
+        let raw = desc.get_raw_with_pool(&mut pool);
+        assert!(raw.ReplicasFilter.is_null());
     }
 }

--- a/crates/libs/core/src/types/client/partition.rs
+++ b/crates/libs/core/src/types/client/partition.rs
@@ -25,7 +25,7 @@ use mssf_com::{
     },
 };
 
-use crate::types::{HealthState, ServicePartitionInformation};
+use crate::types::{HealthState, HealthStateFilterFlags, ServicePartitionInformation};
 
 // Partition related types
 // FABRIC_SERVICE_PARTITION_QUERY_DESCRIPTION
@@ -336,6 +336,23 @@ impl From<&mssf_com::FabricClient::IFabricPartitionHealthResult> for PartitionHe
             partition_id: raw.PartitionId,
             aggregated_health_state: (&raw.AggregatedHealthState).into(),
             health_events: health_event_list,
+        }
+    }
+}
+
+// FABRIC_PARTITION_HEALTH_STATES_FILTER
+#[derive(Debug, Clone)]
+pub struct PartitionHealthStatesFilter {
+    pub health_state_filter: HealthStateFilterFlags,
+}
+
+impl GetRaw<mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATES_FILTER>
+    for PartitionHealthStatesFilter
+{
+    fn get_raw(&self) -> mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATES_FILTER {
+        mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATES_FILTER {
+            HealthStateFilter: self.health_state_filter.bits() as u32,
+            Reserved: std::ptr::null_mut(),
         }
     }
 }

--- a/crates/libs/core/src/types/client/partition.rs
+++ b/crates/libs/core/src/types/client/partition.rs
@@ -329,8 +329,8 @@ pub struct PartitionHealthResult {
     pub partition_id: GUID,
     pub aggregated_health_state: HealthState,
     pub health_events: Vec<super::HealthEvent>,
+    pub replica_health_states: Vec<super::ReplicaHealthState>,
     // TODO: other fields
-    // pub replicas_health: Vec<super::ReplicaHealthResult>,
     // pub health_statistics: super::HealthStatistics,
     // pub unhealthy_evaluations: Vec<super::HealthEvaluation>,
 }
@@ -338,13 +338,24 @@ pub struct PartitionHealthResult {
 impl From<&mssf_com::FabricClient::IFabricPartitionHealthResult> for PartitionHealthResult {
     fn from(value: &mssf_com::FabricClient::IFabricPartitionHealthResult) -> Self {
         let raw = unsafe { value.get_PartitionHealth().as_ref().unwrap() };
+        raw.into()
+    }
+}
+
+impl From<&mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH> for PartitionHealthResult {
+    fn from(raw: &mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH) -> Self {
         let health_event_list = unsafe { raw.HealthEvents.as_ref() }.map_or(vec![], |list| {
             crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
         });
+        let replica_health_states = unsafe { raw.ReplicaHealthStates.as_ref() }
+            .map_or(vec![], |list| {
+                crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+            });
         Self {
             partition_id: raw.PartitionId,
             aggregated_health_state: (&raw.AggregatedHealthState).into(),
             health_events: health_event_list,
+            replica_health_states,
         }
     }
 }
@@ -386,7 +397,7 @@ impl From<&mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATE> for PartitionHe
 mod tests {
     use super::*;
     use crate::mem::{BoxPool, GetRawWithBoxPool};
-    use crate::types::ReplicaHealthStatesFilter;
+    use crate::types::{ReplicaHealthState, ReplicaHealthStatesFilter};
 
     #[test]
     fn test_partition_health_query_description_replicas_filter_raw() {
@@ -415,5 +426,36 @@ mod tests {
         let mut pool = BoxPool::new();
         let raw = desc.get_raw_with_pool(&mut pool);
         assert!(raw.ReplicasFilter.is_null());
+    }
+
+    #[test]
+    fn test_partition_health_result_replica_health_states() {
+        let replica_state = mssf_com::FabricTypes::FABRIC_STATEFUL_SERVICE_REPLICA_HEALTH_STATE {
+            PartitionId: GUID::zeroed(),
+            ReplicaId: 42,
+            AggregatedHealthState: mssf_com::FabricTypes::FABRIC_HEALTH_STATE_OK,
+            Reserved: std::ptr::null_mut(),
+        };
+        let replica_health_state = mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATE {
+            Kind: mssf_com::FabricTypes::FABRIC_SERVICE_KIND_STATEFUL,
+            Value: &replica_state as *const _ as *mut _,
+        };
+        let list = mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATE_LIST {
+            Count: 1,
+            Items: &replica_health_state,
+        };
+        let raw = mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH {
+            PartitionId: GUID::zeroed(),
+            AggregatedHealthState: mssf_com::FabricTypes::FABRIC_HEALTH_STATE_OK,
+            HealthEvents: std::ptr::null(),
+            ReplicaHealthStates: &list,
+            Reserved: std::ptr::null_mut(),
+        };
+        let result = PartitionHealthResult::from(&raw);
+        assert_eq!(result.replica_health_states.len(), 1);
+        match &result.replica_health_states[0] {
+            ReplicaHealthState::Stateful(s) => assert_eq!(s.replica_id, 42),
+            _ => panic!("expected stateful replica health state"),
+        }
     }
 }

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -28,7 +28,7 @@ use mssf_com::{
     },
 };
 
-use crate::types::{HealthState, ReplicaRole};
+use crate::types::{HealthState, HealthStateFilterFlags, ReplicaRole};
 
 use super::{QueryReplicatorOperationName, QueryServiceOperationName};
 
@@ -514,6 +514,23 @@ impl From<&mssf_com::FabricTypes::FABRIC_STATELESS_SERVICE_INSTANCE_HEALTH>
             health_events: unsafe { value.HealthEvents.as_ref() }.map_or(vec![], |list| {
                 crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
             }),
+        }
+    }
+}
+
+// FABRIC_REPLICA_HEALTH_STATES_FILTER
+#[derive(Debug, Clone)]
+pub struct ReplicaHealthStatesFilter {
+    pub health_state_filter: HealthStateFilterFlags,
+}
+
+impl GetRaw<mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATES_FILTER>
+    for ReplicaHealthStatesFilter
+{
+    fn get_raw(&self) -> mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATES_FILTER {
+        mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATES_FILTER {
+            HealthStateFilter: self.health_state_filter.bits() as u32,
+            Reserved: std::ptr::null_mut(),
         }
     }
 }

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -20,9 +20,9 @@ use mssf_com::{
         FABRIC_QUERY_SERVICE_REPLICA_STATUS_DROPPED, FABRIC_QUERY_SERVICE_REPLICA_STATUS_INBUILD,
         FABRIC_QUERY_SERVICE_REPLICA_STATUS_INVALID, FABRIC_QUERY_SERVICE_REPLICA_STATUS_READY,
         FABRIC_QUERY_SERVICE_REPLICA_STATUS_STANDBY, FABRIC_REMOVE_REPLICA_DESCRIPTION,
-        FABRIC_RESTART_REPLICA_DESCRIPTION, FABRIC_SERVICE_KIND_STATEFUL,
-        FABRIC_SERVICE_KIND_STATELESS, FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION,
-        FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM,
+        FABRIC_RESTART_REPLICA_DESCRIPTION, FABRIC_SERVICE_KIND_SELF_RECONFIGURING,
+        FABRIC_SERVICE_KIND_STATEFUL, FABRIC_SERVICE_KIND_STATELESS,
+        FABRIC_SERVICE_REPLICA_QUERY_DESCRIPTION, FABRIC_SERVICE_REPLICA_QUERY_RESULT_ITEM,
         FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM,
         FABRIC_STATELESS_SERVICE_INSTANCE_QUERY_RESULT_ITEM,
     },
@@ -531,6 +531,89 @@ impl GetRaw<mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATES_FILTER>
         mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATES_FILTER {
             HealthStateFilter: self.health_state_filter.bits() as u32,
             Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+// FABRIC_REPLICA_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub enum ReplicaHealthState {
+    Stateful(StatefulServiceReplicaHealthState),
+    Stateless(StatelessServiceInstanceHealthState),
+    SelfReconfiguring(SelfReconfiguringServiceInstanceHealthState),
+    Invalid,
+}
+
+// FABRIC_STATEFUL_SERVICE_REPLICA_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct StatefulServiceReplicaHealthState {
+    pub partition_id: GUID,
+    pub replica_id: i64,
+    pub aggregated_health_state: HealthState,
+    // TODO: UnhealthyEvaluations
+}
+
+// FABRIC_STATELESS_SERVICE_INSTANCE_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct StatelessServiceInstanceHealthState {
+    pub partition_id: GUID,
+    pub instance_id: i64,
+    pub aggregated_health_state: HealthState,
+    // TODO: UnhealthyEvaluations
+}
+
+// FABRIC_SELF_RECONFIGURING_SERVICE_INSTANCE_HEALTH_STATE
+#[derive(Debug, Clone)]
+pub struct SelfReconfiguringServiceInstanceHealthState {
+    pub partition_id: GUID,
+    pub instance_id: i64,
+    pub aggregated_health_state: HealthState,
+    // TODO: UnhealthyEvaluations
+}
+
+impl From<&mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATE> for ReplicaHealthState {
+    fn from(value: &mssf_com::FabricTypes::FABRIC_REPLICA_HEALTH_STATE) -> Self {
+        match value.Kind {
+            FABRIC_SERVICE_KIND_STATEFUL => {
+                let raw = unsafe {
+                    (value.Value
+                        as *const mssf_com::FabricTypes::FABRIC_STATEFUL_SERVICE_REPLICA_HEALTH_STATE)
+                        .as_ref()
+                        .unwrap()
+                };
+                Self::Stateful(StatefulServiceReplicaHealthState {
+                    partition_id: raw.PartitionId,
+                    replica_id: raw.ReplicaId,
+                    aggregated_health_state: (&raw.AggregatedHealthState).into(),
+                })
+            }
+            FABRIC_SERVICE_KIND_STATELESS => {
+                let raw = unsafe {
+                    (value.Value
+                        as *const mssf_com::FabricTypes::FABRIC_STATELESS_SERVICE_INSTANCE_HEALTH_STATE)
+                        .as_ref()
+                        .unwrap()
+                };
+                Self::Stateless(StatelessServiceInstanceHealthState {
+                    partition_id: raw.PartitionId,
+                    instance_id: raw.InstanceId,
+                    aggregated_health_state: (&raw.AggregatedHealthState).into(),
+                })
+            }
+            FABRIC_SERVICE_KIND_SELF_RECONFIGURING => {
+                let raw = unsafe {
+                    (value.Value
+                        as *const mssf_com::FabricTypes::FABRIC_SELF_RECONFIGURING_SERVICE_INSTANCE_HEALTH_STATE)
+                        .as_ref()
+                        .unwrap()
+                };
+                Self::SelfReconfiguring(SelfReconfiguringServiceInstanceHealthState {
+                    partition_id: raw.PartitionId,
+                    instance_id: raw.InstanceId,
+                    aggregated_health_state: (&raw.AggregatedHealthState).into(),
+                })
+            }
+            _ => Self::Invalid,
         }
     }
 }

--- a/crates/libs/core/src/types/client/service.rs
+++ b/crates/libs/core/src/types/client/service.rs
@@ -1297,22 +1297,32 @@ pub struct ServiceHealthResult {
     pub service_name: Uri,
     pub aggregated_health_state: HealthState,
     pub health_events: Vec<HealthEvent>,
-    // TODO: implement other fields
-    // pub partitions_health: Vec<PartitionHealth>,
+    pub partition_health_states: Vec<super::PartitionHealthState>,
 }
 
 impl From<&mssf_com::FabricClient::IFabricServiceHealthResult> for ServiceHealthResult {
     fn from(value: &mssf_com::FabricClient::IFabricServiceHealthResult) -> Self {
         let raw = unsafe { value.get_ServiceHealth().as_ref().unwrap() };
+        raw.into()
+    }
+}
 
+impl From<&mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH> for ServiceHealthResult {
+    fn from(raw: &mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH) -> Self {
         let health_event_list = unsafe { raw.HealthEvents.as_ref() }.map_or(vec![], |list| {
             crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
         });
+
+        let partition_health_states = unsafe { raw.PartitionHealthStates.as_ref() }
+            .map_or(vec![], |list| {
+                crate::iter::vec_from_raw_com(list.Count as usize, list.Items)
+            });
 
         Self {
             service_name: Uri::from(raw.ServiceName),
             aggregated_health_state: HealthState::from(&raw.AggregatedHealthState),
             health_events: health_event_list,
+            partition_health_states,
         }
     }
 }
@@ -1349,6 +1359,7 @@ impl GetRaw<FABRIC_DELETE_SERVICE_DESCRIPTION> for DeleteServiceDescription {
 #[cfg(test)]
 mod health_query_tests {
     use super::*;
+    use crate::GUID;
     use crate::types::PartitionHealthStatesFilter;
 
     #[test]
@@ -1378,5 +1389,31 @@ mod health_query_tests {
         let mut pool = BoxPool::new();
         let raw = desc.get_raw_with_pool(&mut pool);
         assert!(raw.PartitionsFilter.is_null());
+    }
+
+    #[test]
+    fn test_service_health_result_partition_health_states() {
+        let partition_state = mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATE {
+            PartitionId: GUID::zeroed(),
+            AggregatedHealthState: mssf_com::FabricTypes::FABRIC_HEALTH_STATE_WARNING,
+            Reserved: std::ptr::null_mut(),
+        };
+        let list = mssf_com::FabricTypes::FABRIC_PARTITION_HEALTH_STATE_LIST {
+            Count: 1,
+            Items: &partition_state,
+        };
+        let raw = mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH {
+            ServiceName: Uri::from("fabric:/App1/Svc1").as_raw(),
+            AggregatedHealthState: mssf_com::FabricTypes::FABRIC_HEALTH_STATE_WARNING,
+            HealthEvents: std::ptr::null(),
+            PartitionHealthStates: &list,
+            Reserved: std::ptr::null_mut(),
+        };
+        let result = ServiceHealthResult::from(&raw);
+        assert_eq!(result.partition_health_states.len(), 1);
+        assert_eq!(
+            result.partition_health_states[0].aggregated_health_state,
+            HealthState::Warning
+        );
     }
 }

--- a/crates/libs/core/src/types/client/service.rs
+++ b/crates/libs/core/src/types/client/service.rs
@@ -1238,8 +1238,8 @@ pub struct ServiceHealthQueryDescription {
     pub service_name: Uri,
     pub health_policy: Option<ApplicationHealthPolicy>,
     pub events_filter: Option<HealthEventsFilter>,
+    pub partitions_filter: Option<super::PartitionHealthStatesFilter>,
     // TODO: implement other filters
-    // pub partitions_filter: Option<PartitionHealthStatesFilter>,
     // pub health_statistics_filter: Option<HealthStatisticsFilter>,
 }
 
@@ -1266,6 +1266,14 @@ impl crate::mem::GetRawWithBoxPool<mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH_
                 pool.push(b)
             })
             .unwrap_or_default();
+        let partitions_filter = self
+            .partitions_filter
+            .as_ref()
+            .map(|f| {
+                let b = Box::new(f.get_raw());
+                pool.push(b)
+            })
+            .unwrap_or_default();
         let ex1 = Box::new(
             mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH_QUERY_DESCRIPTION_EX1 {
                 HealthStatisticsFilter: std::ptr::null_mut(),
@@ -1277,7 +1285,7 @@ impl crate::mem::GetRawWithBoxPool<mssf_com::FabricTypes::FABRIC_SERVICE_HEALTH_
             ServiceName: self.service_name.as_raw(),
             HealthPolicy: health_policy,
             EventsFilter: events_filter,
-            PartitionsFilter: std::ptr::null_mut(),
+            PartitionsFilter: partitions_filter,
             Reserved: ex1 as *mut c_void,
         }
     }
@@ -1335,5 +1343,40 @@ impl GetRaw<FABRIC_DELETE_SERVICE_DESCRIPTION> for DeleteServiceDescription {
             ForceDelete: self.force_delete,
             Reserved: std::ptr::null_mut(),
         }
+    }
+}
+
+#[cfg(test)]
+mod health_query_tests {
+    use super::*;
+    use crate::types::PartitionHealthStatesFilter;
+
+    #[test]
+    fn test_service_health_query_description_partitions_filter_raw() {
+        let desc = ServiceHealthQueryDescription {
+            service_name: Uri::from("fabric:/App1/Svc1"),
+            partitions_filter: Some(PartitionHealthStatesFilter {
+                health_state_filter: HealthStateFilterFlags::WARNING,
+            }),
+            ..Default::default()
+        };
+        let mut pool = BoxPool::new();
+        let raw = desc.get_raw_with_pool(&mut pool);
+        assert!(!raw.PartitionsFilter.is_null());
+        assert_eq!(
+            unsafe { (*raw.PartitionsFilter).HealthStateFilter },
+            HealthStateFilterFlags::WARNING.bits() as u32
+        );
+    }
+
+    #[test]
+    fn test_service_health_query_description_no_partitions_filter_raw() {
+        let desc = ServiceHealthQueryDescription {
+            service_name: Uri::from("fabric:/App1/Svc1"),
+            ..Default::default()
+        };
+        let mut pool = BoxPool::new();
+        let raw = desc.get_raw_with_pool(&mut pool);
+        assert!(raw.PartitionsFilter.is_null());
     }
 }

--- a/crates/libs/util/src/monitoring/producer.rs
+++ b/crates/libs/util/src/monitoring/producer.rs
@@ -14,7 +14,8 @@ use mssf_core::{
     types::{
         ApplicationHealthStatesFilter, ApplicationQueryDescription, ClusterHealthQueryDescription,
         HealthEventsFilter, HealthStateFilterFlags, NodeHealthQueryDescription,
-        NodeHealthStatesFilter, NodeQueryResultItem, Uri,
+        NodeHealthStatesFilter, NodeQueryResultItem, PartitionHealthStatesFilter,
+        ReplicaHealthStatesFilter, Uri,
     },
 };
 use std::time::Duration;
@@ -370,9 +371,13 @@ impl HealthDataProducer {
         token: BoxedCancelToken,
         svc: mssf_core::types::ServiceQueryResultItem,
     ) -> Option<ProducerEvent> {
+        // As with cluster health, Ignore partitions health because we retrieve them separately.
         let svc_name = svc.get_service_name().clone();
         let desc = mssf_core::types::ServiceHealthQueryDescription {
             service_name: svc_name,
+            partitions_filter: Some(PartitionHealthStatesFilter {
+                health_state_filter: HealthStateFilterFlags::NONE,
+            }),
             ..Default::default()
         };
         let svc_health = self
@@ -399,9 +404,13 @@ impl HealthDataProducer {
         service_name: Uri,
         application_name: Uri,
     ) -> Option<ProducerEvent> {
+        // As with cluster health, Ignore replicas health because we retrieve them separately.
         let partition_id = part.get_partition_id();
         let desc = mssf_core::types::PartitionHealthQueryDescription {
             partition_id,
+            replicas_filter: Some(ReplicaHealthStatesFilter {
+                health_state_filter: HealthStateFilterFlags::NONE,
+            }),
             ..Default::default()
         };
         let part_health = self


### PR DESCRIPTION
Made changes to components related to querying the "Health Store" to support missing filters (Partition/Replica) as well as missing Health Event types (DeployedApplication / DeployedServicePackage)

**Changes**
- Added missing "HEALTH_STATES_FILTER" definitions for "Replica" and "Partition" health queries
    - Added `PartitionHealthStatesFilter` and `ReplicaHealthStatesFilter` struct definitions, following the existing pattern used by NodeHealthStatesFilter / ApplicationHealthStatesFilter / ServiceHealthStatesFilter.
    - Wired up missing health state filers for `ServiceHealthQueryDescription` and `PartitionHealthQueryDescription`.
    - Added `PartitionHealthState` and `ReplicaHealthState`, the aggregated-state-only result types these filters imply.
    - `PartitionHealthResult` / `ServiceHealthResult` now populate "replica_health_states" and "parition_health_states" respectively.
- Added "DeployedApplication" and "DeployedServicePackage" health queries
    - New module `types::client::deployed_application` for `DeployedApplicationHealthQueryDescription` and `DeployedApplicationHealth`.
    - New module `types::client::deployed_service_package` for `DeployedServicePackageHealthStatesFilter`, `DeployedServicePackageHealthState`, `DeployedServicePackageHealthQueryDescription`, and `DeployedServicePackageHealth`.
    - Added `get_deployed_application_health` and `get_deployed_service_package_health` to `HealthClient`.

**Tests**
- Unit tests for the new raw conversions; `test_fabric_client` extended to exercise
  both new HealthClient functions.
- Unit tests asserting the new health state filter fields are wired through to the raw struct,
  and are null when not set.