### PR TITLE
[xDS Proposals] SF gRPC xDS, SLB, and HTTP reverse-proxy design proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin
 obj
 .windows
 .paw
+.reviews
 
 # cargo stuff
 target

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -734,22 +734,54 @@ Consequences and rules:
 - **Replica role (`mssf-partition-role`) — a second, orthogonal
   reserved header.** This header selects the *replica class* within
   the already-selected partition, independent of `mssf-partition-key`.
-  Allowed values are `primary` (default), `secondary`, and `any`; the
+  Allowed values are exactly `primary` (default), `secondary`, and
+  `any`; the
   agent emits, per partition, an extra `Route` header match that maps
-  `secondary` → the partition's `...-secondary` `ROUND_ROBIN` cluster
-  and `any` → a `ROUND_ROBIN` cluster spanning primary + secondaries,
-  with `primary` selecting the `...-primary` cluster. For a
+  `secondary` → the partition's `...-secondary` `ROUND_ROBIN` cluster (`{S1, S2, …}`)
+  and `any` → a `ROUND_ROBIN` cluster spanning primary + secondaries (`{P, S1, S2, …}`),
+  with `primary` selecting the `...-primary` cluster (`{P}`).
+  For a
   **stateless** service `any` is the only meaningful value and maps to
-  the single instance cluster; `primary`/`secondary` collapse to that
-  same instance set. **Unlike `mssf-partition-key`, this header fails
-  *safe*, not closed:** when it is **absent or its value matches no
-  role route**, the request falls through to the partition's
-  **primary** cluster. This preserves the write-safety guarantee the
-  old `-secondary` resource name gave for free — the plain
-  `xds:///fabric/App/Svc` target is primary-only unless a caller opts
-  into secondary/any reads. The final correctness backstop is
-  unchanged: the header is a routing hint and SF returns `NotPrimary`
-  if a write reaches a secondary.
+  the single instance cluster; `primary`/`secondary` collapse
+  to that
+  same instance set.
+
+  **Governing principle** (the [central design principle](#central-design-principle)
+  applied to roles). The xDS layer exposes **only** the replica
+  roles SF Naming actually resolves — primary, secondary, or all
+  replicas — and does **not** synthesize any failover/fallback
+  aggregation (there is no priority-aggregated cluster and no
+  selectable `failover` role, because SF Naming offers none). A client
+  that wants fallback — e.g. read the primary but tolerate a secondary
+  when the primary is unavailable — obtains it by **retrying with a
+  different `mssf-partition-role` value**. That is a client
+  responsibility, not a server/routing feature.
+
+  **Unlike `mssf-partition-key`, this header fails
+  *safe*, not closed:** when it is **absent** *or* **present but its
+  value matches no role route** (e.g. a misspelled `read-only`), the
+  request falls through to the partition's **primary** cluster — one
+  authoritative rule that covers both the absent and the
+  present-but-unrecognized cases, consistent with the first-match RDS
+  ordering below (the role routes precede the key-only primary
+  fallback, so any unmatched role value lands on primary). This
+  preserves the write-safety guarantee the old `-secondary` resource
+  name gave for free — the plain `xds:///fabric/App/Svc` target is
+  primary-only unless a caller opts into secondary/any reads.
+
+  **One exception — topology-blind SLB paths fail *closed*.** The
+  fail-*safe*-to-primary default assumes a topology-aware backend that
+  can actually reach the partition's primary. It does **not** hold on
+  a flat, topology-blind `@slb` VIP (Scenario C in the
+  [SLB proposal](./GrpcXdsSlb.md#scenario-c--direct-via-slb-port-mapping-translation)),
+  where a default-primary request would land on an arbitrary replica.
+  There the role instead **fails closed** and requires an explicit
+  `mssf-partition-role: any`. This variant is per-resource (the RDS
+  policy is emitted per advertised `xds:///` target), so the
+  topology-blind `@slb` resource carries the fail-closed policy while
+  the ordinary topology-aware resource keeps the fail-safe default.
+  The final correctness backstop is unchanged: the header is a routing
+  hint and SF returns `NotPrimary` if a write reaches a secondary.
 - **RDS route ordering (how absent-⇒-primary is actually built).**
   RDS routes are **first-match-wins**, and a single `Route` can match
   the partition key **and** the role header together. The fail-*safe*
@@ -780,7 +812,8 @@ Consequences and rules:
   routes above are emitted once with the top partition's
   `Range [low, i64::MAX)` matcher **and** once with a
   `String::Exact "9223372036854775807"` matcher, in the same
-  secondary → any → (primary) → key-only-primary order, so the boundary
+  secondary → any → (primary) → key-only-primary order, so
+  the boundary
   value keeps both role selection and the fail-closed key behavior.
 - **Value encoding.** Header values are ASCII strings: Int64 keys
   are decimal (optionally negative, full `i64` range); Named keys
@@ -819,8 +852,13 @@ signal is not needed under xDS. Two mechanisms, used together:
 The agent registers a notification filter for the URI. When SF
 naming says "primary moved from N1 to N2," the agent emits a
 fresh EDS `DiscoveryResponse` with updated endpoint addresses
-(or with the old primary marked `HealthStatus::DRAINING`).
-gRPC's LB picks the new primary on the next request.
+(optionally reflecting the old primary as `HealthStatus::DRAINING`
+when SF's `ChangeRole` gives advance notice — a passive reflection of
+the naming event, not a health state the agent synthesizes).
+gRPC's LB picks the new primary on the next request. This is
+naming-driven failover — per the
+[central design principle](#central-design-principle), an EDS re-push,
+not an xDS priority construct the layer would have to invent.
 
 ### Server-side ORCA reports (optional, for richer signals)
 
@@ -883,7 +921,7 @@ sequenceDiagram
     SF-->>Agent: ServiceNotification<br/>(RSP version bump,<br/> primary now N2)
 
     Note over Agent: Translate to xDS
-    Agent->>Agent: build new EDS resource:<br/>endpoints = [N2], version v+1<br/>(optionally mark N1 DRAINING<br/> in a transitional push)
+    Agent->>Agent: build new EDS resource:<br/>endpoints = [N2], version v+1<br/>(optionally reflect N1 DRAINING<br/> if SF gave advance notice)
     Agent-->>Xds: DiscoveryResponse(EDS, v+1)
     Xds-->>Agent: DiscoveryRequest ACK(v+1)
 
@@ -923,7 +961,7 @@ secondary. Three sub-cases:
 | **N1 process crashes (no graceful role-change)** | Steps 7–8 don't happen first; instead the open HTTP/2 connection fails. `tonic-xds` evicts the N1 subchannel on TCP error. The agent still gets a notification within seconds and pushes EDS v+1. Order is reversed but the destination is the same. |
 | **N2 not yet ready when push arrives** | Step 14 fails until N2 accepts connections. `tonic-xds` keeps the subchannel in `CONNECTING` and surfaces `Unavailable` to picks until ready. Client retries succeed once N2 transitions. |
 | **Notification delivery delayed** | Steady-state lag (sub-second on a healthy cluster). Requests in the gap may hit N1 and bounce with `Code::Unavailable` until the push lands. Caller-side retry policy covers the window. |
-| **Old primary marked `DRAINING` first, removed in a second push** | Two `DiscoveryResponse`s instead of one. `tonic-xds` stops picking N1 for new RPCs immediately at the `DRAINING` push; in-flight requests finish; the second push (endpoint removed) closes the idle subchannel. Useful for graceful shedding when SF gives advance notice. |
+| **Old primary reflected as `DRAINING` first, removed in a second push** | Two `DiscoveryResponse`s instead of one, used only when SF's `ChangeRole` gives advance notice. `tonic-xds` stops picking N1 for **new** RPCs immediately at the `DRAINING` push — that routing signal is all the agent does; whether an in-flight request completes or is terminated is the **replica's** call (it finishes as secondary or returns `NotPrimary`), not a drain the agent orchestrates. The second push (endpoint removed) closes the idle subchannel. |
 | **Multiple concurrent failovers (e.g. primary plus a secondary)** | Each is one notification → one EDS push, versioned and ACKed independently via ADS. The dataplane converges on the last-pushed state. |
 
 ### Why this is "automatic" from the client's perspective
@@ -1179,32 +1217,51 @@ Four near-term caveats:
   the `i64::MAX` top-partition boundary (confirm the highest
   partition's `high_key` does not overflow `Int64Range.end`).
 
-### Phase 4 — Priority failover + read-from-secondary
+### Phase 4 — Naming-driven primary failover + read-from-secondary
 
-- **Primary failover:** aggregate primary + secondaries into one
-  cluster with priorities (P0 = primary, P1 = secondaries).
-  Default route → this cluster; xDS shifts traffic to P1 only when
-  P0 goes unhealthy. This is failover, *not* load-spreading.
-- **Read-from-secondary:** for read-only workloads, the client sets
-  the `mssf-partition-role` header per request (`primary` (default) /
-  `secondary` / `any`). RDS matches this header **in addition to**
-  `mssf-partition-key`, so partition selection is unchanged. For a
-  **singleton** service the role match selects, within the one default
-  route, the `...-primary`, `...-secondary` `ROUND_ROBIN`, or
-  all-replicas (`any`) cluster. For a **partitioned** service each
-  partition's `Route`s fan out by role to *that partition's*
-  `...-primary` / `...-secondary` / all-replicas cluster rather than
-  one flat secondary cluster. Steering reads onto secondaries is a
-  *per-request header* choice, not a priority level (a healthy-primary
-  priority cluster would never send reads to P1). **When the header is
-  absent or unmatched the request falls through to primary**, so
-  write-safety is preserved by default (the role routes are emitted
-  ahead of a key-only primary fallback per the [RDS route
-  ordering](#partition-key-semantics), so a broad primary route cannot
-  shadow them and a missing/malformed key still fails closed); a caller
-  wanting a hard read-only channel stamps `mssf-partition-role:
+- **Primary failover (the default/`primary` route):** the default
+  route points at a **primary-only, single-endpoint EDS cluster**.
+  Its failover is the **EDS re-push** — when naming promotes and
+  re-publishes a new primary, the control tier pushes the new
+  endpoint (optionally reflecting the old one as draining when SF
+  gives advance notice) and gRPC reconnects. The
+  default route is **never** aggregated with a secondaries tier:
+  an SF secondary is not a promoted primary until naming re-publishes
+  it, so silently shifting the write path onto a secondary would
+  break the write-safe guarantee. This is naming-driven failover,
+  *not* load-spreading.
+- **Read-from-secondary (secondary-safe reads, opt-in):** for
+  read-only workloads, the client sets the `mssf-partition-role`
+  header per request (`primary` (default) / `secondary` / `any`).
+  Each opt-in value selects a **distinct** read cluster,
+  and **none** is ever wired onto the default/`primary` write path:
+  `secondary` → a `...-secondary` `ROUND_ROBIN` cluster (`{S1, S2, …}`); `any` → an
+  all-replicas `ROUND_ROBIN` cluster (`{P, S1, S2, …}`). RDS
+  matches the role header **in
+  addition to** `mssf-partition-key`, so partition selection is
+  unchanged. For a **singleton** service the role match selects,
+  within the one default route, the `...-primary` (`{P}`), `...-secondary`
+  `ROUND_ROBIN` (`{S1, S2, …}`), or all-replicas (`any`, `{P, S1, S2, …}`) cluster. For a
+  **partitioned** service each partition's `Route`s fan out by role to
+  *that partition's* `...-primary` / `...-secondary` / all-replicas
+  cluster rather than one flat secondary cluster. Steering reads onto
+  secondaries — round-robin (`secondary`/`any`) — is a *per-request
+  header* choice on an opt-in read route, never the default write path.
+  **When the header is absent or unmatched the request falls through
+  to primary**, so write-safety is preserved by default (the role
+  routes are emitted ahead of a key-only primary fallback per the [RDS
+  route ordering](#partition-key-semantics), so a broad primary route
+  cannot shadow them and a missing/malformed key still fails closed); a
+  caller wanting a hard read-only channel stamps `mssf-partition-role:
   secondary` via a client-side metadata interceptor (the replacement
   for the old `-secondary` resource name).
+- **No synthesized failover/fallback** (the
+  [central design principle](#central-design-principle) in action). The
+  xDS layer offers only the
+  roles SF Naming resolves (`primary`/`secondary`/`any`); it does not
+  build a priority-aggregated failover cluster. A client wanting
+  fallback retries with a different `mssf-partition-role` value (see
+  [Partition key semantics](#partition-key-semantics)).
 - Both are achieved with no server-side changes; the server still
   returns `NotPrimary` if a write lands on a secondary.
 
@@ -1357,7 +1414,9 @@ receive xDS snapshots and re-serve them locally.
 
 - **mTLS / SDS** via xDS Secret Discovery Service.
 - **Fault injection / circuit breakers** from
-  `Cluster.outlier_detection` (free once xDS is in place).
+  `Cluster.outlier_detection` (free once xDS is in place) — an
+  optional client-side convenience that never supersedes
+  naming-driven failover or the replica's `NotPrimary` write-safety.
 - **gRPC RLS** (Route Lookup Service) for very-dynamic routing
   if a workload needs it.
 - **Upstream contributions to `tonic-xds`.** Anything we have

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -86,8 +86,9 @@ plumbing to talk to SF services.
    ([LDS/RDS/CDS/EDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#resource-types)).
 3. Map SF stateful semantics (primary / secondary / partition
    key) onto standard xDS resources — `round_robin` for
-   stateless, priority-routing for primary-with-fallback, and
-   RDS `Route` matching on the partition key to select the owning
+   stateless, a primary-only single-endpoint EDS whose failover is
+   a naming-driven re-push (never a priority/fallback aggregation),
+   and RDS `Route` matching on the partition key to select the owning
    partition (which then reuses the same primary LB).
 4. Stay incremental: ship a minimal but *complete* xDS chain
    first — a gRPC `xds:///` channel always resolves
@@ -417,7 +418,8 @@ This is a topology refinement layered on the existing
   `InstanceCount=1`) and reduce `mssf-xds-agent` to a snapshot
   relay. The translation code is unchanged; only *where it runs*
   and *how the snapshot reaches the node* change.
-- **Phases 3–5** (partitioning, priority routing, ORCA/LRS) then
+- **Phases 3–5** (partitioning, naming-driven primary failover +
+  read-from-secondary, ORCA/LRS) then
   implement **once** in the control tier and fan out to every relay
   for free.
 
@@ -473,9 +475,9 @@ Examples:
 |---|---|---|
 | Fabric URI (`fabric:/App/Svc`) | `Listener` name | One listener per URI. **Single-tier:** created lazily on first subscribe. **Two-tier:** the discovery singleton's cluster-wide `fabric:` catch-all translates *every* service eagerly (see [Two-tier translation cost](#applying-the-split-to-xds)). |
 | Partition (`PartitionKeyType::*`) | `RouteConfiguration` → `Cluster` selection | Singleton: one cluster. Int64/Named: one `Route` per partition, matched on the `mssf-partition-key` request header. |
-| Replica role (`mssf-partition-role`) | `RouteConfiguration` `Route` header match → per-partition `Cluster` variant | Within a partition, the role header picks the cluster: `primary` (default) → `...-primary`; `secondary` → `...-secondary`; `any` → the all-replicas cluster. **Absent/unmatched ⇒ primary** (write-safe). For a **stateless** service `any` is the only meaningful value and maps to the single instance cluster; `primary`/`secondary` collapse to that same instance set. |
-| `ServiceEndpointRole::StatefulPrimary` | `Cluster` name `...-primary` + `Priority 0` in EDS | Optionally aggregated with secondaries (Priority 1) for failover routing. Selected by `mssf-partition-role: primary` (the default). |
-| `ServiceEndpointRole::StatefulSecondary` | `Cluster` name `...-secondary` + EDS with `round_robin` | For read-from-secondary; selected per-request via `mssf-partition-role: secondary`. `any` targets a ROUND_ROBIN cluster spanning primary + secondaries. |
+| Replica role (`mssf-partition-role`) | `RouteConfiguration` `Route` header match → per-partition `Cluster` variant | Within a partition — where `P` denotes the primary replica and `S1, S2, …` the secondaries (`S` generically) — the role header picks the cluster: `primary` (default) → `...-primary` (`{P}`); `secondary` → `...-secondary` (`{S1, S2, …}`); `any` → the all-replicas cluster (`{P, S1, S2, …}`). **Absent/unmatched ⇒ primary** (write-safe). For a **stateless** service `any` is the only meaningful value and maps to the single instance cluster; `primary`/`secondary` collapse to that same instance set. The xDS layer exposes only the replica roles SF Naming resolves and does **not** synthesize a failover/fallback cluster (see [LB policy mapping](#lb-policy-mapping)). |
+| `ServiceEndpointRole::StatefulPrimary` | `Cluster` name `...-primary` (`{P}`) — **primary-only single-endpoint EDS** (`Priority 0` only) | Selected by `mssf-partition-role: primary` (the default). Failover is the **EDS re-push** when naming re-publishes the promoted primary; **never** aggregated with a Priority-1 secondaries tier (that would silently break write-safety). |
+| `ServiceEndpointRole::StatefulSecondary` | `Cluster` name `...-secondary` + EDS with `round_robin` | Opt-in read routes only, **never** the default/`primary` write path: `secondary` → this `...-secondary` `ROUND_ROBIN` cluster (`{S1, S2, …}`); `any` → a ROUND_ROBIN cluster spanning primary + secondaries (`{P, S1, S2, …}`). These two read clusters are **distinct** from each other. |
 | `ResolvedServiceEndpoint.address` (URL string) | `LbEndpoint.endpoint.address` | Agent parses the SF endpoint string; see [Endpoint address parsing](#endpoint-address-parsing). Fails the resource if unparseable. |
 | `ResolvedServicePartition` version bump (notification) | EDS `DiscoveryResponse` push | Standard xDS push semantics; no client polling. |
 | Server returns `ServicePartitionAccessStatus::NotPrimary` (stale primary) | endpoint's EDS `HealthStatus` flips **only when the agent re-resolves and pushes** | The server does **not** self-report into EDS. The client sees an RPC error and retries / [re-resolves](#forced-re-resolve-on-client-observed-failure); the endpoint's EDS health changes control-plane-side once the notification stream tells the agent the primary moved. |
@@ -539,9 +541,8 @@ validates it against the `echomain` and `kvstore` samples.
 |---|---|---|
 | Stateless service, fan out | `ROUND_ROBIN` | default |
 | Stateless service, latency-aware | `LEAST_REQUEST` | `choice_count=2` |
-| Stateful primary only | `ROUND_ROBIN` over a 1-endpoint EDS | primary cluster only |
-| Stateful primary with failover to secondaries | priority-aggregated cluster: P0 = primary, P1 = secondaries | `PriorityLoadAssignment`; P1 gets traffic only when P0 is unhealthy |
-| Stateful read-from-secondary | separate `...-secondary` `ROUND_ROBIN` cluster, selected **per-request** via `mssf-partition-role: secondary` (default `primary`) | see note below — this is *not* the priority mechanism |
+| Stateful primary only (**the write-safe default/`primary` route**) | `ROUND_ROBIN` over a 1-endpoint EDS | primary cluster only (`{P}`); failover is the **EDS re-push** when naming re-publishes the promoted primary |
+| Stateful read-from-secondary / all-replicas reads | `secondary` → a `...-secondary` `ROUND_ROBIN` cluster (`{S1, S2, …}`); `any` → an all-replicas `ROUND_ROBIN` cluster (`{P, S1, S2, …}`); selected **per-request** (default `primary`) | see note below — the xDS layer offers only the roles SF Naming resolves, no priority-aggregated failover cluster |
 | Partitioned stateful (Int64/Named) | **same as the two rows above, applied to the selected partition's cluster** | partition is chosen by RDS first; see below |
 
 > **Partitioned routing = partition selection (RDS) + the ordinary
@@ -561,7 +562,7 @@ validates it against the `echomain` and `kvstore` samples.
 >    optional ownership check.
 > 2. **Route within the partition.** Once the cluster is chosen,
 >    routing is *identical* to the singleton stateful-primary case
->    (1-endpoint primary EDS, or primary+secondary priority), with
+>    (1-endpoint primary EDS), with
 >    the same EDS-push failover. Nothing partition-specific.
 >
 > **`RING_HASH` is not used** — SF partitions are authoritative key
@@ -570,40 +571,51 @@ validates it against the `echomain` and `kvstore` samples.
 > Phase 3 adds only the RDS selection layer and reuses the
 > Phase 1/4 primary LB unchanged.
 
-> **Priority failover ≠ read-from-secondary.** These are two
-> distinct mechanisms, easy to conflate:
+> **No priority-aggregated failover cluster.** A tempting but rejected
+> option is an xDS *priority* tier (P0 = primary, P1 = secondaries in one
+> aggregated cluster). Per xDS semantics P1 receives **no** traffic while
+> P0 is healthy above the over-provisioning threshold, so such a tier
+> gives primary-with-failover, *not* load-spreading — and it is a
+> **failover aggregation that SF Naming itself does not offer**. Per the
+> governing principle (see [Partition key semantics](#partition-key-semantics)),
+> **the xDS layer exposes only the replica roles SF Naming resolves
+> (`primary`/`secondary`/`any`) and does not synthesize failover/fallback
+> aggregation.** So there is **no** selectable `failover` role or cluster.
+> A client that wants fallback (read the primary but tolerate a secondary
+> when the primary is unavailable) achieves it by **retrying with a
+> different `mssf-partition-role` value** — a client responsibility, not a
+> server/routing feature. The default/`primary` route uses a
+> **primary-only single-endpoint EDS** whose failover is the naming-driven
+> **EDS re-push** (naming re-publishes the promoted primary), never a
+> silent shift onto an unpromoted secondary.
 >
-> - **Priority failover** (P0 = primary, P1 = secondaries in one
->   priority-aggregated cluster) is a *failover* tier. Per xDS
->   semantics, P1 receives **no** traffic while P0 is healthy above
->   the over-provisioning threshold, so a healthy-primary request
->   never reaches a secondary. This gives primary-with-failover, not
->   load-spreading.
-> - **Read-from-secondary** deliberately sends healthy-path reads to
->   secondaries. It is *not* expressed with priorities, and it is a
->   **per-request** choice carried in the `mssf-partition-role`
->   header (`primary` (default) / `secondary` / `any`), *not* a
->   resource-name convention. RDS matches the role header **in
->   addition to** the `mssf-partition-key` match, so partition
->   selection is unchanged and orthogonal: for a **singleton
->   (non-partitioned)** service the role match selects, within the
->   one default route, the `...-primary`, `...-secondary`, or
->   all-replicas (`any`) cluster; for a **partitioned** service each
->   partition's `Route`s fan out by role to *that partition's*
->   `...-primary` / `...-secondary` / all-replicas cluster (partition
->   N's own replicas), never one flat secondary cluster. **When the
->   header is absent or its value matches no role route, the request
->   falls through to that partition's primary cluster** — the role routes
->   are emitted ahead of a key-only primary fallback (see the RDS route
->   ordering under [Partition key semantics](#partition-key-semantics)), so
->   the plain `xds:///fabric/App/Svc` target stays primary-only just as the
->   old `-secondary` suffix did for free, and writes are never silently
->   steered onto a secondary. A caller wanting a hard read-only channel
->   stamps `mssf-partition-role: secondary` on every call via a client-side
->   metadata interceptor (the per-channel replacement for a dedicated
->   `-secondary` resource name). The correctness backstop is unchanged: the
->   header is a routing *hint*, and SF still returns `NotPrimary` if a write
->   lands on a secondary.
+> **Read-from-secondary** deliberately sends healthy-path reads to
+> secondaries. It is *not* expressed with priorities, and it is a
+> **per-request** choice carried in the `mssf-partition-role`
+> header (`primary` (default) / `secondary` / `any`),
+> *not* a resource-name convention. RDS matches the role header **in
+> addition to** the `mssf-partition-key` match, so partition
+> selection is unchanged and orthogonal: for a **singleton
+> (non-partitioned)** service the role match selects, within the
+> one default route, the `...-primary`, `...-secondary`, or all-replicas
+> (`any`) cluster; for a
+> **partitioned** service each
+> partition's `Route`s fan out by role to *that partition's*
+> `...-primary` / `...-secondary` / all-replicas
+> cluster (partition
+> N's own replicas), never one flat secondary cluster. **When the
+> header is absent or its value matches no role route, the request
+> falls through to that partition's primary cluster** — the role routes
+> are emitted ahead of a key-only primary fallback (see the RDS route
+> ordering under [Partition key semantics](#partition-key-semantics)), so
+> the plain `xds:///fabric/App/Svc` target stays primary-only just as the
+> old `-secondary` suffix did for free, and writes are never silently
+> steered onto a secondary. A caller wanting a hard read-only channel
+> stamps `mssf-partition-role: secondary` on every call via a client-side
+> metadata interceptor (the per-channel replacement for a dedicated
+> `-secondary` resource name). The correctness backstop is unchanged: the
+> header is a routing *hint*, and SF still returns `NotPrimary` if a write
+> lands on a secondary.
 
 ### Partition key semantics
 
@@ -758,10 +770,20 @@ A server that's lost its primary role can emit an
 [ORCA](https://github.com/cncf/xds/blob/main/xds/data/orca/v3/orca_load_report.proto)
 load report with a custom utility metric (e.g.
 `mssf.role.degraded = 1`). gRPC's `weighted_round_robin` /
-`xds_wrr` LB honors per-endpoint utility. The agent doesn't
-need to know about the event; the data plane self-adjusts.
+`xds_wrr` LB honors per-endpoint utility.
 
-ORCA is additive; the push-driven path is the primary mechanism.
+**ORCA does not self-report EDS health and does not switch replica
+roles on the client.** A degraded utility metric only *deweights* an
+already-known endpoint within a generic WRR pool; it cannot identify
+the promoted replacement primary, cannot create the new primary's EDS
+endpoint, and is not a role-state transition. The **authoritative**
+failover mechanism stays [push-driven](#push-driven-preferred):
+control-plane notification → SF re-resolve → EDS push. To stay
+consistent with that model, ORCA is used **only as a trigger** — a
+same-signal hint that prompts the SF-facing tier to re-resolve and
+push a fresh snapshot — never as a client-side role switch or a
+server self-reporting its own EDS membership. It is additive; the
+push-driven path is the primary mechanism.
 
 ## Failover walkthrough — primary moves N1 → N2
 

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -423,7 +423,7 @@ xDS has four resource types gRPC consumes:
 > |---|---|---|
 > | Which service | URI path | `xds:///fabric/<app>/<service>` becomes the xDS resource (Listener) name |
 > | Per-channel policy (primary-only vs. read-from-secondary, listener pick) | URI resource-name convention | a distinct resource name the agent maps to a cluster — **not** a query param |
-> | Which partition (per request) | `mssf-partition-key` header | RDS route match: `Range` for Int64, `String::Exact` for Named |
+> | Which partition (per request) | `mssf-partition-key` header | RDS route match: `Range` for Int64, `String::Exact` for Named (see [Partition key semantics](#partition-key-semantics)) |
 >
 > The URI is bound once when the channel is built and survives
 > failover; a partition key changes per call, so it cannot ride in
@@ -442,7 +442,7 @@ Examples:
 | URI | Meaning |
 |---|---|
 | `xds:///fabric/MyApp/Greeter` | resolve the service; default LB. Partition (if any) selected per-request via the `mssf-partition-key` header. |
-| `xds:///fabric/MyApp/Kv` | partitioned `KvStore`; the client sets `mssf-partition-key: user:42` per call and RDS routes it to the owning partition's cluster. |
+| `xds:///fabric/MyApp/Kv` | partitioned `KvStore` (Int64); the client sets `mssf-partition-key: 42` (a decimal i64) per call and RDS routes it to the partition whose range covers 42. See [Partition key semantics](#partition-key-semantics). |
 
 ### Mapping table
 
@@ -544,6 +544,56 @@ validates it against the `echomain` and `kvstore` samples.
 > honor exact boundaries or the one-primary-per-partition rule.
 > Phase 3 adds only the RDS selection layer and reuses the
 > Phase 1/4 primary LB unchanged.
+
+### Partition key semantics
+
+The `mssf-partition-key` header value is **not** an arbitrary
+business key — it must be in the **same domain as the service's SF
+partition scheme**, because the agent builds the `Route`s directly
+from SF's live partition information
+([`ServicePartitionInformation`](../../crates/libs/core/src/types/common/partition.rs)).
+SF supports exactly three schemes
+([`PartitionKeyType`](../../crates/libs/core/src/client/svc_mgmt_client.rs)):
+
+| SF scheme | `mssf-partition-key` value | Route built by the agent |
+|---|---|---|
+| `Singleton` | *omitted* | one default `Route`; no matcher |
+| `Int64Range` | a **decimal `i64`** (e.g. `42`) | one `Range` matcher per partition from its `low_key`/`high_key` (inclusive SF `[low, high]` → half-open `[low, high+1)`) |
+| `Named` | the **exact partition name** | one `String::Exact` matcher per partition name (case-sensitive) |
+
+Consequences and rules:
+
+- **No transform/hashing layer.** The client sends the *same* i64
+  or name it would pass to
+  [`resolve_service_partition(name, PartitionKeyType::Int64(k) | String(n))`](../../crates/libs/util/src/resolve.rs).
+  SF does not hash for you; mapping a business entity
+  (`user:42`) to an `i64` or a partition name is the
+  **application's** job, done before setting the header. If a
+  business-key→partition-key transform is ever wanted, it belongs
+  in a client helper, not the agent — the agent only mirrors SF's
+  partition boundaries.
+- **Routes are derived from the live scheme.** The agent enumerates
+  the service's partitions and emits one `Route`/`Cluster` per
+  partition. On **repartition** it must re-emit the
+  `RouteConfiguration` so the matchers keep mirroring SF exactly;
+  stale ranges would mis-route silently.
+- **Malformed / mismatched key.** A non-integer header on an
+  `Int64Range` service, or an unknown name on a `Named` service,
+  matches no `Route`. Define this as a hard client error
+  (`Unavailable`/`InvalidArgument`) rather than a silent fallback
+  to an arbitrary partition.
+- **Missing key on a partitioned service.** No default partition is
+  safe to assume for a partitioned stateful service. Either require
+  the header (fail closed) or route to an explicit
+  `-unpartitioned`/error cluster; do **not** pick partition 0.
+- **Value encoding.** Header values are ASCII strings: Int64 keys
+  are decimal (optionally negative, full `i64` range); Named keys
+  are the partition name verbatim. Reserve the `mssf-` prefix for
+  these SF routing headers.
+
+This contract is validated in Phase 3 against the `KvStore`
+sample (Int64 partitioning); a Named-partition sample should be
+added to cover the `String::Exact` path.
 
 ## Failover signal
 

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -89,9 +89,15 @@ plumbing to talk to SF services.
    stateless, priority-routing for primary-with-fallback, and
    RDS `Route` matching on the partition key to select the owning
    partition (which then reuses the same primary LB).
-4. Stay incremental: ship a minimum viable EDS-only experiment
-   first; add RDS/CDS sophistication and ORCA only when a real
-   workload needs them.
+4. Stay incremental: ship a minimal but *complete* xDS chain
+   first — a gRPC `xds:///` channel always resolves
+   LDS→RDS→CDS→EDS, so the wire minimum is all four resource
+   types (a Listener with an `ApiListener`/HCM, a trivial
+   single-vhost `RouteConfiguration`, one fixed `ROUND_ROBIN`
+   `Cluster`, and EDS from SF naming). The economy is in the
+   *content* — few resources, no partition/priority logic — not
+   in omitting resource types. Add RDS/CDS sophistication and
+   ORCA only when a real workload needs them.
 
 ## Non-Goals
 
@@ -285,6 +291,17 @@ over the local loopback/UDS ADS endpoint. Node-local gRPC clients
 are unchanged — they still point at `127.0.0.1` / a UDS via
 `GRPC_XDS_BOOTSTRAP` and speak vanilla xDS.
 
+Note the tradeoff: because the discovery singleton owns a
+cluster-wide `fabric:` catch-all, it translates and holds **every**
+service in the cluster, subscribed or not — so its translation and
+memory cost scales with the *total* number of cluster services, not
+with what any client asked for. The "lazy on first subscribe"
+economy of the mapping table applies to the **single-tier** agent;
+it does not hold for the two-tier discovery singleton. The
+filtered/on-demand relay option above mitigates only the *relay*
+side (per-node snapshot size), not the singleton's full-cluster
+translation.
+
 Crucially, only the **config** takes the extra hop (control tier →
 relay). Client RPCs still connect **directly** to the target
 replica's endpoint, exactly as in the single-tier form — the
@@ -415,27 +432,32 @@ xDS has four resource types gRPC consumes:
 
 ### URI scheme and routing strategy
 
-> **The whole strategy in one place.** Service identity and
-> per-channel policy live in the **URI**; anything that varies per
-> request lives in a **header**.
+> **The whole strategy in one place.** Service identity lives in the
+> **URI**; anything that varies per request lives in a **header**.
 >
 > | Concern | Where | Mechanism |
 > |---|---|---|
 > | Which service | URI path | `xds:///fabric/<app>/<service>` becomes the xDS resource (Listener) name |
-> | Per-channel policy (primary-only vs. read-from-secondary, listener pick) | URI resource-name convention | a distinct resource name the agent maps to a cluster — **not** a query param |
 > | Which partition (per request) | `mssf-partition-key` header | RDS route match: `Range` for Int64, `String::Exact` for Named (see [Partition key semantics](#partition-key-semantics)) |
+> | Which replica role (per request) | `mssf-partition-role` header | RDS route match on `primary` (default) / `secondary` / `any`; **absent or unmatched ⇒ primary** (see [Partition key semantics](#partition-key-semantics)) |
 >
 > The URI is bound once when the channel is built and survives
-> failover; a partition key changes per call, so it cannot ride in
-> the URI.
+> failover; a partition key and a replica role both change per call,
+> so they cannot ride in the URI. A caller that wants a *hard*
+> read-only channel installs a client-side metadata interceptor that
+> stamps `mssf-partition-role: secondary` on every call (see
+> [LB policy mapping](#lb-policy-mapping)) — this replaces the old
+> dedicated `-secondary` resource name and keeps per-channel
+> ergonomics without a second listener.
 
 `tonic-xds`'s
 [`XdsUri`](https://docs.rs/tonic-xds/latest/tonic_xds/struct.XdsUri.html)
 keeps only a `target: String` and validates just the `xds`
 scheme, so **query params are dropped** — `?role=` / `?partition=`
-cannot carry routing intent. Encode per-channel selectors in the
-resource name; do per-request partition selection with the header
-(see [LB policy mapping](#lb-policy-mapping)).
+cannot carry routing intent. Do per-request partition selection with
+the `mssf-partition-key` header and per-request replica-role
+selection with the `mssf-partition-role` header (see
+[LB policy mapping](#lb-policy-mapping)).
 
 Examples:
 
@@ -443,18 +465,20 @@ Examples:
 |---|---|
 | `xds:///fabric/MyApp/Greeter` | resolve the service; default LB. Partition (if any) selected per-request via the `mssf-partition-key` header. |
 | `xds:///fabric/MyApp/Kv` | partitioned `KvStore` (Int64); the client sets `mssf-partition-key: 42` (a decimal i64) per call and RDS routes it to the partition whose range covers 42. See [Partition key semantics](#partition-key-semantics). |
+| `xds:///fabric/MyApp/Kv` + `mssf-partition-role: secondary` | same plain target, **read-from-secondary**; RDS matches both headers and routes the request to the selected partition's `...-secondary` `ROUND_ROBIN` cluster. `any` targets all replicas of the partition; **absent/unmatched ⇒ primary** (write-safe default). A client wanting a hard read-only channel stamps this header on every call via a metadata interceptor. See [LB policy mapping](#lb-policy-mapping). |
 
 ### Mapping table
 
 | SF concept | xDS resource | Notes |
 |---|---|---|
-| Fabric URI (`fabric:/App/Svc`) | `Listener` name | One listener per URI; created lazily on first subscribe. |
+| Fabric URI (`fabric:/App/Svc`) | `Listener` name | One listener per URI. **Single-tier:** created lazily on first subscribe. **Two-tier:** the discovery singleton's cluster-wide `fabric:` catch-all translates *every* service eagerly (see [Two-tier translation cost](#applying-the-split-to-xds)). |
 | Partition (`PartitionKeyType::*`) | `RouteConfiguration` → `Cluster` selection | Singleton: one cluster. Int64/Named: one `Route` per partition, matched on the `mssf-partition-key` request header. |
-| `ServiceEndpointRole::StatefulPrimary` | `Cluster` name `...-primary` + `Priority 0` in EDS | Optionally aggregated with secondaries (Priority 1) for failover routing. |
-| `ServiceEndpointRole::StatefulSecondary` | `Cluster` name `...-secondary` + EDS with `round_robin` | For read-from-secondary patterns. |
+| Replica role (`mssf-partition-role`) | `RouteConfiguration` `Route` header match → per-partition `Cluster` variant | Within a partition, the role header picks the cluster: `primary` (default) → `...-primary`; `secondary` → `...-secondary`; `any` → the all-replicas cluster. **Absent/unmatched ⇒ primary** (write-safe). For a **stateless** service `any` is the only meaningful value and maps to the single instance cluster; `primary`/`secondary` collapse to that same instance set. |
+| `ServiceEndpointRole::StatefulPrimary` | `Cluster` name `...-primary` + `Priority 0` in EDS | Optionally aggregated with secondaries (Priority 1) for failover routing. Selected by `mssf-partition-role: primary` (the default). |
+| `ServiceEndpointRole::StatefulSecondary` | `Cluster` name `...-secondary` + EDS with `round_robin` | For read-from-secondary; selected per-request via `mssf-partition-role: secondary`. `any` targets a ROUND_ROBIN cluster spanning primary + secondaries. |
 | `ResolvedServiceEndpoint.address` (URL string) | `LbEndpoint.endpoint.address` | Agent parses the SF endpoint string; see [Endpoint address parsing](#endpoint-address-parsing). Fails the resource if unparseable. |
 | `ResolvedServicePartition` version bump (notification) | EDS `DiscoveryResponse` push | Standard xDS push semantics; no client polling. |
-| `ServicePartitionAccessStatus::NotPrimary` (server side) | `HealthStatus::UNHEALTHY` on the endpoint | Removes endpoint from active set without dropping the connection; gRPC LB will pick another. |
+| Server returns `ServicePartitionAccessStatus::NotPrimary` (stale primary) | endpoint's EDS `HealthStatus` flips **only when the agent re-resolves and pushes** | The server does **not** self-report into EDS. The client sees an RPC error and retries / [re-resolves](#forced-re-resolve-on-client-observed-failure); the endpoint's EDS health changes control-plane-side once the notification stream tells the agent the primary moved. |
 | Resolve returns **no endpoints** (`FABRIC_E_SERVICE_OFFLINE`) | see [Offline / empty-endpoint window](#offline--empty-endpoint-window) | Service restarting or removed; the resolver in `resolve.rs` retries this case. |
 | `ServicePartitionInformation` (Int64/Named ranges) | `Route` match on `mssf-partition-key` → per-partition `Cluster` | Partition **selection** only. Within the chosen cluster, routing is identical to the singleton stateful-primary case. |
 
@@ -516,7 +540,8 @@ validates it against the `echomain` and `kvstore` samples.
 | Stateless service, fan out | `ROUND_ROBIN` | default |
 | Stateless service, latency-aware | `LEAST_REQUEST` | `choice_count=2` |
 | Stateful primary only | `ROUND_ROBIN` over a 1-endpoint EDS | primary cluster only |
-| Stateful primary with read-from-secondary | priority-aggregated cluster: P0 = primary, P1 = secondaries | `PriorityLoadAssignment` + per-call route choice |
+| Stateful primary with failover to secondaries | priority-aggregated cluster: P0 = primary, P1 = secondaries | `PriorityLoadAssignment`; P1 gets traffic only when P0 is unhealthy |
+| Stateful read-from-secondary | separate `...-secondary` `ROUND_ROBIN` cluster, selected **per-request** via `mssf-partition-role: secondary` (default `primary`) | see note below — this is *not* the priority mechanism |
 | Partitioned stateful (Int64/Named) | **same as the two rows above, applied to the selected partition's cluster** | partition is chosen by RDS first; see below |
 
 > **Partitioned routing = partition selection (RDS) + the ordinary
@@ -545,6 +570,44 @@ validates it against the `echomain` and `kvstore` samples.
 > Phase 3 adds only the RDS selection layer and reuses the
 > Phase 1/4 primary LB unchanged.
 
+> **Priority failover ≠ read-from-secondary.** These are two
+> distinct mechanisms, easy to conflate:
+>
+> - **Priority failover** (P0 = primary, P1 = secondaries in one
+>   priority-aggregated cluster) is a *failover* tier. Per xDS
+>   semantics, P1 receives **no** traffic while P0 is healthy above
+>   the over-provisioning threshold, so a healthy-primary request
+>   never reaches a secondary. This gives primary-with-failover, not
+>   load-spreading.
+> - **Read-from-secondary** deliberately sends healthy-path reads to
+>   secondaries. It is *not* expressed with priorities, and it is a
+>   **per-request** choice carried in the `mssf-partition-role`
+>   header (`primary` (default) / `secondary` / `any`), *not* a
+>   resource-name convention. RDS matches the role header **in
+>   addition to** the `mssf-partition-key` match, so partition
+>   selection is unchanged and orthogonal: for a **singleton
+>   (non-partitioned)** service the role match selects, within the
+>   one default route, the `...-primary`, `...-secondary`, or
+>   all-replicas (`any`) cluster; for a **partitioned** service each
+>   partition's `Route`s fan out by role to *that partition's*
+>   `...-primary` / `...-secondary` / all-replicas cluster (partition
+>   N's own replicas), never one flat secondary cluster. **When the
+>   header is absent or its value matches no role route, the request
+>   falls through to that partition's primary cluster** (the role
+>   routes are ordered ahead of a key-only primary fallback; see the
+>   RDS route ordering under [Partition key semantics](#partition-key-semantics))
+>   — the plain
+>   `xds:///fabric/App/Svc` target stays primary-only exactly as the
+>   old `-secondary` suffix guaranteed for free, so writes are never
+>   silently steered onto a secondary. A caller that wants a hard
+>   read-only channel installs a client-side metadata interceptor
+>   that stamps `mssf-partition-role: secondary` on every call (the
+>   per-channel replacement for a dedicated `-secondary` resource
+>   name); a caller that needs both roles simply sets the header
+>   per request. The correctness backstop is unchanged: the header is
+>   a routing *hint*, and SF still returns `NotPrimary` if a write
+>   lands on a secondary.
+
 ### Partition key semantics
 
 The `mssf-partition-key` header value is **not** an arbitrary
@@ -558,11 +621,26 @@ SF supports exactly three schemes
 | SF scheme | `mssf-partition-key` value | Route built by the agent |
 |---|---|---|
 | `Singleton` | *omitted* | one default `Route`; no matcher |
-| `Int64Range` | a **decimal `i64`** (e.g. `42`) | one `Range` matcher per partition from its `low_key`/`high_key` (inclusive SF `[low, high]` → half-open `[low, high+1)`) |
+| `Int64Range` | a **decimal `i64`** (e.g. `42`) | one `Range` matcher per partition from its `low_key`/`high_key` (inclusive SF `[low, high]` → half-open `[low, high+1)`; see the `i64::MAX` boundary rule below) |
 | `Named` | the **exact partition name** | one `String::Exact` matcher per partition name (case-sensitive) |
 
 Consequences and rules:
 
+- **`i64::MAX` boundary (top partition).** SF Int64 ranges are
+  inclusive, so the highest partition's `high_key` is
+  `9223372036854775807` (`i64::MAX`). The naive `[low, high+1)`
+  conversion overflows xDS's **signed** `Int64Range.end`, which
+  cannot represent `i64::MAX + 1`. The agent must special-case this:
+  emit the top partition as a `Range [low, i64::MAX)` **plus** a
+  string `exact_match` on the header value `"9223372036854775807"`
+  (the `i64::MAX` boundary), both pointing at the same top-partition
+  cluster. Do **not** substitute an open-ended default/catch-all
+  `Route` for this boundary: a catch-all would also match missing,
+  malformed, and otherwise unmatched partition-key headers and route
+  them to the top partition, contradicting the fail-closed rules
+  below. The mandatory exact string route matches only the boundary
+  value, preserving the promised full-`i64` key range without an
+  overflowed or wrapped `end`.
 - **No transform/hashing layer.** The client sends the *same* i64
   or name it would pass to
   [`resolve_service_partition(name, PartitionKeyType::Int64(k) | String(n))`](../../crates/libs/util/src/resolve.rs).
@@ -586,10 +664,63 @@ Consequences and rules:
   safe to assume for a partitioned stateful service. Either require
   the header (fail closed) or route to an explicit
   `-unpartitioned`/error cluster; do **not** pick partition 0.
+- **Replica role (`mssf-partition-role`) — a second, orthogonal
+  reserved header.** This header selects the *replica class* within
+  the already-selected partition, independent of `mssf-partition-key`.
+  Allowed values are `primary` (default), `secondary`, and `any`; the
+  agent emits, per partition, an extra `Route` header match that maps
+  `secondary` → the partition's `...-secondary` `ROUND_ROBIN` cluster
+  and `any` → a `ROUND_ROBIN` cluster spanning primary + secondaries,
+  with `primary` selecting the `...-primary` cluster. For a
+  **stateless** service `any` is the only meaningful value and maps to
+  the single instance cluster; `primary`/`secondary` collapse to that
+  same instance set. **Unlike `mssf-partition-key`, this header fails
+  *safe*, not closed:** when it is **absent or its value matches no
+  role route**, the request falls through to the partition's
+  **primary** cluster. This preserves the write-safety guarantee the
+  old `-secondary` resource name gave for free — the plain
+  `xds:///fabric/App/Svc` target is primary-only unless a caller opts
+  into secondary/any reads. The final correctness backstop is
+  unchanged: the header is a routing hint and SF returns `NotPrimary`
+  if a write reaches a secondary.
+- **RDS route ordering (how absent-⇒-primary is actually built).**
+  RDS routes are **first-match-wins**, and a single `Route` can match
+  the partition key **and** the role header together. The fail-*safe*
+  role default therefore depends entirely on ordering the role-specific
+  routes **before** the key-only primary fallback; a broad/primary
+  route placed ahead of them would shadow the role routes. The agent
+  emits, **for each partition** (key `K` = its `Range`/`String::Exact`
+  matcher), in this exact order:
+
+  1. `key == K` **and** `role == secondary` → K's `...-secondary`
+     cluster
+  2. `key == K` **and** `role == any` → K's all-replicas cluster
+  3. *(optional, explicit)* `key == K` **and** `role == primary` → K's
+     `...-primary` cluster
+  4. `key == K` (no role matcher) → K's `...-primary` cluster
+     — **fallback** for absent/unmatched role
+
+  Every one of these four still carries the `key == K` matcher, so the
+  **role fails safe while the key stays fail-closed**: a missing or
+  malformed partition key matches **none** of a partition's routes
+  (rejected per the malformed/missing-key rules above), and is never
+  routed to the primary of some arbitrary partition. For a **singleton
+  (non-partitioned)** service the same order applies without the key
+  matcher: `role == secondary`, then `role == any`, then optional
+  `role == primary`, then a **no-matcher primary fallback** last.
+
+  The `i64::MAX` boundary must be **duplicated the same way**: the four
+  routes above are emitted once with the top partition's
+  `Range [low, i64::MAX)` matcher **and** once with a
+  `String::Exact "9223372036854775807"` matcher, in the same
+  secondary → any → (primary) → key-only-primary order, so the boundary
+  value keeps both role selection and the fail-closed key behavior.
 - **Value encoding.** Header values are ASCII strings: Int64 keys
   are decimal (optionally negative, full `i64` range); Named keys
-  are the partition name verbatim. Reserve the `mssf-` prefix for
-  these SF routing headers.
+  are the partition name verbatim; `mssf-partition-role` is one of
+  `primary` / `secondary` / `any`. Reserve the `mssf-` prefix for
+  these SF routing headers (`mssf-partition-key` and
+  `mssf-partition-role`).
 
 This contract is validated in Phase 3 against the `KvStore`
 sample (Int64 partitioning); a Named-partition sample should be
@@ -896,11 +1027,18 @@ Four near-term caveats:
 - Validate that the chosen gRPC-xDS clients accept a minimal ADS
   source (some early versions require LRS, ALS, etc.).
 
-### Phase 1 — Minimal `mssf-xds-agent`, EDS only
+### Phase 1 — Minimal `mssf-xds-agent`, complete LDS→RDS→CDS→EDS chain
 
 - Crate: `crates/tools/mssf-xds-agent` (a new binary).
-- Speaks ADS, serves only `Listener` (stub) + `Cluster` (one
-  per URI, fixed `ROUND_ROBIN`) + `EDS` (from SF naming).
+- Speaks ADS, serving the full minimal chain a gRPC `xds:///`
+  channel needs to come up: a `Listener` carrying an
+  `ApiListener`/`HttpConnectionManager`, a trivial single-vhost
+  `RouteConfiguration` (its `domains` match the target, one
+  default route → the cluster), one fixed `ROUND_ROBIN` `Cluster`
+  per URI, and `EDS` (from SF naming). No partition or priority
+  logic yet — that is the Phase 1 economy, not omitting resource
+  types (a stub Listener with no HCM/route never lets the channel
+  resolve, so nothing would be testable "EDS-only").
 - One `FabricClient` shared across all URIs.
 - Selector logic (which endpoints to include, role filter) is
   keyed off the resource name (the `target`), since query params
@@ -946,15 +1084,38 @@ Four near-term caveats:
   (exact Int64-range / named-key match, **not** hashing).
 - Within each partition's cluster, reuse the Phase 1 primary LB
   unchanged — partition routing adds no new LB policy.
-- Validate against `KvStore` sample (Int64 partitioning).
+- Validate against `KvStore` sample (Int64 partitioning), including
+  the `i64::MAX` top-partition boundary (confirm the highest
+  partition's `high_key` does not overflow `Int64Range.end`).
 
-### Phase 4 — Priority routing (primary + secondaries)
+### Phase 4 — Priority failover + read-from-secondary
 
-- Aggregate primary + secondaries into one cluster with
-  priorities. Default route → P0 (primary). Read-only route
-  (header gated) → P0/P1.
-- Maps directly to "read-from-secondary" without server-side
-  changes.
+- **Primary failover:** aggregate primary + secondaries into one
+  cluster with priorities (P0 = primary, P1 = secondaries).
+  Default route → this cluster; xDS shifts traffic to P1 only when
+  P0 goes unhealthy. This is failover, *not* load-spreading.
+- **Read-from-secondary:** for read-only workloads, the client sets
+  the `mssf-partition-role` header per request (`primary` (default) /
+  `secondary` / `any`). RDS matches this header **in addition to**
+  `mssf-partition-key`, so partition selection is unchanged. For a
+  **singleton** service the role match selects, within the one default
+  route, the `...-primary`, `...-secondary` `ROUND_ROBIN`, or
+  all-replicas (`any`) cluster. For a **partitioned** service each
+  partition's `Route`s fan out by role to *that partition's*
+  `...-primary` / `...-secondary` / all-replicas cluster rather than
+  one flat secondary cluster. Steering reads onto secondaries is a
+  *per-request header* choice, not a priority level (a healthy-primary
+  priority cluster would never send reads to P1). **When the header is
+  absent or unmatched the request falls through to primary**, so
+  write-safety is preserved by default (the role routes are emitted
+  ahead of a key-only primary fallback per the [RDS route
+  ordering](#partition-key-semantics), so a broad primary route cannot
+  shadow them and a missing/malformed key still fails closed); a caller
+  wanting a hard read-only channel stamps `mssf-partition-role:
+  secondary` via a client-side metadata interceptor (the replacement
+  for the old `-secondary` resource name).
+- Both are achieved with no server-side changes; the server still
+  returns `NotPrimary` if a write lands on a secondary.
 
 ### Phase 5 — Optional ORCA + LRS
 
@@ -1013,10 +1174,18 @@ receive xDS snapshots and re-serve them locally.
 
 ## Security
 
-- Local-only by default (loopback TCP or UDS). Cross-node xDS
-  traffic is **not** a goal; every node has its own agent. A UDS
-  listener additionally restricts access by filesystem
-  permissions.
+- Single-tier: local-only (loopback TCP or UDS). Cross-node xDS
+  traffic is **not** a goal in this form — every node has its own
+  agent, and a UDS listener additionally restricts access by
+  filesystem permissions.
+- Two-tier: the discovery→relay snapshot channel **is**
+  cross-node xDS traffic, and it carries the whole cluster's
+  LDS/RDS/CDS/EDS topology. It is trust-scoped to the cluster's
+  internal network (the same boundary SF's own inter-node traffic
+  uses) and reaches only the SF-deployed relay instances. The
+  client-facing hop on each node stays loopback/UDS as above.
+  Hardening this channel with mTLS/SDS is deferred (see below);
+  until then it relies on the cluster-internal network boundary.
 - The agent runs as a service account with FabricClient
   credentials. Standard SF security boundaries apply. In the
   two-tier form only the control tier holds those credentials; the

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -44,6 +44,49 @@ path is fine and this proposal is optional.
 Phase 0 still validates the chosen client(s) against a minimal ADS
 source before building anything.
 
+## Central design principle
+
+> **This is THE principle the rest of this proposal derives from.**
+> The xDS agent — and the sibling
+> [HTTP reverse proxy](./HttpReverseProxy.md) — are **thin
+> discovery/routing components, not smart middleboxes that add
+> correctness logic.** Two facets:
+>
+> 1. **Thin layer (naming-only).** The layer exposes **only what SF
+>    Naming natively provides** — primary/secondary/any replica
+>    resolution, partition resolution, and notification-driven
+>    failover. It does **not** invent or synthesize capabilities Naming
+>    lacks: no priority-failover/fallback aggregation, no
+>    persisted-snapshot durable recovery. When a client wants behavior
+>    the layer doesn't provide, the **client adapts** (retry with a
+>    different `mssf-partition-role`, retry on `Unavailable`) rather
+>    than the layer manufacturing it.
+> 2. **Fat replica.** Each service replica owns its own correctness and
+>    behavior — write-safety (a secondary returns `NotPrimary`),
+>    terminating its own connection/stream when it stops being primary
+>    (the proxy stays passive on failover), handling role changes, and
+>    honoring idempotency. This is **already** how SF services are
+>    written; the design leans on it deliberately.
+
+The concrete design decisions below all follow from this principle:
+
+- Role set = exactly what Naming resolves
+  (`primary`/`secondary`/`any`); no invented `failover` aggregation — a
+  client wanting fallback retries with a different role.
+  ([Partition key semantics](#partition-key-semantics))
+- Absent/unmatched role ⇒ primary (fail-safe); the replica still
+  enforces write-safety via `NotPrimary`.
+  ([Partition key semantics](#partition-key-semantics))
+- Failover = naming-driven EDS re-push; not an xDS priority construct.
+  ([Failover signal](#failover-signal))
+- Control-plane-driven health only; the server never self-reports into
+  EDS. ([Server-side ORCA reports](#server-side-orca-reports-optional-for-richer-signals))
+- Singleton / discovery-tier restart handled like any SF service
+  restart (re-resolve from Naming); no bespoke durable recovery.
+  ([Freshness: PUSH + PULL](#freshness-push--pull-like-sf-yarp))
+- Reverse proxy is passive on failover; the backend replica terminates
+  its own stream. ([HTTP reverse proxy](./HttpReverseProxy.md#the-proxy))
+
 ## Background
 
 Service Fabric (SF) services are addressed by Fabric URIs
@@ -366,6 +409,18 @@ policy already proposed for the agent moves into the control tier
 unchanged; the relays simply mirror whatever snapshot they last
 received.
 
+A discovery-tier restart is handled like any other SF service
+restart: SF Naming is the source of truth, so on restart the control
+tier re-resolves and rebuilds its snapshot from Naming. Consumers
+(relays or direct clients) treat the momentary unavailability exactly
+as they treat any SF Naming resolution — they retry until resolution
+succeeds; existing consumers keep serving their already-received
+snapshot during the gap, and new consumers simply retry until the tier
+is back. No bespoke durable/persisted recovery mechanism is needed
+(and none would be a Naming feature) — per the
+[central design principle](#central-design-principle), the layer offers
+only what Naming provides.
+
 ### Tradeoffs and when to choose it
 
 | | Single-tier (per-node agent) | Two-tier (central discovery) |
@@ -507,9 +562,12 @@ during that window:
 
 The agent should **not** tear down the ADS resource entirely on a
 transient empty result — that would force clients to re-subscribe
-and lose the fast reconnect path. Phase 1 implements
-hold-last-known-good + staleness timeout; the confirmed-removal
-push lands with notifications in Phase 2.
+and lose the fast reconnect path. Hold-last-known-good is a bounded
+*serve-until-stale* reflection of Naming's transient state, **not**
+persisted/durable recovery (the
+[central design principle](#central-design-principle)). Phase 1
+implements it + staleness timeout; the confirmed-removal push lands
+with notifications in Phase 2.
 
 ### Endpoint address parsing
 

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -2,7 +2,7 @@
 
 Status: Proposal / experiment. Nothing shipped.
 
-Date: 2026-06-04 (last updated 2026-07-16)
+Date: 2026-06-04 (last updated 2026-07-20)
 
 Owners: mssf maintainers
 
@@ -464,8 +464,8 @@ Examples:
 | URI | Meaning |
 |---|---|
 | `xds:///fabric/MyApp/Greeter` | resolve the service; default LB. Partition (if any) selected per-request via the `mssf-partition-key` header. |
-| `xds:///fabric/MyApp/Kv` | partitioned `KvStore` (Int64); the client sets `mssf-partition-key: 42` (a decimal i64) per call and RDS routes it to the partition whose range covers 42. See [Partition key semantics](#partition-key-semantics). |
-| `xds:///fabric/MyApp/Kv` + `mssf-partition-role: secondary` | same plain target, **read-from-secondary**; RDS matches both headers and routes the request to the selected partition's `...-secondary` `ROUND_ROBIN` cluster. `any` targets all replicas of the partition; **absent/unmatched ⇒ primary** (write-safe default). A client wanting a hard read-only channel stamps this header on every call via a metadata interceptor. See [LB policy mapping](#lb-policy-mapping). |
+| `xds:///fabric/MyApp/KvStore` | partitioned `KvStore` (Int64); the client sets `mssf-partition-key: 42` (a decimal i64) per call and RDS routes it to the partition whose range covers 42. See [Partition key semantics](#partition-key-semantics). |
+| `xds:///fabric/MyApp/KvStore` + `mssf-partition-role: secondary` | same plain target, **read-from-secondary**; RDS matches both headers and routes the request to the selected partition's `...-secondary` `ROUND_ROBIN` cluster. `any` targets all replicas of the partition; **absent/unmatched ⇒ primary** (write-safe default). A client wanting a hard read-only channel stamps this header on every call via a metadata interceptor. See [LB policy mapping](#lb-policy-mapping). |
 
 ### Mapping table
 
@@ -593,19 +593,16 @@ validates it against the `echomain` and `kvstore` samples.
 >   `...-primary` / `...-secondary` / all-replicas cluster (partition
 >   N's own replicas), never one flat secondary cluster. **When the
 >   header is absent or its value matches no role route, the request
->   falls through to that partition's primary cluster** (the role
->   routes are ordered ahead of a key-only primary fallback; see the
->   RDS route ordering under [Partition key semantics](#partition-key-semantics))
->   — the plain
->   `xds:///fabric/App/Svc` target stays primary-only exactly as the
->   old `-secondary` suffix guaranteed for free, so writes are never
->   silently steered onto a secondary. A caller that wants a hard
->   read-only channel installs a client-side metadata interceptor
->   that stamps `mssf-partition-role: secondary` on every call (the
->   per-channel replacement for a dedicated `-secondary` resource
->   name); a caller that needs both roles simply sets the header
->   per request. The correctness backstop is unchanged: the header is
->   a routing *hint*, and SF still returns `NotPrimary` if a write
+>   falls through to that partition's primary cluster** — the role routes
+>   are emitted ahead of a key-only primary fallback (see the RDS route
+>   ordering under [Partition key semantics](#partition-key-semantics)), so
+>   the plain `xds:///fabric/App/Svc` target stays primary-only just as the
+>   old `-secondary` suffix did for free, and writes are never silently
+>   steered onto a secondary. A caller wanting a hard read-only channel
+>   stamps `mssf-partition-role: secondary` on every call via a client-side
+>   metadata interceptor (the per-channel replacement for a dedicated
+>   `-secondary` resource name). The correctness backstop is unchanged: the
+>   header is a routing *hint*, and SF still returns `NotPrimary` if a write
 >   lands on a secondary.
 
 ### Partition key semantics

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -760,11 +760,11 @@ Consequences and rules:
   matcher), in this exact order:
 
   1. `key == K` **and** `role == secondary` → K's `...-secondary`
-     cluster
-  2. `key == K` **and** `role == any` → K's all-replicas cluster
+     cluster (`{S1, S2, …}`)
+  2. `key == K` **and** `role == any` → K's all-replicas cluster (`{P, S1, S2, …}`)
   3. *(optional, explicit)* `key == K` **and** `role == primary` → K's
-     `...-primary` cluster
-  4. `key == K` (no role matcher) → K's `...-primary` cluster
+     `...-primary` cluster (`{P}`)
+  4. `key == K` (no role matcher) → K's `...-primary` cluster (`{P}`)
      — **fallback** for absent/unmatched role
 
   Every one of these four still carries the `key == K` matcher, so the

--- a/docs/proposal/GrpcXds.md
+++ b/docs/proposal/GrpcXds.md
@@ -718,6 +718,20 @@ Consequences and rules:
   `primary` / `secondary` / `any`. Reserve the `mssf-` prefix for
   these SF routing headers (`mssf-partition-key` and
   `mssf-partition-role`).
+- **Not an authorization boundary (untrusted addressing primitive).**
+  `mssf-partition-key` (and `mssf-partition-role`) are **caller-supplied
+  routing hints**, validated only for *well-formedness*, never for
+  *entitlement*: the caller picks which partition it addresses, and the
+  routing layer faithfully delivers to it. Under a partition-per-tenant
+  layout this is a cross-tenant addressing (IDOR) risk — changing the
+  key value reads/writes another tenant's partition if the backend
+  assumes the routing layer already scoped the request. The routing
+  layer does **not** scope it. In multi-tenant contexts,
+  **partition/authority-level authorization is required** — enforced by
+  the backend on every request and/or by the ADS authorization posture
+  (see [Security](#security)) that scopes which authorities/partitions a
+  given identity may address at all. Add a conformance test that
+  caller-A carrying tenant-B's key is rejected by the backend.
 
 This contract is validated in Phase 3 against the `KvStore`
 sample (Int64 partitioning); a Named-partition sample should be
@@ -1177,18 +1191,64 @@ receive xDS snapshots and re-serve them locally.
   filesystem permissions.
 - Two-tier: the discovery→relay snapshot channel **is**
   cross-node xDS traffic, and it carries the whole cluster's
-  LDS/RDS/CDS/EDS topology. It is trust-scoped to the cluster's
-  internal network (the same boundary SF's own inter-node traffic
-  uses) and reaches only the SF-deployed relay instances. The
-  client-facing hop on each node stays loopback/UDS as above.
-  Hardening this channel with mTLS/SDS is deferred (see below);
-  until then it relies on the cluster-internal network boundary.
+  LDS/RDS/CDS/EDS topology. It reaches only the SF-deployed relay
+  instances and the client-facing hop on each node stays loopback/UDS.
+- **Discovery→relay channel authentication (security gate, not an
+  open-ended deferral).** The relay holds no `FabricClient` and
+  re-serves **verbatim** whatever snapshot arrives, so an
+  unauthenticated channel is a **config-poisoning** surface: a
+  same-network adversary that claims the discovery address (especially
+  during a singleton-restart race) could push a poisoned EDS snapshot
+  and redirect client RPCs — **including writes** — to attacker
+  endpoints. A network boundary alone is a single point of failure,
+  not defense-in-depth. The gate before the two-tier form is exposed
+  beyond a single-tenant, fully-trusted internal network is:
+  1. **First verify** whether SF's inter-node transport already
+     provides **mutual authentication** for this channel. The docs
+     currently claim only network *scoping*, not mutual auth — this
+     must be confirmed, not assumed.
+  2. **If it does not**, require **control-tier-identity-pinned mTLS**
+     on the discovery→relay channel (the relay pins the control tier's
+     identity and rejects any other snapshot source) **before** the
+     two-tier form is exposed publicly or multi-tenant. This is the
+     recommended resolution of the ship-now-vs-mTLS-first timing
+     trade-off; network-boundary trust is acceptable **only** for a
+     fully-trusted single-tenant internal
+     deployment with the residual risk explicitly signed off.
+- **ADS authorization (which resources, not just who).** Authenticating
+  the caller is **not sufficient**: the discovery tier owns a
+  cluster-wide `fabric:` catch-all, so a single authenticated principal
+  (or one leaked credential) could otherwise enumerate **every**
+  service/partition/endpoint — full-topology reconnaissance as the
+  blast radius of one credential. Two supported postures, stated
+  explicitly:
+  - **Trusted-first-party posture (default for this proposal).** The
+    ADS frontend is served **only** to fully-trusted first-party
+    consumers (per-node relays, the SF-deployed proxy fleet) that are
+    already entitled to the whole topology. No per-identity scoping is
+    required *because no untrusted identity is admitted.*
+  - **Scoped posture (required before any untrusted/multi-tenant
+    exposure).** Add a **per-identity authorization layer** that scopes
+    the served snapshot (per-authority / per-app), so differently-scoped
+    credentials receive **strictly different** resource sets. A public
+    or multi-tenant ADS frontend **must not** ship on authN alone.
+    This also backstops the `mssf-partition-key`
+    [cross-tenant addressing risk](#partition-key-semantics).
 - The agent runs as a service account with FabricClient
   credentials. Standard SF security boundaries apply. In the
   two-tier form only the control tier holds those credentials; the
   per-node relay has no naming access.
-- xDS-level mTLS / RBAC is deferred (Future work). Until then,
-  xDS data is host-trust scoped.
+- **Separate trust anchor for external clients.** Any credential
+  provisioned to an off-node / external ADS client (see the SLB
+  proposal's off-node bootstrap) **must not** chain to the cluster
+  management CA and **must not** be valid for SF management or node
+  transport. Reusing cluster certs / distributing the cluster CA to
+  external clients merges a low-trust topology reader into the cluster
+  administration trust domain. Issue external ADS/proxy clients from a
+  **dedicated, narrowly-scoped trust anchor**, not the cluster CA.
+- xDS-level mTLS / RBAC hardening beyond the gates above is tracked in
+  Future work (SDS-distributed certs); until then, single-tier xDS
+  data stays host-trust scoped.
 
 ## Open questions
 

--- a/docs/proposal/GrpcXdsSlb.md
+++ b/docs/proposal/GrpcXdsSlb.md
@@ -221,6 +221,26 @@ directly and the SLB forwards at L4 to a healthy backend. The data
 path is the **raw SLB SDN path — no application proxy hop** — so it
 is as fast as any Azure L4 traffic.
 
+**Advertisement-time eligibility (structural, not just a role
+constraint).** A flat `@slb` VIP is **topology-blind**: it hashes a
+5-tuple to *some* healthy backend with no notion of which partition
+that backend owns. For a **partitioned** service this is not merely a
+relaxed role — it is *incorrect*: a `key=K` request can hash to a node
+that hosts a **different** partition, silently violating partition
+ownership. Restricting the path to `mssf-partition-role: any` (below)
+does **not** fix this, because `any` still means "any replica **of the
+owning partition**," which a flat VIP cannot guarantee. Therefore
+Scenario C is **structurally available only** for services where
+**every backend serves every key** — i.e. **`Singleton`** or
+**stateless** services. The control tier **must reject** partitioned
+(`Int64Range` / `Named`) targets from Scenario C advertisement
+entirely (do not emit an `@slb` VIP endpoint for them, regardless of
+role); such services must take a topology-aware path — Scenario A,
+Scenario C2 (per-instance NAT), or the
+[reverse proxy](./HttpReverseProxy.md). (Add an integration test that
+hashes a key-K request to a non-owning node and asserts the
+partitioned service was never advertised on the flat VIP.)
+
 The xDS server's job here is a **translation**: instead of
 advertising the service's private node endpoints (unreachable off
 VNet), it advertises the **SLB frontend** as the endpoint. Concretely
@@ -288,17 +308,23 @@ Properties:
   removes unhealthy nodes), **not** xDS: the only EDS endpoint is the
   VIP, so xDS would drop it only if the *entire* VIP/service is gone,
   not per replica.
-- **Scope:** stateless services, or "any active replica is fine"
-  reads — i.e. **only** the base proposal's `mssf-partition-role:
-  any`. Because the VIP is topology-blind, the Scenario C RDS resource
-  must **require an explicit `mssf-partition-role: any` match and fail
-  closed** for absent / `primary` / `secondary`: it must **not** reuse
-  the base proposal's absent-⇒-primary fallback, since a
-  default-primary request served by the flat VIP would land on an
-  arbitrary replica (often a secondary), violating the base proposal's
-  write-safety guarantee. Callers needing primary/secondary (including
-  the absent-⇒-primary default) must take a topology-aware path —
-  Scenario A (in-VNet direct), Scenario C2 (per-instance NAT), or the
+- **Scope:** **`Singleton`/stateless services only** (every backend
+  serves every key — see the advertisement-time eligibility rule
+  above; partitioned targets are **rejected** from this path, not
+  merely constrained). Within that eligible set, the path serves "any
+  active replica is fine" reads — i.e. **only** the base proposal's
+  `mssf-partition-role: any`. Because the VIP is topology-blind, the
+  Scenario C RDS resource must **require an explicit
+  `mssf-partition-role: any` match and fail closed** for absent /
+  `primary` / `secondary`: it must **not** reuse the base proposal's
+  absent-⇒-primary fallback, since a default-primary request served by
+  the flat VIP would land on an arbitrary replica, violating the base
+  proposal's write-safety guarantee. This is the per-resource
+  fail-closed variant of the base
+  [`mssf-partition-role` semantics](./GrpcXds.md#partition-key-semantics).
+  Callers needing primary/secondary (including the absent-⇒-primary
+  default) must take a topology-aware path — Scenario A (in-VNet
+  direct), Scenario C2 (per-instance NAT), or the
   [reverse proxy](./HttpReverseProxy.md).
 - **Dual advertisement:** the same service can be advertised two
   ways from one snapshot — node-IP endpoints for in-VNet Scenario A
@@ -371,13 +397,31 @@ The client dials `VIP:<Fport_A>`; the SLB NATs it to the exact
 instance holding the primary. One L4 hop, no proxy, **and**
 primary-correct.
 
+**Where the Azure-specific translation lives (layering, honest).**
+Steps 1–2 above require knowledge the base SF-generic tier was defined
+**without**: an IMDS/ARM-sourced `node → VMSS-instance → NAT-port`
+(and `→ VIP`) table, re-derived on scale events. To keep the base
+proposal's "reuse the SF-generic core unchanged" claim (Goal 4) honest,
+that Azure knowledge is **not** folded into the SF-generic snapshot
+logic. It lives in a **decorating `mssf-slb-mapper` layer** that sits
+**above** the SF-generic control tier: the base tier still produces the
+ordinary SF→xDS snapshot (replica → node endpoint), and the mapper
+**post-processes** it for `@slb`-advertised services, rewriting node
+endpoints into `VIP:<NAT-port>` (C2) or `VIP:<frontendPort>` (C)
+endpoints using the Azure table. The upward dependency on
+Azure/IMDS/ARM is thus **isolated in the mapper**, not pushed into the
+SF-generic translation — this is what "reuse as an unchanged core +
+decorate" means, and it is the honest reading of the C/C2 data flow.
+
 **Supported roles (C2 is topology-aware).** Unlike the flat Scenario C
 VIP, the per-instance-NAT path resolves the specific replica behind
 each frontend port, so it **can honor the full base-proposal role
 contract** — `primary` (and the absent-⇒-primary default), `secondary`,
 and `any` — exactly like Scenario A direct: the control tier advertises
-the NAT port of the primary instance for `primary`, a secondary
-instance's NAT port for `secondary`, etc. C2 therefore does **not** need
+the NAT port of the primary instance for `primary` (`{P}`), a secondary
+instance's NAT port for `secondary` (`{S1, S2, …}`), and all instances for
+`any` (`{P, S1, S2, …}`) — using the base proposal's `P`/`S1, S2, …`
+replica-role notation. C2 therefore does **not** need
 Scenario C's fail-closed `any`-only restriction.
 
 ```mermaid
@@ -584,7 +628,10 @@ the SLB. Design points:
   ships a static bootstrap file plus the CA** to each off-node client
   (the same way any public gRPC client is provisioned); the cluster
   cannot self-serve this over the very channel it is trying to
-  establish. This is a prerequisite for every public (C/C2) path.
+  establish. This is a prerequisite for every public (C/C2) path. The
+  trust anchor and client cert shipped here **must** come from the
+  dedicated external-client PKI, **not** the cluster management CA (see
+  [Security](#security)).
 
 ## Azure SLB configuration required
 
@@ -633,8 +680,27 @@ traffic crosses the SLB:
   only authorized clients/proxies can pull topology. A **weaker,
   server-only-TLS policy is acceptable only for a clearly scoped
   private / trusted-network deployment** (VNet-internal frontend, no
-  off-VNet exposure). Cluster certs already exist on nodes; reuse them
-  or issue a dedicated xDS cert.
+  off-VNet exposure).
+  - **AuthN is not authZ-of-resources.** Authenticating the caller
+    does **not** authorize *which* resources it may pull. The base
+    proposal's ADS
+    [authorization posture](./GrpcXds.md#security) applies here: the
+    default posture serves the ADS frontend **only** to fully-trusted
+    first-party proxies already entitled to the whole topology; any
+    **untrusted / multi-tenant** public frontend **must** add a
+    **per-identity authorization layer** that scopes the served
+    snapshot (per-authority / per-app) so one credential cannot
+    enumerate the entire cluster. State which posture a given
+    deployment adopts.
+  - **Separate trust anchor for external clients.** Cluster certs
+    already exist on nodes, but external ADS clients **must not** be
+    provisioned a credential that chains to the **cluster management
+    CA** or is valid for SF management (19000/19080) or node
+    transport — that would merge a low-trust topology reader into the
+    cluster-administration trust domain. Issue external ADS/proxy
+    clients from a **dedicated, narrowly-scoped external-client PKI**
+    whose issuing CA is **not** the cluster CA. (This is a requirement,
+    not an option.)
   - **Defense-in-depth beyond authn.** Auth answers "who," not "how
     much": a public ADS frontend is still a topology-enumerating,
     handshake-consuming target. Where the client population is known,

--- a/docs/proposal/GrpcXdsSlb.md
+++ b/docs/proposal/GrpcXdsSlb.md
@@ -162,12 +162,19 @@ This proposal therefore splits on **client network position** and
    NAT, outbound, idle timeout) needed for the xDS control stream
    and the data path to survive an SLB.
 4. Reuse the base proposal's SF→xDS translation and two-tier
-   discovery **unchanged**; add only what the SLB boundary forces.
+   discovery **as an unchanged core**, and add the Azure/SLB-specific
+   translation as a **decorating layer above** it — not by editing the
+   SF-generic tier in place. See the SF-generic-vs-Azure-specific
+   boundary note under [Scenario C2](#scenario-c2--primary-aware-direct-via-slb-per-instance-nat).
 
 ## Non-Goals
 
 - Changing the SF→xDS mapping, URI/header strategy, or failover
-  model from the base proposal. Those are inherited verbatim.
+  model from the base proposal. The **SF-generic core** (partition
+  matching, role semantics, notification-driven failover) is inherited
+  verbatim; the Azure/SLB specifics (VIP/NAT translation) are added as
+  a **separate decorating layer**, not by rewriting that core (see the
+  boundary note under [Scenario C2](#scenario-c2--primary-aware-direct-via-slb-per-instance-nat)).
 - Making the Azure SLB itself partition-aware. It stays a flat L4
   balancer; any topology awareness lives in cluster-side software.
 - A public multi-tenant gateway product. This is SF-cluster-scoped.
@@ -496,6 +503,20 @@ Two consequences to plan for:
   (RPC error / `NotPrimary` + forced re-resolve or control-plane EDS
   update): the client must not treat the old mapping as valid once the
   primary relocates.
+- **Fail-closed publication barrier for a concurrently changing
+  mapping.** The advertised endpoint is a **join across two
+  eventually-consistent control planes** (SF membership and the
+  Azure/VMSS→NAT table). The control tier **must not** advertise an
+  endpoint built from a **mismatched-generation** join. While the
+  `SF-node → VMSS-instance → NAT-port` mapping is mid-change (VMSS
+  scale-in / reimage / NAT reassignment), the affected role/partition's
+  EDS must **fail closed** — served **empty / `Unavailable`** — until
+  the control tier holds a **verified, same-generation** membership +
+  mapping pair. A change on **either** source invalidates the cached
+  mapping for the affected instances. A stale or ambiguous mapping is
+  never published: better a brief, explicit unavailability than
+  silently NATing a client to a dead or unintended instance. Simulate
+  all orderings of failover / scale-in / NAT removal / restart.
 
 **Constraints (be honest):**
 

--- a/docs/proposal/GrpcXdsSlb.md
+++ b/docs/proposal/GrpcXdsSlb.md
@@ -9,6 +9,17 @@ Owners: mssf maintainers
 Extends: [gRPC xDS over Service Fabric Naming](./GrpcXds.md)
 (the base proposal — also a proposal/experiment, nothing shipped).
 
+This proposal **inherits the base proposal's
+[central design principle](./GrpcXds.md#central-design-principle)**:
+the xDS layer is a thin, naming-only discovery/routing component and
+each replica is "fat" (owns its own write-safety and role changes).
+Locally that means the SLB paths expose **only naming-provided
+selection** — `@slb` honors only `role=any` (a flat VIP cannot pick a
+specific replica), while the topology-aware paths (Scenario A/C2) honor
+the full naming-provided role set — and add no correctness logic of
+their own; the backend replica still returns `NotPrimary` on a
+misrouted write.
+
 ## Why pursue this?
 
 The [base proposal](./GrpcXds.md) gives node-local gRPC clients a
@@ -459,9 +470,11 @@ proposal**: re-resolve + EDS push + client reconnect, plus the
 in-flight-to-old-primary window. As in the base doc, the stale
 server on instance A merely returns `NotPrimary`; it does **not**
 mark its own endpoint unhealthy. Only the notification-driven
-control tier re-resolves and pushes the replacement endpoint (or an
-unhealthy/draining EDS state), so gRPC drains to the new one without
-dropping the connection abruptly. A client that observes the failure
+control tier re-resolves and pushes the replacement endpoint
+(optionally reflecting the old one as `DRAINING` when SF gives
+advance notice — a passive routing signal; in-flight completion is
+the replica's call), so gRPC stops picking the old endpoint for new
+RPCs and the client reconnects to the new one. A client that observes the failure
 first may trigger the separately documented forced-re-resolve fast
 path. "No Azure changes" refers only to the NAT rules — the client
 still experiences a normal xDS reconnect, not a zero-cost switch.

--- a/docs/proposal/GrpcXdsSlb.md
+++ b/docs/proposal/GrpcXdsSlb.md
@@ -7,7 +7,7 @@ Date: 2026-07-16
 Owners: mssf maintainers
 
 Extends: [gRPC xDS over Service Fabric Naming](./GrpcXds.md)
-(the "base proposal", accepted).
+(the base proposal — also a proposal/experiment, nothing shipped).
 
 ## Why pursue this?
 
@@ -74,7 +74,11 @@ Grounded in Azure docs
   IPs**. They are routable only from inside the VNet or across
   VNet peering / VPN / ExpressRoute. Secondary node types can
   optionally get **per-instance public IPs**
-  (`enableNodePublicIP`); primary node types cannot.
+  (`enableNodePublicIP`); at the time of writing (2026-07) Azure
+  managed-cluster docs restrict this to **secondary** node types
+  (primary node types cannot). This has changed over time — verify
+  against current managed-cluster networking docs before relying on
+  it as an absolute.
 - **Managed vs. classic; BYOLB.** Managed clusters auto-create a
   Standard public LB + FQDN per node type and reserve NSG priority
   ranges. **Bring-your-own-LB** (Standard SKU) is supported for
@@ -84,9 +88,10 @@ Grounded in Azure docs
   - **Outbound rule required** — Standard SLB is "secure by
     default"; each node type needs an outbound rule (port 443 for
     cluster setup) or deployment fails.
-  - **Idle timeout** — default ~4–5 min. **Long-lived gRPC / ADS
-    streams are silently dropped** if idle past the timeout unless
-    TCP keepalive / HTTP/2 pings keep them warm.
+  - **Idle timeout** — default **4 minutes** (configurable up to
+    30). **Long-lived gRPC / ADS streams are silently dropped** if
+    idle past the timeout unless TCP keepalive / HTTP/2 pings keep
+    them warm.
   - **Session persistence** — default distribution is a 5-tuple
     hash (a given TCP flow is pinned to one backend for its life);
     optional 2-/3-tuple source-IP affinity.
@@ -171,6 +176,11 @@ This proposal therefore splits on **client network position** and
 
 ## Reachability scenarios
 
+> **Note on numbering:** there is no Scenario B below. The former
+> Scenario B (in-cluster reverse proxy) moved to its own
+> [reverse-proxy proposal](./HttpReverseProxy.md); the labels A, C,
+> and C2 are kept stable to avoid churn in cross-references.
+
 ### Scenario A — client is in-VNet / peered / VPN / ExpressRoute
 
 Node private IPs are routable from the client. Then:
@@ -183,8 +193,15 @@ Node private IPs are routable from the client. Then:
   options:
   - **Node-local not available (off-node, in-VNet):** point the
     client at the **two-tier control tier** (`mssf-xds-discovery`)
-    via its VNet address, or at a small set of relays exposed on a
-    VNet-internal LB rule. See
+    via its VNet address (exposed through a VNet-internal LB rule).
+    In the base design the relays re-serve only over loopback/UDS to
+    on-node clients and hold no FabricClient, so **exposing a relay
+    fleet to off-node clients over the network is a new capability
+    this proposal would add** (relays would need a network-facing,
+    TLS ADS listener) — not something the base design already
+    supports. Prefer routing off-node clients to the discovery tier;
+    treat a network-exposed relay/edge fleet as an explicit,
+    opt-in addition. See
     [Control-plane reach through the SLB](#control-plane-reach-through-the-slb).
   - **Client on a node:** identical to the base proposal
     (loopback/UDS local agent).
@@ -209,9 +226,36 @@ advertising the service's private node endpoints (unreachable off
 VNet), it advertises the **SLB frontend** as the endpoint. Concretely
 the control tier, for a service that has an SLB mapping, emits a
 `Cluster` whose EDS holds a single `LbEndpoint = VIP:<frontendPort>`.
-The client's `tonic-xds` channel dials that; the SLB spreads across
-the backend pool; the SLB's health probe on `<servicePort>` prunes
-nodes that are not running the service.
+The client's `tonic-xds` channel dials that; the SLB's health probe
+on `<servicePort>` prunes nodes that are not running the service.
+
+**Which VIP? (multi-node-type clusters.)** As the Background notes, a
+cluster can have several node types, each its **own VMSS behind its
+own LB/VIP**. The `VIP` in the translation is therefore **not
+global** — it is the VIP of the node type(s) actually running the
+service. In practice the service must be **pinned to one node type**
+(SF placement constraints) so a single `VIP:<frontendPort>` is
+well-defined; if it spans multiple node types, the control tier emits
+one `LbEndpoint` **per fronting node type's VIP** (the client then
+gets whichever backend any VIP hashes to — still an "any-healthy"
+path). Either way the mapping the control tier holds is
+**per-(service, node type)**, not a single cluster-wide VIP.
+
+**How load actually spreads (important).** The SLB is a *per-flow*
+(5-tuple) balancer, and a typical gRPC client multiplexes **all**
+RPCs for a target over **one long-lived HTTP/2 connection**. That
+single TCP flow is hashed to **one** backend and pinned there for
+its entire life, so — for a single-channel client — **effectively no
+spreading happens**: all traffic lands on one backend until the
+connection is torn down. Spreading across the pool only comes from
+having **multiple connections**, e.g. multiple client channels /
+subchannels, `GRPC_ARG` connection settings that open more than one
+transport, client-side connection cycling, or a server
+`MAX_CONNECTION_AGE` that periodically forces reconnects (each new
+flow re-hashes to a possibly different backend). Scenario C is
+therefore an **any-healthy-backend** path — correctness does not
+depend on even distribution — not a fine-grained load spreader for a
+single channel.
 
 ```mermaid
 flowchart LR
@@ -226,8 +270,8 @@ flowchart LR
     end
     Disc -.->|"EDS: endpoint = VIP:Fport"| Ext
     Ext -->|"gRPC to VIP:Fport"| SLB
-    SLB -->|"5-tuple spread"| S1
-    SLB --> S2
+    SLB -->|"per-flow (5-tuple) pin"| S1
+    SLB -.->|"only with extra connections"| S2
 ```
 
 Properties:
@@ -235,22 +279,48 @@ Properties:
 - **Fast:** no proxy tier, no in-cluster hop; just the SLB. This is
   the whole point versus the [reverse proxy](./HttpReverseProxy.md).
 - **xDS still earns its keep:** service discovery (which services
-  exist and their `VIP:port`), health-driven removal, LB-policy /
-  service-config push, and RDS selection **across** multiple
-  SLB-fronted services. What it does **not** do is pick a replica
-  *within* a service — the SLB is topology-blind, so
-  `mssf-partition-key` / primary selection has no effect on this
-  path.
+  exist and their `VIP:port`), LB-policy / service-config push, and
+  RDS selection **across** multiple SLB-fronted services. What it
+  does **not** do is pick a replica *within* a service — the SLB is
+  topology-blind, so `mssf-partition-key` / primary selection has no
+  effect on this path. Note that **per-backend health pruning on
+  this path is an SLB property** (the health probe on `<servicePort>`
+  removes unhealthy nodes), **not** xDS: the only EDS endpoint is the
+  VIP, so xDS would drop it only if the *entire* VIP/service is gone,
+  not per replica.
 - **Scope:** stateless services, or "any active replica is fine"
-  reads. **Not** for partition/primary-targeted calls — those need
-  Scenario A (in-VNet direct), Scenario C2 (per-instance NAT), or
-  the [reverse proxy](./HttpReverseProxy.md).
+  reads — i.e. **only** the base proposal's `mssf-partition-role:
+  any`. Because the VIP is topology-blind, the Scenario C RDS resource
+  must **require an explicit `mssf-partition-role: any` match and fail
+  closed** for absent / `primary` / `secondary`: it must **not** reuse
+  the base proposal's absent-⇒-primary fallback, since a
+  default-primary request served by the flat VIP would land on an
+  arbitrary replica (often a secondary), violating the base proposal's
+  write-safety guarantee. Callers needing primary/secondary (including
+  the absent-⇒-primary default) must take a topology-aware path —
+  Scenario A (in-VNet direct), Scenario C2 (per-instance NAT), or the
+  [reverse proxy](./HttpReverseProxy.md). **Not** for
+  partition/primary-targeted calls on the flat VIP.
 - **Dual advertisement:** the same service can be advertised two
   ways from one snapshot — node-IP endpoints for in-VNet Scenario A
   clients and a `VIP:frontendPort` endpoint for Scenario C clients.
-  The client selects via the base proposal's **resource-name
-  convention** (a distinct `xds:///` target, e.g. `.../Svc` vs.
-  `.../Svc@slb`), so no query params are needed.
+  This is the **SLB-vs-direct** axis (which *endpoint set* a channel
+  dials). It is orthogonal to replica-role selection **only for
+  `role=any`**: because the flat VIP is topology-blind it can honor
+  *only* `mssf-partition-role: any`, so on this path the two axes are
+  **not** fully orthogonal — `primary`/`secondary` (and the
+  absent-⇒-primary default) require a topology-aware path, not the flat
+  VIP. Replica-role selection itself the base proposal carries per
+  request in the [`mssf-partition-role` header](./GrpcXds.md#partition-key-semantics),
+  **not** a resource name. The SLB-vs-direct axis still uses the base
+  proposal's **resource-name convention** (a distinct `xds:///` target
+  that the agent maps to a cluster — not a query param). The exact
+  spelling depends on that convention, which is still an
+  [open question in the base proposal](./GrpcXds.md) (URI shape is
+  not yet locked): a suffix like `.../Svc@slb` vs. `.../Svc` is one
+  option, but `@` must be confirmed as a legal character in the xDS
+  resource/target name `tonic-xds` accepts before adopting it — a
+  distinct path segment (e.g. `.../Svc/slb`) is the safe fallback.
 
 How the control tier learns the mapping is an
 [open question](#open-questions): static config, an ARM query of
@@ -265,27 +335,58 @@ which map a frontend port to a port on **one specific VMSS
 instance**. That is enough to regain **primary selection with no
 proxy hop**.
 
-The idea: give each backend instance a **dedicated, static** NAT
+The idea: give each backend instance a **dedicated** NAT
 frontend port that targets the service's (fixed) port on *that
 instance* — `VIP:<Fport_A> → instanceA:<servicePort>`,
-`VIP:<Fport_B> → instanceB:<servicePort>`, … set up **once**. Then
-the control tier does a two-step translation:
+`VIP:<Fport_B> → instanceB:<servicePort>`, … Then the control tier
+does a two-step translation:
 
 1. FabricClient resolves the partition **primary** to its node
-   endpoint (`nodeA_ip:<servicePort>`), exactly as in the base
-   proposal.
-2. A static **`instance → VIP:frontendPort`** table maps that
-   instance to its dedicated NAT port. The control tier advertises
+   endpoint (`nodeA_ip:<servicePort>` / SF node name), exactly as in
+   the base proposal.
+2. A **`node → VMSS-instance-ID → VIP:frontendPort`** table maps that
+   node to its dedicated NAT port. The control tier advertises
    **that** `VIP:<Fport_A>` as the single EDS endpoint.
+
+**Prerequisite — the node↔instance↔port mapping.** This is the
+non-trivial part and must be called out. FabricClient identifies the
+primary by **SF node name / node IP**, but inbound NAT rules target a
+**VMSS instance ID**, and SF node names are **not** trivially the
+same as VMSS instance IDs. The control tier therefore needs a
+reliable, continuously-maintained mapping
+`SF-node-name/IP → VMSS-instance-ID → NAT frontend port`. Obtaining
+and keeping it correct (e.g. from IMDS/ARM instance metadata joined
+to the LB's NAT rules, or an SF node property that records the
+instance ID) is a hard requirement for C2 to work at all — the
+"table" in step 2 does not exist for free.
+
+**Instance IDs are only unique within a VMSS.** With multiple node
+types, a bare instance ID is ambiguous — it must be qualified by node
+type, since each node type is a **separate VMSS behind its own LB**.
+The mapping is therefore
+`SF-node → (node type / VMSS, instance ID) → that LB's VIP:frontendPort`:
+resolving the primary's node also resolves **which node type's LB**
+holds the NAT rule, and the advertised endpoint is **that** VIP. When
+a primary moves across node types on failover, the advertised VIP
+changes too, not just the frontend port.
 
 The client dials `VIP:<Fport_A>`; the SLB NATs it to the exact
 instance holding the primary. One L4 hop, no proxy, **and**
 primary-correct.
 
+**Supported roles (C2 is topology-aware).** Unlike the flat Scenario C
+VIP, the per-instance-NAT path resolves the specific replica behind
+each frontend port, so it **can honor the full base-proposal role
+contract** — `primary` (and the absent-⇒-primary default), `secondary`,
+and `any` — exactly like Scenario A direct: the control tier advertises
+the NAT port of the primary instance for `primary`, a secondary
+instance's NAT port for `secondary`, etc. C2 therefore does **not** need
+Scenario C's fail-closed `any`-only restriction.
+
 ```mermaid
 flowchart LR
     Ext["external gRPC client"]
-    Disc["mssf-xds-discovery<br/>primary → instanceA<br/>instanceA → VIP:Fport_A"]
+    Disc["mssf-xds-discovery<br/>primary → nodeA → instanceA<br/>instanceA → VIP:Fport_A"]
     SLB["Azure SLB<br/>NAT: Fport_A→instanceA<br/>Fport_B→instanceB"]
     subgraph Cluster
         A["instance A (primary)"]
@@ -296,15 +397,66 @@ flowchart LR
     SLB -->|"NAT to specific instance"| A
 ```
 
-**Failover is cheap and Azure-static.** When the primary moves
+**Failover reuses pre-existing NAT ports.** When the primary moves
 A→B, the control tier re-resolves, sees the primary on instance B,
 and pushes a new EDS endpoint `VIP:<Fport_B>`; the client reconnects
-there. **Nothing in Azure changes** — the NAT rules are permanent,
-one per instance; only *which pre-existing frontend port the xDS
-server advertises* changes. This is the crucial difference from
-"dynamically rewrite a NAT rule on failover," which would be slow
-control-plane churn; here the remap happens entirely in the xDS
-push.
+there. The key win is that **no Azure NAT rule is rewritten on
+failover** — the per-instance NAT ports already exist, and only
+*which pre-existing frontend port the xDS server advertises* changes.
+This avoids the slow control-plane churn of "dynamically rewrite a
+NAT rule on failover"; the remap happens entirely in the xDS push.
+
+Failover **latency and client behavior are the same as the base
+proposal**: re-resolve + EDS push + client reconnect, plus the
+in-flight-to-old-primary window. As in the base doc, the stale
+server on instance A merely returns `NotPrimary`; it does **not**
+mark its own endpoint unhealthy. Only the notification-driven
+control tier re-resolves and pushes the replacement endpoint (or an
+unhealthy/draining EDS state), so gRPC drains to the new one without
+dropping the connection abruptly. A client that observes the failure
+first may trigger the separately documented forced-re-resolve fast
+path. "No Azure changes" refers only to the NAT rules — the client
+still experiences a normal xDS reconnect, not a zero-cost switch.
+
+**The NAT table is not static across VMSS lifecycle events, but
+scale-in and reimage differ.** The per-instance rules are only
+"permanent" relative to a *fixed* instance set, and VMSS is elastic —
+but the two events that move it have different effects on the NAT
+mapping:
+
+- **Scale-in (instance removed).** The instance leaves the set, and
+  with inbound NAT *pools* its per-instance rule is destroyed; the
+  frontend port is freed and instance IDs are **not stably reused**.
+  This genuinely removes a `node → instance → NAT port` entry, so the
+  table must be re-derived on scale events, not cached once.
+- **Reimage (instance rebuilt in place).** Reimaging normally
+  **preserves the VMSS instance identity and its generated inbound-NAT
+  mapping** — only the live TCP flow is interrupted while the instance
+  reboots. The NAT frontend port does **not** disappear; it points at
+  the same instance again once it comes back. So the table entry
+  survives; what a mid-connection client sees is a dropped flow and a
+  reconnect once the instance and its replica are back.
+
+So the `node → instance → NAT port` table is a **moving** set that
+must be kept in sync with VMSS membership (re-derived on scale events;
+on reimage the mapping persists but the hosted replica may relocate).
+Two consequences to plan for:
+
+- The port budget (below) tracks a **changing** instance count, not
+  a one-time allocation.
+- **On a mid-connection infra event, don't assume the SF primary has
+  already moved.** An infrastructure-driven removal/reimage (or a node
+  going down) breaks the flow *before* SF necessarily deactivates the
+  node or reconverges naming. Until node deactivation and re-resolution
+  complete, the control tier may still advertise the old instance's
+  port — a **stale-mapping / brief-outage window** where the client
+  reconnects to a port whose replica is gone or moving. Correctness
+  therefore depends on the base proposal's failover ordering
+  (RPC error / `NotPrimary` + forced re-resolve or control-plane EDS
+  update): the client must not
+  treat the old mapping as valid once the primary relocates. State this
+  ordering/durability prerequisite rather than assuming the switch has
+  already happened.
 
 **Constraints (be honest):**
 
@@ -314,8 +466,17 @@ push.
   declare a fixed endpoint (like the samples' `ServiceEndpoint1`).
 - **Port budget.** One NAT frontend port per **(instance, exposed
   service)**. Scales with node count × services-exposed-this-way —
-  fine for a handful of services, not for hundreds. NSG must open
-  the NAT frontend-port range.
+  fine for a handful of services, not for hundreds. Concretely the
+  ceiling is `nodes × services-exposed` NAT ports, bounded by both the
+  finite TCP frontend-port space (~65K) and Azure's **per-LB
+  inbound-NAT limits** (single-instance NAT rules number in the low
+  thousands per LB — verify the current figure in the Azure Load
+  Balancer limits doc). So e.g. ~100 nodes × ~10 services ≈ 1000 ports
+  is already near that ceiling: C2 stops scaling **well before** the
+  reverse proxy would, which is the point at which to reach for it.
+  Because the instance set moves (scale/reimage), the allocation must
+  be **re-tracked as membership changes**, not sized once. NSG must
+  open the NAT frontend-port range.
 - **Multiple replicas per instance.** If one instance hosts several
   partition primaries of the same service on **distinct** ports,
   you need a NAT port per (instance, replica port) — feasible only
@@ -362,27 +523,75 @@ the SLB. Design points:
 
 - **Expose discovery on a stable LB rule.** Add a load-balancing
   rule `VIP:<xdsPort> → discoveryPort` with a TCP health probe, so
-  clients (Scenario A) or the [reverse proxy](./HttpReverseProxy.md)
-  (bootstrapping) can open ADS.
-  All relays/discovery instances serve the same snapshot, so the
-  5-tuple spread is safe — a stream pins to one backend for its
-  life; on backend loss the client reconnects and re-subscribes
-  (standard xDS).
+  clients can open ADS. This rule serves **every scenario's bootstrap**,
+  not just Scenario A: the public **C / C2** clients that motivate this
+  proposal must also reach an ADS endpoint to fetch their EDS
+  translation (the SLB frontend for C, the per-instance NAT port for
+  C2), and the [reverse proxy](./HttpReverseProxy.md) needs it to
+  bootstrap. Which frontend each uses follows the client's network
+  location:
+  - **In-VNet / peered (Scenario A):** the **VNet-internal** frontend
+    (private VIP).
+  - **Off-VNet / public (Scenarios C and C2):** the **public** frontend
+    (public VIP) — the same public boundary the C/C2 data path crosses,
+    since these clients cannot reach a private VIP. Public exposure of
+    the control plane **requires** client auth/authz (see
+    [Security](#security)).
+
+  **Which node type's VIP?** As with the data-plane VIPs, there is no
+  single cluster VIP: the ADS rule must front a **specific node type's
+  LB** — the one whose VMSS actually hosts the discovery singleton
+  (pin it via placement constraints). Off-node clients bootstrap
+  against **that** node type's `VIP:<xdsPort>`.
+
+  **Pick one backend tier explicitly.**
+  In the base proposal the discovery tier `mssf-xds-discovery` is a
+  **stateless singleton** (`InstanceCount=1`) and the relays are
+  per-node (`-1`) serving only node-local loopback/UDS clients. This
+  rule should front the **discovery singleton** (a single backend —
+  so there is no cross-backend "spread" and no reconnect storm across
+  backends; a stream simply pins to the one instance and reconnects
+  on its restart). Note the **relays do not cover a direct off-node
+  client** here: relay last-known-good only helps clients that connect
+  *through a relay* (node-local loopback/UDS clients). A direct client
+  attached to the discovery singleton keeps the resources it has
+  already **accepted** and continues serving them while it reconnects
+  — so an ADS gap is a **stale-config interval** (config updates pause
+  until the stream is re-established and re-synced), not an immediate
+  outage. Fronting the **relay fleet** instead would require first
+  giving relays a network-facing ADS listener (see Scenario A note) — a
+  change this proposal would have to introduce; only then does the
+  5-tuple-spread reasoning (all relays serve the same snapshot) apply.
+  Do not conflate the two tiers.
 - **Keepalive vs. SLB idle timeout.** ADS is a long-lived, often
-  idle HTTP/2 stream. The SLB idle timeout (~4–5 min) will silently
-  drop it. **Require** gRPC keepalive pings (client
+  idle HTTP/2 stream. The SLB idle timeout (**4 minutes** by default)
+  will silently drop it. **Require** gRPC keepalive pings (client
   `keep_alive_while_idle`, server permit-without-stream) at an
   interval below the LB idle timeout, and/or raise the rule's
-  `idleTimeoutInMinutes`. This is mandatory, not optional — without
-  it, config updates stop arriving and clients silently serve stale
-  endpoints.
-- **Reconnect storms.** If a discovery backend fails, every pinned
-  client reconnects at once and re-subscribes. Bound this with
-  jittered reconnect (tonic/`tower` backoff) and rely on relays
-  holding last-known-good so a reconnect gap is not an outage.
+  `idleTimeoutInMinutes` (**up to the 30-minute maximum**). This is
+  mandatory, not optional — without it, config updates stop arriving
+  and clients silently serve stale endpoints.
+- **Reconnect storms.** If the discovery singleton restarts, every
+  pinned client reconnects at once and re-subscribes. Bound this with
+  jittered reconnect (tonic/`tower` backoff). During the gap a direct
+  client keeps serving its **already-accepted** resources (a
+  stale-config interval, not an outage); relay-held last-known-good
+  only helps clients that connect **through a relay** (node-local),
+  not direct off-node streams.
 - **TLS.** Because the ADS stream now crosses the network (not
   loopback/UDS), it must be **TLS**, terminated at the discovery /
   relay listener. See [Security](#security).
+- **Off-node bootstrap (endpoint + trust anchor).** On-node clients
+  are bootstrapped by the local agent over loopback/UDS; an off-VNet
+  C/C2 client has **no such channel** and must obtain, out of band, at
+  least: the public ADS `VIP:<xdsPort>` / FQDN, the xDS
+  bootstrap/target config, the **CA / trust anchor** to validate the
+  TLS/mTLS listener, and its own **client cert / token** for the
+  required authz. The straightforward answer is that the **operator
+  ships a static bootstrap file plus the CA** to each off-node client
+  (the same way any public gRPC client is provisioned); the cluster
+  cannot self-serve this over the very channel it is trying to
+  establish. This is a prerequisite for every public (C/C2) path.
 
 ## Azure SLB configuration required
 
@@ -391,7 +600,8 @@ are cluster policy):
 
 | Purpose | Frontend | Backend | Probe | Notes |
 |---|---|---|---|---|
-| xDS ADS (control) | `VIP:<xdsPort>` | discovery/relay port | TCP | Scenario A clients + reverse-proxy bootstrap. Raise idle timeout; require keepalive. |
+| xDS ADS — in-VNet (control) | internal `VIP:<xdsPort>` | discovery singleton port | TCP | Scenario A clients + reverse-proxy bootstrap. Raise idle timeout; require keepalive. |
+| xDS ADS — public (control) | public `VIP:<xdsPort>` | discovery singleton port | TCP | Scenario C/C2 off-VNet bootstrap. **Requires** client auth/authz (mTLS or equivalent). Raise idle timeout; require keepalive. |
 | Service ingress (Scenario C) | `VIP:<frontendPort>` | service port | TCP on service port | Direct-via-SLB fast path; probe prunes nodes not running the service. This mapping is exactly what the EDS translation advertises. |
 | Existing mgmt | `VIP:19000/19080` | 19000/19080 | TCP | Unchanged SF management; leave as-is. |
 
@@ -402,9 +612,11 @@ Also:
 
 - **Outbound rule (443)** must exist on each node type (Standard
   SLB requirement) or deployment fails.
-- **NSG rules** must open the new frontend ports inbound
-  (managed-cluster custom NSG range 1000–3000; classic clusters add
-  to the NSG directly). Keep 19080 reachable for SFRP.
+- **NSG rules** must open the new frontend ports inbound (managed
+  clusters expose a reserved customer-usable NSG priority window —
+  see the [managed-cluster networking docs](https://learn.microsoft.com/en-us/azure/service-fabric/how-to-managed-cluster-networking)
+  for the exact current range, which has changed over time; classic
+  clusters add to the NSG directly). Keep 19080 reachable for SFRP.
 - **BYOLB** (secondary node types) must have the backend + NAT
   pools pre-configured and outbound connectivity, per Azure BYOLB
   requirements.
@@ -419,15 +631,32 @@ host-trust scoped. **That no longer holds** once xDS or data-plane
 traffic crosses the SLB:
 
 - **Control plane (ADS over SLB):** require **TLS** on the
-  discovery/relay listener; strongly prefer **mTLS** so only
-  authorized clients/proxies can pull the topology (it reveals
-  every service's endpoints). Cluster certs already exist on nodes;
-  reuse them or issue a dedicated xDS cert.
+  discovery/relay listener. Because the ADS stream reveals **every
+  service's endpoints**, server-only TLS is not enough — it proves the
+  server's identity but lets any TLS client enumerate the topology. For
+  a **public** C/C2 control-plane frontend, therefore **require client
+  authentication and authorization** — **mTLS or an equivalent
+  mechanism** (e.g. a validated bearer/JWT with an authz check) — so
+  only authorized clients/proxies can pull topology. A **weaker,
+  server-only-TLS policy is acceptable only for a clearly scoped
+  private / trusted-network deployment** (VNet-internal frontend, no
+  off-VNet exposure). Cluster certs already exist on nodes; reuse them
+  or issue a dedicated xDS cert.
+  - **Defense-in-depth beyond authn.** Auth answers "who," not "how
+    much": a public ADS frontend is still a topology-enumerating,
+    handshake-consuming target. Where the client population is known,
+    add an **NSG source-IP allowlist**; enable **Azure DDoS Protection**
+    on the public VIP; and apply **connection/handshake rate limiting**
+    on the discovery listener.
 - **Data plane (Scenarios A/C/C2):** the client and replica (or the
-  SLB-fronted service) negotiate TLS end-to-end; xDS SDS can
-  distribute certs later (base proposal Future work). The reverse
-  proxy's own TLS-termination and authN/authZ model is covered in
-  its [proposal](./HttpReverseProxy.md#security).
+  SLB-fronted service) negotiate TLS **end-to-end**. This works
+  because the SLB is a **pure L4 passthrough** — it forwards TCP and
+  does **not** terminate or inspect TLS — so the handshake and the
+  session run all the way to the backend (or NAT'd instance) without
+  the LB breaking it. xDS SDS can distribute certs later (base
+  proposal Future work). The reverse proxy's own TLS-termination and
+  authN/authZ model is covered in its
+  [proposal](./HttpReverseProxy.md#security).
 - **NSG posture:** expose only the xDS/service/mgmt ports needed;
   everything else stays closed. Prefer per-node-type subnets/NSGs
   (managed-cluster BYOLB pattern) so blast radius is bounded.
@@ -463,6 +692,15 @@ The **reverse-proxy** path (for public primary-targeted callers
 that C2 cannot serve) is phased separately in its
 [proposal](./HttpReverseProxy.md#phasing).
 
+**Observability for the new failure modes.** These phases introduce
+silent failure modes an operator must be able to see. Watch: **ADS
+stream age / last-sync time** and **keepalive-ping failures** (catches
+idle-timeout drops and stale-config intervals); **EDS-advertised vs.
+actual-primary mismatch** (catches the C2 stale-mapping window / wrong
+NAT port); and **per-backend traffic skew** (catches Scenario C
+landing all traffic on one backend). Surfacing these makes each phase
+verifiable in practice rather than silently degraded.
+
 Stop at the earliest phase that satisfies the real client
 population — many clusters only ever need Scenario A.
 
@@ -478,7 +716,9 @@ population — many clusters only ever need Scenario A.
   needs LB read permissions; (c) keeps ownership with the service
   author. Likely support static first, then labels.
 - **Per-instance public IPs as an alternative.**
-  Secondary node types can get per-instance public IPs. Could EDS
+  Secondary node types can get per-instance public IPs (a
+  point-in-time constraint — primary node types are excluded per
+  current managed-cluster docs, 2026-07; re-verify). Could EDS
   hand back those per-node public IPs so a public client *does* go
   direct-to-replica (an xDS path, no proxy)? Possible but fragile
   (public IP per node, NSG surface, cost, primary node types

--- a/docs/proposal/GrpcXdsSlb.md
+++ b/docs/proposal/GrpcXdsSlb.md
@@ -1,0 +1,513 @@
+# gRPC xDS over Service Fabric on Azure Standard Load Balancer — Proposal
+
+Status: Proposal / experiment. Nothing shipped.
+
+Date: 2026-07-16
+
+Owners: mssf maintainers
+
+Extends: [gRPC xDS over Service Fabric Naming](./GrpcXds.md)
+(the "base proposal", accepted).
+
+## Why pursue this?
+
+The [base proposal](./GrpcXds.md) gives node-local gRPC clients a
+vanilla `xds:///fabric/...` channel that resolves SF naming to the
+**actual replica endpoint** and routes RPCs **directly** to it —
+primary-aware, partition-aware, failover-driven. It assumes the
+client runs *on a cluster node* and reaches a local
+`mssf-xds-agent` over loopback/UDS, and that the replica endpoints
+it hands back are reachable from the client.
+
+On Azure, a Service Fabric cluster sits **behind an Azure Standard
+Load Balancer (SLB)**. That breaks two assumptions for any client
+that is not co-located on a node:
+
+1. **Control-plane reach.** An off-node client cannot talk to a
+   loopback/UDS agent. It can only reach the cluster through the
+   SLB's frontend IP (VIP) / FQDN.
+2. **Data-plane reach.** The base proposal's whole value is
+   direct-to-replica routing. But a replica endpoint is a private
+   VNet node IP. An off-VNet client can reach only the VIP, never
+   an individual node — and the SLB is a flat L4 balancer with **no
+   knowledge of SF partitions, replicas, or which node holds a
+   primary**.
+
+This proposal extends the xDS design so SF services fronted by an
+Azure SLB are reachable with xDS semantics from clients that are
+**not** node-local, and states plainly where direct-to-replica
+routing is and is not achievable through an SLB.
+
+## Background — how a SF cluster uses Azure SLB
+
+Grounded in Azure docs
+([networking patterns](https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-patterns-networking),
+[managed-cluster networking](https://learn.microsoft.com/en-us/azure/service-fabric/how-to-managed-cluster-networking)).
+
+- **Topology.** A SF cluster runs on one or more **node types**,
+  each a **virtual machine scale set (VMSS)**. Each node type sits
+  behind an **Azure Standard Load Balancer** with a **backend
+  address pool** = the VMSS instances. The LB has a frontend IP
+  (public VIP with an FQDN like
+  `mycluster.<region>.cloudapp.azure.com`, or a private IP for an
+  internal LB).
+- **Load-balancing rules.** Each rule maps a **frontend port** to a
+  **backend port** and spreads new flows across **all healthy
+  backend nodes** using a 5-tuple hash. Management rules cover
+  **19000** (client / TCP gateway, used by `FabricClient`) and
+  **19080** (HTTP gateway / Service Fabric Explorer / the Service
+  Fabric Resource Provider). Application ports (e.g. 80, 8080) are
+  added as extra rules.
+- **Health probes.** A TCP probe per rule (`FabricGatewayProbe`
+  :19000, `FabricHttpGatewayProbe` :19080, and one per app port),
+  default 5s interval / 2 probes.
+- **Inbound NAT pools/rules.** Map a range of frontend ports to a
+  port on a **specific VMSS instance** (e.g. 50000+ → 3389 for
+  RDP). Unlike LB rules, a NAT rule targets *one* backend instance.
+- **The critical property.** The SLB is **L4 and
+  topology-blind**. A connection to `VIP:appPort` lands on *some*
+  healthy node running that port — **not** necessarily the node
+  holding the primary of the partition the caller wants. SF's own
+  answer to this is the in-cluster **reverse proxy** / naming
+  resolution; the SLB alone cannot route to a replica.
+- **Reachability of node IPs.** Backend nodes have **private VNet
+  IPs**. They are routable only from inside the VNet or across
+  VNet peering / VPN / ExpressRoute. Secondary node types can
+  optionally get **per-instance public IPs**
+  (`enableNodePublicIP`); primary node types cannot.
+- **Managed vs. classic; BYOLB.** Managed clusters auto-create a
+  Standard public LB + FQDN per node type and reserve NSG priority
+  ranges. **Bring-your-own-LB** (Standard SKU) is supported for
+  secondary node types and requires pre-configured **backend and
+  NAT pools** and explicit **outbound connectivity**.
+- **Standard SLB gotchas that matter for gRPC.**
+  - **Outbound rule required** — Standard SLB is "secure by
+    default"; each node type needs an outbound rule (port 443 for
+    cluster setup) or deployment fails.
+  - **Idle timeout** — default ~4–5 min. **Long-lived gRPC / ADS
+    streams are silently dropped** if idle past the timeout unless
+    TCP keepalive / HTTP/2 pings keep them warm.
+  - **Session persistence** — default distribution is a 5-tuple
+    hash (a given TCP flow is pinned to one backend for its life);
+    optional 2-/3-tuple source-IP affinity.
+  - **SFRP visibility** — 19080 must be publicly reachable for the
+    portal/SFRP to query the cluster; internal-only LBs lose portal
+    status.
+
+```
+        Internet / peer VNet
+                |
+                v
+        +-----------------+          Azure Standard Load Balancer
+        |  VIP / FQDN     |          (L4, topology-blind, 5-tuple)
+        |  :19000 :19080  |
+        |  :<app ports>   |
+        +--------+--------+
+                 | spreads new flows across the whole backend pool
+    +------------+------------+------------------+
+    v                         v                  v
++--------+               +--------+          +--------+
+| Node A |               | Node B |   ...    | Node N |   (VMSS backend pool)
+| privIP |               | privIP |          | privIP |
++--------+               +--------+          +--------+
+   replicas of many partitioned/stateful services live here
+```
+
+## The core tension: VIP vs. per-replica addressability
+
+xDS gives the client a set of **endpoints** and lets the client's
+LB connect **directly** to the chosen one. That requires the client
+to have **network reachability to each endpoint**. Behind an SLB:
+
+- If node IPs are routable from the client (in-VNet / peered / VPN
+  / ExpressRoute), xDS works exactly as in the base proposal — the
+  SLB is irrelevant to the data path.
+- If the client sits behind the VIP only (public internet, no VNet
+  path), a single **LB rule** cannot fan a client out to arbitrary
+  backend nodes or steer a flow to "the node with primary of
+  partition K" — the rule spreads across the whole pool. Two ways
+  out that stay **direct** (true xDS, no proxy): let any backend
+  serve it and dial the VIP directly (Scenario C), or use
+  **per-instance NAT** so a dedicated frontend port targets exactly
+  the instance holding the primary, with the xDS server choosing
+  which port to advertise (Scenario C2). When neither fits — public,
+  primary-targeted, and unable to meet C2's fixed-port/NAT-budget
+  constraints — routing needs an in-cluster **reverse proxy**, which
+  is a different architecture (client speaks plain gRPC, proxy on
+  the data path) and is specified separately in the
+  [HTTP Reverse Proxy proposal](./HttpReverseProxy.md).
+
+This proposal therefore splits on **client network position** and
+**whether replica identity matters**, and covers only the **direct
+(xDS) paths** A/C/C2; the proxy fallback lives in its own doc.
+
+## Goals
+
+1. Let an **in-VNet / peered** gRPC client use the base proposal's
+   `xds:///fabric/...` channel unchanged, with the control plane
+   reachable through the cluster and endpoints resolving to
+   routable node IPs.
+2. Define supported **direct (xDS)** paths for **off-VNet / public**
+   clients that can only reach the VIP: a fast **direct-via-SLB**
+   path for any-replica traffic (Scenario C) and a **primary-aware
+   direct** path using per-instance NAT (Scenario C2). When neither
+   fits, defer to the in-cluster reverse proxy in its own
+   [proposal](./HttpReverseProxy.md).
+3. Specify the **Azure SLB configuration** (rules, probes, ports,
+   NAT, outbound, idle timeout) needed for the xDS control stream
+   and the data path to survive an SLB.
+4. Reuse the base proposal's SF→xDS translation and two-tier
+   discovery **unchanged**; add only what the SLB boundary forces.
+
+## Non-Goals
+
+- Changing the SF→xDS mapping, URI/header strategy, or failover
+  model from the base proposal. Those are inherited verbatim.
+- Making the Azure SLB itself partition-aware. It stays a flat L4
+  balancer; any topology awareness lives in cluster-side software.
+- A public multi-tenant gateway product. This is SF-cluster-scoped.
+- Managing ARM/Bicep deployment automation. We specify the
+  required LB shape; templating is out of scope for v1.
+
+## Reachability scenarios
+
+### Scenario A — client is in-VNet / peered / VPN / ExpressRoute
+
+Node private IPs are routable from the client. Then:
+
+- **Data plane:** the base proposal works **unchanged**. EDS hands
+  back the replica's VNet endpoint (`10.x.y.z:port`) and the
+  client connects directly — primary-aware, partition-aware,
+  failover-driven. The SLB is not on the data path at all.
+- **Control plane:** the client needs to reach an ADS server. Two
+  options:
+  - **Node-local not available (off-node, in-VNet):** point the
+    client at the **two-tier control tier** (`mssf-xds-discovery`)
+    via its VNet address, or at a small set of relays exposed on a
+    VNet-internal LB rule. See
+    [Control-plane reach through the SLB](#control-plane-reach-through-the-slb).
+  - **Client on a node:** identical to the base proposal
+    (loopback/UDS local agent).
+
+Scenario A is the **recommended** target: it preserves every xDS
+benefit. Most first-party callers (services in the same or a peered
+VNet) fall here.
+
+### Scenario C — direct via SLB (port-mapping translation)
+
+When replica identity **does not matter** — a stateless service, or
+any service where every eligible backend can serve the request —
+there is no need for a proxy. If the cluster has an SLB rule
+mapping a **frontend port to the service's backend port**
+(`VIP:<frontendPort> → <servicePort>`), the client can dial the VIP
+directly and the SLB forwards at L4 to a healthy backend. The data
+path is the **raw SLB SDN path — no application proxy hop** — so it
+is as fast as any Azure L4 traffic.
+
+The xDS server's job here is a **translation**: instead of
+advertising the service's private node endpoints (unreachable off
+VNet), it advertises the **SLB frontend** as the endpoint. Concretely
+the control tier, for a service that has an SLB mapping, emits a
+`Cluster` whose EDS holds a single `LbEndpoint = VIP:<frontendPort>`.
+The client's `tonic-xds` channel dials that; the SLB spreads across
+the backend pool; the SLB's health probe on `<servicePort>` prunes
+nodes that are not running the service.
+
+```mermaid
+flowchart LR
+    Ext["external gRPC client"]
+    subgraph Ctl["xDS control plane"]
+        Disc["mssf-xds-discovery<br/>knows SLB rule:<br/>VIP:Fport → servicePort"]
+    end
+    SLB["Azure SLB<br/>VIP:Fport (L4, fast)"]
+    subgraph Cluster
+        S1["service instance (Node A)"]
+        S2["service instance (Node B)"]
+    end
+    Disc -.->|"EDS: endpoint = VIP:Fport"| Ext
+    Ext -->|"gRPC to VIP:Fport"| SLB
+    SLB -->|"5-tuple spread"| S1
+    SLB --> S2
+```
+
+Properties:
+
+- **Fast:** no proxy tier, no in-cluster hop; just the SLB. This is
+  the whole point versus the [reverse proxy](./HttpReverseProxy.md).
+- **xDS still earns its keep:** service discovery (which services
+  exist and their `VIP:port`), health-driven removal, LB-policy /
+  service-config push, and RDS selection **across** multiple
+  SLB-fronted services. What it does **not** do is pick a replica
+  *within* a service — the SLB is topology-blind, so
+  `mssf-partition-key` / primary selection has no effect on this
+  path.
+- **Scope:** stateless services, or "any active replica is fine"
+  reads. **Not** for partition/primary-targeted calls — those need
+  Scenario A (in-VNet direct), Scenario C2 (per-instance NAT), or
+  the [reverse proxy](./HttpReverseProxy.md).
+- **Dual advertisement:** the same service can be advertised two
+  ways from one snapshot — node-IP endpoints for in-VNet Scenario A
+  clients and a `VIP:frontendPort` endpoint for Scenario C clients.
+  The client selects via the base proposal's **resource-name
+  convention** (a distinct `xds:///` target, e.g. `.../Svc` vs.
+  `.../Svc@slb`), so no query params are needed.
+
+How the control tier learns the mapping is an
+[open question](#open-questions): static config, an ARM query of
+the LB's `loadBalancingRules`, or SF service-manifest labels
+(SF-YARP-style `Yarp.Enable`-like opt-in).
+
+### Scenario C2 — primary-aware direct via SLB (per-instance NAT)
+
+Scenario C loses replica selection because an **LB rule** spreads
+across the whole pool. But Azure also has **inbound NAT rules**,
+which map a frontend port to a port on **one specific VMSS
+instance**. That is enough to regain **primary selection with no
+proxy hop**.
+
+The idea: give each backend instance a **dedicated, static** NAT
+frontend port that targets the service's (fixed) port on *that
+instance* — `VIP:<Fport_A> → instanceA:<servicePort>`,
+`VIP:<Fport_B> → instanceB:<servicePort>`, … set up **once**. Then
+the control tier does a two-step translation:
+
+1. FabricClient resolves the partition **primary** to its node
+   endpoint (`nodeA_ip:<servicePort>`), exactly as in the base
+   proposal.
+2. A static **`instance → VIP:frontendPort`** table maps that
+   instance to its dedicated NAT port. The control tier advertises
+   **that** `VIP:<Fport_A>` as the single EDS endpoint.
+
+The client dials `VIP:<Fport_A>`; the SLB NATs it to the exact
+instance holding the primary. One L4 hop, no proxy, **and**
+primary-correct.
+
+```mermaid
+flowchart LR
+    Ext["external gRPC client"]
+    Disc["mssf-xds-discovery<br/>primary → instanceA<br/>instanceA → VIP:Fport_A"]
+    SLB["Azure SLB<br/>NAT: Fport_A→instanceA<br/>Fport_B→instanceB"]
+    subgraph Cluster
+        A["instance A (primary)"]
+        B["instance B (secondary)"]
+    end
+    Disc -.->|"EDS: endpoint = VIP:Fport_A"| Ext
+    Ext -->|"gRPC to VIP:Fport_A"| SLB
+    SLB -->|"NAT to specific instance"| A
+```
+
+**Failover is cheap and Azure-static.** When the primary moves
+A→B, the control tier re-resolves, sees the primary on instance B,
+and pushes a new EDS endpoint `VIP:<Fport_B>`; the client reconnects
+there. **Nothing in Azure changes** — the NAT rules are permanent,
+one per instance; only *which pre-existing frontend port the xDS
+server advertises* changes. This is the crucial difference from
+"dynamically rewrite a NAT rule on failover," which would be slow
+control-plane churn; here the remap happens entirely in the xDS
+push.
+
+**Constraints (be honest):**
+
+- **Fixed service port.** The NAT rule's backend port is static, so
+  the service must publish a **known, stable** endpoint port per
+  instance. Dynamic SF ports don't work; the service manifest must
+  declare a fixed endpoint (like the samples' `ServiceEndpoint1`).
+- **Port budget.** One NAT frontend port per **(instance, exposed
+  service)**. Scales with node count × services-exposed-this-way —
+  fine for a handful of services, not for hundreds. NSG must open
+  the NAT frontend-port range.
+- **Multiple replicas per instance.** If one instance hosts several
+  partition primaries of the same service on **distinct** ports,
+  you need a NAT port per (instance, replica port) — feasible only
+  if those ports are fixed and known. Shared-port hosting can't be
+  disambiguated by NAT.
+- **BYOLB / managed-cluster NAT pools.** The per-instance NAT pool
+  must exist (BYOLB requires NAT pools anyway); on managed clusters
+  confirm the NAT-pool shape is expressible.
+
+Within those limits, **C2 dominates the reverse proxy**: same public
+reachability and primary/partition awareness, but **no proxy tier
+and no data-path hop**. Prefer C2 when the fixed-port and
+port-budget constraints hold; fall back to the
+[reverse proxy](./HttpReverseProxy.md) when they don't (many
+services, dynamic ports, or large clusters).
+
+### Choosing a scenario
+
+All three scenarios below are **direct (xDS)** paths — no proxy on
+the data path. When none fit (public, primary-targeted, and can't
+meet C2's constraints), use the
+[reverse proxy](./HttpReverseProxy.md) instead.
+
+| | A: in-VNet / peered | C: direct via SLB | C2: direct via SLB (per-instance NAT) |
+|---|---|---|---|
+| Client network path | routes to node IPs | VIP only | VIP only |
+| Data path | direct to replica | direct via SLB (L4, no proxy) | direct via SLB NAT (L4, no proxy) |
+| Replica/partition-aware | yes | **no** (SLB is blind) | **yes** (NAT targets the primary's instance) |
+| Requires | node-IP routability | LB rule + EDS translation | per-instance NAT + **fixed** service port |
+| Port budget | — | 1 per service | 1 per (instance × service) |
+| Best for | first-party, same/peered VNet | stateless / any-replica | primary-targeted, public, few services / fixed ports |
+| Speed | fastest (direct) | fast (one L4 hop) | fast (one L4 hop) |
+
+A and C/C2 can coexist for the same service (dual advertisement).
+Order of preference for a **public, primary-targeted** caller: **C2**
+(no hop, if fixed-port + port-budget hold) → the
+[reverse proxy](./HttpReverseProxy.md) when they don't. For
+**stateless/any-replica** public callers, **C** is simplest.
+
+## Control-plane reach through the SLB
+
+Whichever scenario, an off-node client's **ADS stream** may cross
+the SLB. Design points:
+
+- **Expose discovery on a stable LB rule.** Add a load-balancing
+  rule `VIP:<xdsPort> → discoveryPort` with a TCP health probe, so
+  clients (Scenario A) or the [reverse proxy](./HttpReverseProxy.md)
+  (bootstrapping) can open ADS.
+  All relays/discovery instances serve the same snapshot, so the
+  5-tuple spread is safe — a stream pins to one backend for its
+  life; on backend loss the client reconnects and re-subscribes
+  (standard xDS).
+- **Keepalive vs. SLB idle timeout.** ADS is a long-lived, often
+  idle HTTP/2 stream. The SLB idle timeout (~4–5 min) will silently
+  drop it. **Require** gRPC keepalive pings (client
+  `keep_alive_while_idle`, server permit-without-stream) at an
+  interval below the LB idle timeout, and/or raise the rule's
+  `idleTimeoutInMinutes`. This is mandatory, not optional — without
+  it, config updates stop arriving and clients silently serve stale
+  endpoints.
+- **Reconnect storms.** If a discovery backend fails, every pinned
+  client reconnects at once and re-subscribes. Bound this with
+  jittered reconnect (tonic/`tower` backoff) and rely on relays
+  holding last-known-good so a reconnect gap is not an outage.
+- **TLS.** Because the ADS stream now crosses the network (not
+  loopback/UDS), it must be **TLS**, terminated at the discovery /
+  relay listener. See [Security](#security).
+
+## Azure SLB configuration required
+
+For the ports this design introduces (illustrative — exact ports
+are cluster policy):
+
+| Purpose | Frontend | Backend | Probe | Notes |
+|---|---|---|---|---|
+| xDS ADS (control) | `VIP:<xdsPort>` | discovery/relay port | TCP | Scenario A clients + reverse-proxy bootstrap. Raise idle timeout; require keepalive. |
+| Service ingress (Scenario C) | `VIP:<frontendPort>` | service port | TCP on service port | Direct-via-SLB fast path; probe prunes nodes not running the service. This mapping is exactly what the EDS translation advertises. |
+| Existing mgmt | `VIP:19000/19080` | 19000/19080 | TCP | Unchanged SF management; leave as-is. |
+
+(The reverse proxy's own gRPC ingress rule is specified in the
+[reverse-proxy proposal](./HttpReverseProxy.md#azure-slb-integration).)
+
+Also:
+
+- **Outbound rule (443)** must exist on each node type (Standard
+  SLB requirement) or deployment fails.
+- **NSG rules** must open the new frontend ports inbound
+  (managed-cluster custom NSG range 1000–3000; classic clusters add
+  to the NSG directly). Keep 19080 reachable for SFRP.
+- **BYOLB** (secondary node types) must have the backend + NAT
+  pools pre-configured and outbound connectivity, per Azure BYOLB
+  requirements.
+- **Internal LB** variant: if the whole cluster is internal-only,
+  Scenario A over a private VIP is the natural fit; SFRP/portal
+  visibility is lost (a known SF tradeoff, not introduced here).
+
+## Security
+
+The base proposal deferred mTLS because traffic was loopback/UDS,
+host-trust scoped. **That no longer holds** once xDS or data-plane
+traffic crosses the SLB:
+
+- **Control plane (ADS over SLB):** require **TLS** on the
+  discovery/relay listener; strongly prefer **mTLS** so only
+  authorized clients/proxies can pull the topology (it reveals
+  every service's endpoints). Cluster certs already exist on nodes;
+  reuse them or issue a dedicated xDS cert.
+- **Data plane (Scenarios A/C/C2):** the client and replica (or the
+  SLB-fronted service) negotiate TLS end-to-end; xDS SDS can
+  distribute certs later (base proposal Future work). The reverse
+  proxy's own TLS-termination and authN/authZ model is covered in
+  its [proposal](./HttpReverseProxy.md#security).
+- **NSG posture:** expose only the xDS/service/mgmt ports needed;
+  everything else stays closed. Prefer per-node-type subnets/NSGs
+  (managed-cluster BYOLB pattern) so blast radius is bounded.
+
+## Phasing
+
+Layered on the base proposal's phases (which build the agent,
+notifications, two-tier discovery, partitioning):
+
+- **Phase S0 — validate Scenario A.** Off-node in-VNet client,
+  ADS to the control tier over a VNet address, EDS resolving to
+  node IPs, RPC direct to replica. Add keepalive; measure behavior
+  against the SLB idle timeout. No new components.
+- **Phase S1 — control plane through the SLB.** Add the
+  `VIP:<xdsPort>` LB rule + probe + NSG + TLS; confirm ADS survives
+  the idle timeout with keepalive and reconnects cleanly on backend
+  loss.
+- **Phase S1.5 — Scenario C direct-via-SLB.** For a stateless
+  sample, add the `VIP:<frontendPort> → servicePort` rule + probe,
+  teach the control tier the mapping, and emit the translated
+  `VIP:frontendPort` EDS endpoint under an `@slb` resource name.
+  Client dials the VIP directly, no proxy. Cheapest public path;
+  no new runtime component.
+- **Phase S1.7 — Scenario C2 primary-aware NAT.** For a
+  fixed-port stateful sample (e.g. `echomain-stateful`), stand up
+  the per-instance NAT pool and the `instance → VIP:frontendPort`
+  table; the control tier resolves the primary and advertises that
+  instance's NAT port, re-advertising on failover. Verify primary
+  correctness and failover with **no Azure changes** on role move.
+  No proxy tier.
+
+The **reverse-proxy** path (for public primary-targeted callers
+that C2 cannot serve) is phased separately in its
+[proposal](./HttpReverseProxy.md#phasing).
+
+Stop at the earliest phase that satisfies the real client
+population — many clusters only ever need Scenario A.
+
+## Open questions
+
+- **How the control tier learns the SLB port mapping (Scenario C).**
+  Three sources: (a) **static config** handed to the discovery tier
+  (`servicePort → VIP:frontendPort`); (b) an **ARM/Azure query** of
+  the load balancer's `loadBalancingRules` to derive the mapping
+  automatically; (c) **SF service-manifest labels** where a service
+  opts in (SF-YARP-style) and declares its SLB frontend port. (b)
+  is most automatic but couples the control tier to Azure RM and
+  needs LB read permissions; (c) keeps ownership with the service
+  author. Likely support static first, then labels.
+- **Per-instance public IPs as an alternative.**
+  Secondary node types can get per-instance public IPs. Could EDS
+  hand back those per-node public IPs so a public client *does* go
+  direct-to-replica (an xDS path, no proxy)? Possible but fragile
+  (public IP per node, NSG surface, cost, primary node types
+  excluded) — likely a niche option, not the default.
+- **Idle-timeout / keepalive defaults.** What keepalive interval
+  and LB `idleTimeoutInMinutes` become the recommended baseline?
+  Needs measurement on a real cluster.
+- **Managed cluster automation.** Which LB rules/probes can be
+  expressed through managed-cluster `loadBalancingRules` vs.
+  requiring BYOLB? Affects how turnkey Scenarios A/C/C2 are.
+
+(Reverse-proxy-specific open questions — client shape, placement —
+are in its [proposal](./HttpReverseProxy.md#open-questions).)
+
+## Future work
+
+- **xDS SDS** to distribute replica certs, enabling
+  end-to-end mTLS without out-of-band cert plumbing.
+- **Private Link ingress** as a VIP alternative for partner
+  clients (auxiliary subnets already support Private Link Service).
+- **Global / multi-region** routing: front several clusters' VIPs
+  with Azure Front Door / Traffic Manager and let xDS authorities
+  select a cluster.
+
+## References
+
+- [Networking patterns for Azure Service Fabric](https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-patterns-networking) — internal/external LB, static IP, mgmt ports 19000/19080, Standard SLB outbound note.
+- [Configure network settings for SF managed clusters](https://learn.microsoft.com/en-us/azure/service-fabric/how-to-managed-cluster-networking) — LB rules/probes, NAT pools, NSG ranges, BYOLB, per-instance public IP, IPv6.
+- [Azure Load Balancer overview](https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-overview) — Standard SLB behavior, 5-tuple distribution, idle timeout.
+- [gRPC xDS over Service Fabric Naming](./GrpcXds.md) — the base proposal this extends (agent, two-tier discovery, SF→xDS mapping, URI/header strategy, failover).
+- [HTTP Reverse Proxy for Service Fabric](./HttpReverseProxy.md) — the in-cluster reverse-proxy fallback (generalized from this doc's former Scenario B) for public primary-targeted callers that Scenarios A/C/C2 cannot serve, covering HTTP and gRPC.
+- [microsoft/service-fabric-yarp](https://github.com/microsoft/service-fabric-yarp) — prior art for an in-cluster discovery-fed data-plane proxy (HTTP; no partition-key routing).

--- a/docs/proposal/GrpcXdsSlb.md
+++ b/docs/proposal/GrpcXdsSlb.md
@@ -2,7 +2,7 @@
 
 Status: Proposal / experiment. Nothing shipped.
 
-Date: 2026-07-16
+Date: 2026-07-16 (last updated 2026-07-20)
 
 Owners: mssf maintainers
 
@@ -299,28 +299,25 @@ Properties:
   write-safety guarantee. Callers needing primary/secondary (including
   the absent-⇒-primary default) must take a topology-aware path —
   Scenario A (in-VNet direct), Scenario C2 (per-instance NAT), or the
-  [reverse proxy](./HttpReverseProxy.md). **Not** for
-  partition/primary-targeted calls on the flat VIP.
+  [reverse proxy](./HttpReverseProxy.md).
 - **Dual advertisement:** the same service can be advertised two
   ways from one snapshot — node-IP endpoints for in-VNet Scenario A
   clients and a `VIP:frontendPort` endpoint for Scenario C clients.
-  This is the **SLB-vs-direct** axis (which *endpoint set* a channel
-  dials). It is orthogonal to replica-role selection **only for
-  `role=any`**: because the flat VIP is topology-blind it can honor
-  *only* `mssf-partition-role: any`, so on this path the two axes are
-  **not** fully orthogonal — `primary`/`secondary` (and the
-  absent-⇒-primary default) require a topology-aware path, not the flat
-  VIP. Replica-role selection itself the base proposal carries per
-  request in the [`mssf-partition-role` header](./GrpcXds.md#partition-key-semantics),
-  **not** a resource name. The SLB-vs-direct axis still uses the base
+  This **SLB-vs-direct** axis (which *endpoint set* a channel dials) is
+  orthogonal to replica-role selection **only for `role=any`**; as above,
+  the topology-blind VIP cannot honor `primary`/`secondary` (or the
+  absent-⇒-primary default), which need a topology-aware path.
+  Replica-role selection is carried per request in the
+  [`mssf-partition-role` header](./GrpcXds.md#partition-key-semantics),
+  **not** a resource name, whereas the SLB-vs-direct axis uses the base
   proposal's **resource-name convention** (a distinct `xds:///` target
-  that the agent maps to a cluster — not a query param). The exact
-  spelling depends on that convention, which is still an
-  [open question in the base proposal](./GrpcXds.md) (URI shape is
-  not yet locked): a suffix like `.../Svc@slb` vs. `.../Svc` is one
-  option, but `@` must be confirmed as a legal character in the xDS
-  resource/target name `tonic-xds` accepts before adopting it — a
-  distinct path segment (e.g. `.../Svc/slb`) is the safe fallback.
+  that the agent maps to a cluster — not a query param). Its exact
+  spelling depends on that convention, still an
+  [open question in the base proposal](./GrpcXds.md) (URI shape is not yet
+  locked): a suffix like `.../Svc@slb` vs. `.../Svc` is one option, but `@`
+  must be confirmed as a legal character in the xDS resource/target name
+  `tonic-xds` accepts before adopting it — a distinct path segment (e.g.
+  `.../Svc/slb`) is the safe fallback.
 
 How the control tier learns the mapping is an
 [open question](#open-questions): static config, an ARM query of
@@ -453,10 +450,8 @@ Two consequences to plan for:
   reconnects to a port whose replica is gone or moving. Correctness
   therefore depends on the base proposal's failover ordering
   (RPC error / `NotPrimary` + forced re-resolve or control-plane EDS
-  update): the client must not
-  treat the old mapping as valid once the primary relocates. State this
-  ordering/durability prerequisite rather than assuming the switch has
-  already happened.
+  update): the client must not treat the old mapping as valid once the
+  primary relocates.
 
 **Constraints (be honest):**
 
@@ -573,11 +568,9 @@ the SLB. Design points:
   and clients silently serve stale endpoints.
 - **Reconnect storms.** If the discovery singleton restarts, every
   pinned client reconnects at once and re-subscribes. Bound this with
-  jittered reconnect (tonic/`tower` backoff). During the gap a direct
-  client keeps serving its **already-accepted** resources (a
-  stale-config interval, not an outage); relay-held last-known-good
-  only helps clients that connect **through a relay** (node-local),
-  not direct off-node streams.
+  jittered reconnect (tonic/`tower` backoff); during the gap a direct
+  client keeps serving its already-accepted resources (a stale-config
+  interval, not an outage), as noted above.
 - **TLS.** Because the ADS stream now crosses the network (not
   loopback/UDS), it must be **TLS**, terminated at the discovery /
   relay listener. See [Security](#security).

--- a/docs/proposal/HttpReverseProxy.md
+++ b/docs/proposal/HttpReverseProxy.md
@@ -286,7 +286,15 @@ direct-naming is a valid MVP.
   for HTTP callers, request metadata for gRPC callers — matched to
   the owning partition per the base proposal's semantics. Malformed
   or missing keys fail the same way (hard error, never a silent
-  fallback to an arbitrary partition).
+  fallback to an arbitrary partition). **Note:** the key is an
+  **untrusted, non-authorizing** addressing hint — the caller picks
+  the partition and the proxy faithfully routes to it. In multi-tenant
+  (e.g. partition-per-tenant) deployments this is a cross-tenant
+  addressing (IDOR) risk, so partition/authority-level authorization
+  must be enforced (by the proxy's client authZ and/or the backend);
+  see the base proposal's
+  [partition-key threat note](./GrpcXds.md#partition-key-semantics)
+  and [Security](#security).
 - **Replica role:** `mssf-partition-role` header — a normal HTTP
   header for HTTP callers, request metadata for gRPC callers —
   selects `primary` (default) / `secondary` (read-from-secondary)
@@ -358,19 +366,32 @@ A public VIP is internet-facing, so the proxy is the security
 boundary:
 
 - **TLS termination.** The proxy terminates client TLS at the VIP
-  and re-originates to the replica with mTLS inside the cluster
-  (cluster certs). For gRPC, upstream must remain HTTP/2. **Backend
-  assumption:** this presumes the target replica accepts
-  cluster-cert mTLS on its listener. SF application services
-  commonly present their **own** service/endpoint certificate, or
-  listen plaintext; when a backend does not speak cluster-cert
-  mTLS, the proxy must be configured **per service** with the
-  expected upstream scheme (its service cert / CA to validate, or
-  explicit plaintext for trusted in-cluster networks) rather than
-  assuming every replica is a cluster-cert mTLS peer.
-- **AuthN/AuthZ.** The proxy is the natural place to enforce client
-  identity (mTLS client certs, tokens/JWT) and per-service
-  authorization before it will proxy.
+  and re-originates to the replica **inside the cluster over TLS**.
+  **Scope the proxy's upstream identity narrowly:** the proxy
+  re-originates with a **dedicated proxy identity** (its own cert),
+  **not** a full cluster cert that every replica trusts as an
+  administrative peer. A dedicated identity bounds blast radius — a
+  proxy compromise can then reach only what that identity is
+  authorized for, and **cannot impersonate arbitrary privileged
+  clients**. **Backend assumption:** this presumes the target replica
+  accepts the proxy's upstream mTLS identity on its listener. SF
+  application services commonly present their **own** service/endpoint
+  certificate; when a backend does not speak the proxy's mTLS identity,
+  the proxy must be configured **per service** with the expected
+  upstream scheme (its service cert / CA to validate). **Plaintext
+  upstream is disallowed on any externally-facing path** — it is
+  permitted **only** for a clearly **private / test-only** backend that
+  is not reachable from the public ingress. An externally-facing
+  request must never be forwarded over an unauthenticated, unencrypted
+  upstream. For gRPC, the upstream must remain HTTP/2.
+- **AuthN/AuthZ.** For any **public** exposure, client authentication
+  and per-service authorization (mTLS client certs, tokens/JWT) are
+  **mandatory by default** — the proxy **ships closed**. It **must
+  not** proxy an unauthenticated public request to a backend in the
+  default posture; an anonymous request cannot reach, and certainly
+  cannot mutate, a write primary. Relaxing this (anonymous/open
+  ingress) is allowed **only** for an explicitly-scoped private or
+  test deployment, never as the public default.
 - **DoS / abuse surface.** A public, L4-fronted L7 proxy has a
   real abuse surface (connection floods, slowloris/half-open,
   HTTP/2 stream-concurrency exhaustion). The proxy enforces basic

--- a/docs/proposal/HttpReverseProxy.md
+++ b/docs/proposal/HttpReverseProxy.md
@@ -1,0 +1,348 @@
+# HTTP Reverse Proxy for Service Fabric — Proposal
+
+Status: Proposal / experiment. Nothing shipped.
+
+Date: 2026-07-17
+
+Owners: mssf maintainers
+
+Relates to:
+[gRPC xDS over Service Fabric Naming](./GrpcXds.md) (the "base xDS
+proposal", accepted) and
+[gRPC xDS over Service Fabric on Azure SLB](./GrpcXdsSlb.md) (the
+"SLB proposal"). This doc **generalizes the SLB proposal's former
+Scenario B** — originally a gRPC-only gateway — into a generic
+**SF-naming-aware HTTP reverse proxy** that covers HTTP/1.1,
+HTTP/2, and gRPC (which is HTTP/2). It is architecturally a
+**reverse proxy**, not an xDS design — see
+[Is this xDS?](#is-this-xds).
+
+## Why pursue this?
+
+The xDS scenarios cover most callers that can reach service
+endpoints directly:
+
+- **In-VNet / peered** clients get direct-to-replica xDS
+  (base proposal + SLB proposal Scenario A).
+- **Public, any-replica** clients dial the VIP directly
+  (SLB proposal Scenario C).
+- **Public, primary-targeted** clients dial per-instance NAT ports
+  directly (SLB proposal Scenario C2) **when** the service has a
+  fixed port and the NAT budget is acceptable.
+
+Two gaps remain, and both point at a reverse proxy:
+
+1. **Public / VIP-only, primary-targeted, can't meet C2.** A client
+   that can reach only the VIP, needs partition/primary-aware
+   routing, and cannot satisfy Scenario C2's fixed-port +
+   per-instance-NAT constraints (many services, dynamic ports,
+   large cluster). A single L4 VIP cannot steer it to "the node
+   holding partition K's primary" — something inside the cluster
+   must decide.
+2. **Plain HTTP services, not just gRPC.** SF hosts REST/HTTP
+   services too. A single L7 entry point that resolves SF naming,
+   selects the partition/primary, and proxies **any** HTTP verb —
+   plus gRPC as a first-class HTTP/2 case — is more broadly useful
+   than a gRPC-only gateway and matches what SF's built-in reverse
+   proxy and SF-YARP already do for HTTP (but without their
+   limitations; see [SF-YARP](#can-sf-yarp-be-used-directly)).
+
+This proposal defines `mssf-http-proxy`: an SF-naming-aware,
+partition/primary-aware HTTP reverse proxy that terminates external
+HTTP/HTTP2/gRPC behind the SLB and forwards each request to the
+correct replica.
+
+## Is this xDS?
+
+**No — and that is why it lives in its own doc.** The defining
+property of xDS is that the *client's own* data plane receives the
+endpoint set and connects **directly** to the chosen backend; the
+control plane is never on the data path. That holds for SLB
+Scenarios A / C / C2. It does **not** hold here:
+
+| | xDS scenarios (A/C/C2) | This proposal (proxy) |
+|---|---|---|
+| Client runs xDS? | yes | **no** — plain HTTP/gRPC to the VIP |
+| Who connects to the replica? | the client, directly | **the proxy**, then re-originates |
+| Control/proxy on the data path? | no | **yes** — the proxy is the data path |
+| Pattern | xDS | **L7 reverse proxy** |
+
+The client here has no endpoint set, no LB policy, no xDS resolver
+— it opens a normal HTTP or gRPC connection to a fixed VIP and (for
+partitioned services) sets the `mssf-partition-key` header. All
+routing happens **server-side** in the proxy. xDS appears only
+*inside* the proxy, as one way it ingests topology (below) — and
+even that is optional. This is the textbook definition of a reverse
+proxy, the same slot SF's built-in reverse proxy and
+[SF-YARP](https://github.com/microsoft/service-fabric-yarp) occupy.
+
+Treat this as the **escape hatch / general ingress** for callers
+the direct xDS paths cannot serve — not as "xDS for public
+clients".
+
+## Protocol scope
+
+The proxy is **transport-generic at the routing layer** (it routes
+on host / path / headers) but must be **protocol-correct at the
+transport layer**. Concretely:
+
+- **HTTP/1.1** — standard request/response proxying.
+- **HTTP/2 (h2, h2c)** — required, including for gRPC.
+- **gRPC** — gRPC *is* HTTP/2 with `content-type: application/grpc`,
+  **trailers** (`grpc-status` / `grpc-message` arrive in HTTP/2
+  *trailing* headers), and **long-lived streams**. To carry gRPC
+  correctly the proxy **must**:
+  - speak **HTTP/2 end-to-end**, including to the backend (never
+    downgrade to HTTP/1.1 upstream);
+  - **forward trailers** (drop them and every RPC looks like it
+    returned no status);
+  - **stream** without buffering whole request/response bodies.
+
+  These are hard requirements, not niceties: a stock HTTP/1.1 proxy
+  (or one that terminates to HTTP/1.1, strips trailers, or buffers
+  bodies) **silently breaks gRPC**. This is why nginx needs
+  `grpc_pass` rather than plain `proxy_pass`. Building on
+  **tonic / hyper / tower** gives HTTP/2 + trailers + streaming
+  natively, so gRPC is covered without special-casing routing.
+
+**Out of scope for v1** (possible future work): **gRPC-Web**
+translation (browser clients over HTTP/1.1), **HTTP/JSON ↔ gRPC
+transcoding** (needs proto descriptors), and **WebSocket**
+upgrades. None are required to proxy HTTP or native gRPC.
+
+## Goals
+
+1. Give **public / VIP-only** clients partition/primary-aware
+   access to SF services — HTTP and gRPC alike — when SLB
+   Scenarios A/C/C2 do not apply.
+2. Reuse the base proposal's **partition-key semantics** and
+   **failover model** so routing behavior matches the in-cluster
+   xDS path; only the *place* the decision is made differs.
+3. Keep the external client trivial: normal HTTP/gRPC to the VIP,
+   plus the `mssf-partition-key` header for partitioned services.
+   No SF-specific client code.
+4. Improve on SF's built-in reverse proxy and SF-YARP: native
+   HTTP/2 + trailers for gRPC, **key-based** partition selection,
+   and Linux support.
+
+## Non-Goals
+
+- A general-purpose API gateway (rate limiting, quotas, developer
+  portal, etc.). This is an SF-naming-aware L7 data plane.
+- Replacing the xDS scenarios. Direct-to-replica (A/C/C2) is
+  preferred whenever the client can reach endpoints; the proxy is
+  the fallback and adds a hop.
+- Protocol translation (gRPC-Web, JSON transcoding) in v1.
+- Reimplementing SF naming or the SF→xDS mapping — inherited from
+  the base proposal.
+
+## Design
+
+### The proxy
+
+`mssf-http-proxy` is a stateless `-1` service deployed on a node
+type exposed by the SLB. It:
+
+1. **Ingests topology** (see [Config ingest](#config-ingest)) —
+   which services exist, their partitions, and each partition's
+   current primary/secondary endpoints.
+2. **Terminates external HTTP/HTTP2/gRPC** on stable ports
+   (`VIP:80` / `VIP:443`). The SLB spreads external connections
+   across proxy instances by 5-tuple; any instance can serve any
+   request because all share the same topology.
+3. **Selects the service** from the request (Host header and/or URL
+   path prefix — e.g. `/<App>/<Service>/...`, mirroring SF's
+   built-in reverse proxy addressing — or an explicit mapping).
+4. **Selects the partition** by reading `mssf-partition-key`,
+   using the base proposal's
+   [partition-key semantics](./GrpcXds.md#partition-key-semantics)
+   (decimal `i64` for Int64Range, exact name for Named). Singleton
+   services skip this step.
+5. **Selects the replica** — the partition's **primary** by default,
+   or a secondary for read routes — and forwards the request,
+   preserving method, headers, body, and (for gRPC) trailers and
+   streaming.
+6. **Follows failover** — when the primary moves, the topology
+   update repoints the proxy; in-flight retries land on the new
+   primary.
+
+```mermaid
+flowchart LR
+    Ext["external client<br/>(HTTP / gRPC)"]
+    SLB["Azure SLB<br/>VIP:80/443 (L4)"]
+    subgraph Cluster
+        P1["mssf-http-proxy<br/>(stateless -1)"]
+        P2["mssf-http-proxy"]
+        Disc["mssf-xds-discovery<br/>(control tier, snapshot)"]
+        Svc["target replica<br/>(partition primary)"]
+    end
+    Ext -->|"HTTP/gRPC + mssf-partition-key"| SLB
+    SLB -->|"5-tuple spread"| P1
+    SLB --> P2
+    Disc -.->|"topology (xDS snapshot)"| P1
+    Disc -.->|"topology (xDS snapshot)"| P2
+    P1 -->|"in-cluster hop to primary"| Svc
+```
+
+**Tradeoff, stated honestly:** this is **not** direct-to-replica.
+It adds one in-cluster hop and a proxy tier, and gives up the "no
+data-path component" property the base proposal is proud of. It is
+the price of serving a client that can reach only a single L4 VIP,
+and of offering one generic HTTP entry point.
+
+### Config ingest
+
+The proxy needs SF topology; two sources, an implementation detail
+that does not change its reverse-proxy nature:
+
+- **Reuse the xDS control-tier snapshot (preferred).** If the
+  [two-tier discovery](./GrpcXds.md#two-tier-discovery-sf-yarp-inspired)
+  control tier is deployed, the proxy subscribes to the same
+  LDS/RDS/CDS/EDS snapshot every other consumer uses — one source
+  of truth, one config model, no extra SF-naming load.
+- **Read SF naming directly.** The proxy owns a `FabricClient` and
+  resolves/subscribes itself (what SF-YARP's
+  `FabricDiscovery.Service` does). Simpler to deploy standalone but
+  duplicates the naming subscription and the SF→xDS logic.
+
+Prefer reuse when the control tier already exists; standalone
+direct-naming is a valid MVP.
+
+### Routing model
+
+- **Service:** Host header and/or path prefix, or explicit config.
+- **Partition:** `mssf-partition-key` header — a normal HTTP header
+  for HTTP callers, request metadata for gRPC callers — matched to
+  the owning partition per the base proposal's semantics. Malformed
+  or missing keys fail the same way (hard error, never a silent
+  fallback to an arbitrary partition).
+- **Replica:** primary by default; secondary for explicitly marked
+  read routes.
+
+## Can SF-YARP be used directly?
+
+Now that this is a generic HTTP proxy, [SF-YARP](https://github.com/microsoft/service-fabric-yarp)
+is the closest prior art — it is exactly an SF-naming-fed YARP
+(HTTP) reverse proxy. So the question is sharper than before.
+
+**What SF-YARP already does:** a YARP-based L7 HTTP proxy with
+HTTP/2 (so it can proxy gRPC), SF discovery + endpoint resolution,
+and `StatefulReplicaSelectionMode` = `PrimaryOnly` / `All` /
+`SecondaryOnly`. For **HTTP or gRPC** to **stateless, singleton, or
+primary-only** services, SF-YARP may already be sufficient with no
+new code.
+
+**Where SF-YARP falls short:**
+
+- **No key-based partition selection.** SF-YARP "does not handle
+  the partitioning key" — the caller must pass the **partition GUID
+  as a query parameter**. This proposal routes on
+  `mssf-partition-key` (i64 / name matching the SF scheme), so the
+  caller supplies the natural key, not a resolved GUID. Decisive
+  functional gap.
+- **Windows-only.** "YarpProxy app is only supported on Windows."
+  mssf targets Linux and Windows.
+- **Separate stack / config model.** SF-YARP is .NET/YARP with its
+  own `FabricDiscovery.Service` and service-manifest `Yarp.*`
+  labels. A tonic proxy reusing the base proposal's xDS snapshot
+  keeps one source of truth and one runtime across in-cluster and
+  proxy paths.
+- **Maturity.** The SF-YARP repo is effectively dormant (~2022,
+  .NET 5/6-era).
+
+**Recommendation.** Use SF-YARP as a valid **stopgap** when *all*
+of these hold: Windows cluster, callers that can pass an explicit
+partition GUID (or stateless/primary-only services), and no desire
+to unify on the xDS snapshot. Build `mssf-http-proxy` when
+**key-based** partition routing, **Linux**, or **config/stack
+unification** matters. Extending SF-YARP with a key→partition
+plugin is possible but stays Windows/.NET and closes neither gap.
+
+## Azure SLB integration
+
+The proxy is normally the **public ingress**, so it sits behind the
+SLB. Required LB shape (illustrative ports):
+
+| Purpose | Frontend | Backend | Probe | Notes |
+|---|---|---|---|---|
+| HTTP ingress | `VIP:80` | proxy HTTP port | TCP/HTTP | plaintext / h2c |
+| HTTPS ingress | `VIP:443` | proxy HTTPS port | TCP/HTTPS | TLS termination at the proxy |
+
+Plus the Standard-SLB essentials from the SLB proposal apply:
+outbound rule (443), NSG opening the ingress ports inbound, and —
+because HTTP/2 and gRPC streams are long-lived — **keepalive tuned
+below the SLB idle timeout** (~4–5 min) so streams are not silently
+dropped. See
+[SLB proposal — Azure SLB configuration](./GrpcXdsSlb.md#azure-slb-configuration-required).
+
+## Security
+
+A public VIP is internet-facing, so the proxy is the security
+boundary:
+
+- **TLS termination.** The proxy terminates client TLS at the VIP
+  and re-originates to the replica with mTLS inside the cluster
+  (cluster certs). For gRPC, upstream must remain HTTP/2.
+- **AuthN/AuthZ.** The proxy is the natural place to enforce client
+  identity (mTLS client certs, tokens/JWT) and per-service
+  authorization before it will proxy.
+- **NSG posture.** Expose only the ingress ports (and control-plane
+  ports if the proxy ingests xDS over the network); everything else
+  closed. Prefer per-node-type subnets/NSGs so blast radius is
+  bounded.
+
+## Phasing
+
+- **Phase P1 — MVP.** `mssf-http-proxy` ingesting the control-tier
+  snapshot (or direct SF naming), terminating external HTTP at
+  `VIP:80/443`, selecting service + primary; **HTTP/1.1 and plain
+  HTTP/2** first, stateless / singleton services.
+- **Phase P2 — gRPC + partitioning.** End-to-end HTTP/2 with
+  **trailer forwarding and streaming** (native gRPC), plus
+  `mssf-partition-key` selection (RDS `Range`/`Exact`) and
+  primary+secondary read routes.
+- **Phase P3 — hardening.** mTLS end-to-end, authN/authZ, outlier
+  ejection, metrics, retry/hedging over failover windows.
+
+Only build this when the client population actually includes
+VIP-only callers (or plain-HTTP services) the direct xDS paths
+cannot serve.
+
+## Open questions
+
+- **Service addressing convention.** Host-based
+  (`svc.app.example.com`), path-based (`/<App>/<Service>/...` like
+  SF's built-in reverse proxy), or configurable? Path-based matches
+  existing SF muscle memory; host-based is cleaner for per-service
+  TLS/authz.
+- **Config-ingest choice.** Reuse control-tier snapshot vs. direct
+  SF naming — pick per deployment, or support both behind one
+  interface?
+- **Placement.** Dedicated node type behind its own LB, or
+  co-resident with the discovery control tier? Isolation vs.
+  footprint.
+- **gRPC value-adds.** Should the proxy read `grpc-status` trailers
+  for status-aware retry/hedging during failover, or stay
+  status-agnostic? Reading trailers is more useful but couples the
+  proxy to gRPC semantics.
+- **Per-instance public IPs as an alternative.** Secondary node
+  types can get per-instance public IPs; a public client could then
+  go direct-to-replica (an xDS path) and skip the proxy. Fragile
+  (public IP per node, NSG surface, cost, primary node types
+  excluded) — niche, but it moves such callers back onto the xDS
+  scenarios.
+
+## Future work
+
+- **gRPC-Web** translation for browser clients.
+- **HTTP/JSON ↔ gRPC transcoding** (proto-descriptor driven).
+- **ORCA / LRS** load-aware balancing across replicas.
+- **Private Link ingress** as a VIP alternative for partner
+  clients.
+
+## References
+
+- [gRPC xDS over Service Fabric Naming](./GrpcXds.md) — base proposal: SF→xDS mapping, partition-key semantics, two-tier discovery, failover.
+- [gRPC xDS over Service Fabric on Azure SLB](./GrpcXdsSlb.md) — the xDS scenarios (A/C/C2) this proposal is the fallback for; Azure SLB configuration details.
+- [microsoft/service-fabric-yarp](https://github.com/microsoft/service-fabric-yarp) — prior art: an SF-naming-fed HTTP reverse proxy (no partition-key routing; Windows-only).
+- [Networking patterns for Azure Service Fabric](https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-patterns-networking) — SLB, mgmt ports, outbound requirement.

--- a/docs/proposal/HttpReverseProxy.md
+++ b/docs/proposal/HttpReverseProxy.md
@@ -8,7 +8,8 @@ Owners: mssf maintainers
 
 Relates to:
 [gRPC xDS over Service Fabric Naming](./GrpcXds.md) (the "base xDS
-proposal", accepted) and
+proposal"; like this doc, `Status: Proposal / experiment. Nothing
+shipped.`) and
 [gRPC xDS over Service Fabric on Azure SLB](./GrpcXdsSlb.md) (the
 "SLB proposal"). This doc **generalizes the SLB proposal's former
 Scenario B** — originally a gRPC-only gateway — into a generic
@@ -115,15 +116,21 @@ upgrades. None are required to proxy HTTP or native gRPC.
 1. Give **public / VIP-only** clients partition/primary-aware
    access to SF services — HTTP and gRPC alike — when SLB
    Scenarios A/C/C2 do not apply.
-2. Reuse the base proposal's **partition-key semantics** and
+2. Reuse the base proposal's **partition-key** and **replica-role**
+   semantics (`mssf-partition-key` / `mssf-partition-role`) and its
    **failover model** so routing behavior matches the in-cluster
    xDS path; only the *place* the decision is made differs.
 3. Keep the external client trivial: normal HTTP/gRPC to the VIP,
-   plus the `mssf-partition-key` header for partitioned services.
+   plus the `mssf-partition-key` header for partitioned services
+   and the optional `mssf-partition-role` header for read routing.
    No SF-specific client code.
-4. Improve on SF's built-in reverse proxy and SF-YARP: native
-   HTTP/2 + trailers for gRPC, **key-based** partition selection,
-   and Linux support.
+4. Improve on SF's built-in reverse proxy and SF-YARP where they
+   fall short: **key/role-based** partition and replica selection
+   (`mssf-partition-key` / `mssf-partition-role`), **Linux**
+   support, and **config/stack unification** with the xDS agent
+   (one xDS snapshot and runtime across the in-cluster and proxy
+   paths). HTTP/2 + gRPC proxying itself is table stakes — SF-YARP
+   already does it (see [SF-YARP](#can-sf-yarp-be-used-directly)).
 
 ## Non-Goals
 
@@ -158,13 +165,28 @@ type exposed by the SLB. It:
    [partition-key semantics](./GrpcXds.md#partition-key-semantics)
    (decimal `i64` for Int64Range, exact name for Named). Singleton
    services skip this step.
-5. **Selects the replica** — the partition's **primary** by default,
-   or a secondary for read routes — and forwards the request,
-   preserving method, headers, body, and (for gRPC) trailers and
-   streaming.
+5. **Selects the replica role** by reading `mssf-partition-role`,
+   reusing the base proposal's
+   [replica-role semantics](./GrpcXds.md#partition-key-semantics):
+   `primary` (default) / `secondary` / `any`. The header is a
+   normal HTTP header for HTTP callers and request metadata for
+   gRPC callers, so it maps to the proxy unchanged. **Absent or
+   unmatched ⇒ primary** (fail-*safe*, write-safe), matching the
+   in-cluster xDS path. It then forwards the request to a replica
+   of that role, preserving method, headers, body, and (for gRPC)
+   trailers and streaming.
 6. **Follows failover** — when the primary moves, the topology
-   update repoints the proxy; in-flight retries land on the new
-   primary.
+   update repoints the proxy to the new endpoint; the proxy then
+   **stops routing new work to the old-primary pool and establishes
+   a new pool to the new primary** (a topology repoint alone does not
+   tear down established upstream connections). The proxy is
+   **passive toward in-flight streams**: it drains the old-primary
+   pool for **new** streams only and does **not** proactively reset
+   or cancel established upstream streams. The backend app (the
+   replica that is no longer primary) is responsible for ending its
+   own stream; the proxy just propagates whatever the backend does
+   back to the client (see [Failover and retries](#failover-and-retries)).
+   Retry behavior is bounded by idempotency, not automatic.
 
 ```mermaid
 flowchart LR
@@ -189,6 +211,55 @@ It adds one in-cluster hop and a proxy tier, and gives up the "no
 data-path component" property the base proposal is proud of. It is
 the price of serving a client that can reach only a single L4 VIP,
 and of offering one generic HTTP entry point.
+
+### Failover and retries
+
+Goal 3 keeps the external client free of **SF/xDS-specific
+failover logic** — no xDS resolution, no partition/replica
+awareness, no SF-specific client code. It does **not** relieve
+the client of the *ordinary* retry and reconnection any HTTP/gRPC
+client must already handle: a `503` / `Code::Unavailable`, or a
+closed stream, is still the client's to retry or re-establish,
+exactly as with any upstream. What the proxy absorbs is only
+**SF-topology failover** — repointing to the new primary — and,
+within that, it may transparently retry only *known-idempotent*
+requests. It cannot delegate SF failover to "the caller's own
+idempotency rules" the way the base proposal does, but it also
+does not take over the caller-owned retry model — that stays
+consistent with the sibling proposal. This constrains what the
+proxy may safely do when a primary moves mid-request:
+
+- **Idempotent requests** (safe HTTP methods, or requests the
+  operator explicitly marks idempotent) may be **transparently
+  retried** against the new primary once the topology update
+  lands.
+- **Non-idempotent requests** (unary gRPC, `POST`/`PATCH` and
+  similar) **must not** be auto-retried by the proxy — a replay
+  could double-apply a write. On failover mid-request these
+  surface a `Code::Unavailable` / `503` to the client, which
+  owns the decision to retry.
+- **Long-lived gRPC streams and streaming bodies cannot be
+  transparently replayed.** A primary move is not a graceful drain
+  of a *still-valid* backend (which stops **new** streams but lets
+  in-flight ones finish); the old primary is no longer the primary,
+  so new work is repointed to the new primary. The proxy does **not**
+  proactively reset or cancel the affected streams. Instead, the
+  **backend app** owns termination: when the replica detects it is no
+  longer primary it closes the stream / ends the RPC (typically
+  surfacing `NotPrimary` / an error), or completes the in-flight
+  request if it still can. The proxy simply propagates that back to
+  the client (`Code::Unavailable` / `503` as applicable); the client
+  then re-establishes the stream against the new primary. A long-lived
+  stream pinned to the old primary therefore ends when the backend
+  closes it, not via a proxy-initiated reset, and there is no
+  proxy-side buffering that would make a stream survive a backend
+  change.
+
+So the proxy's default policy is: retry only known-idempotent
+requests, once the pool has been rebuilt to the new primary;
+surface an error for everything else. Status-aware retry/hedging
+over the failover window is Phase P3 work (see [Phasing](#phasing)),
+not an MVP guarantee.
 
 ### Config ingest
 
@@ -216,8 +287,13 @@ direct-naming is a valid MVP.
   the owning partition per the base proposal's semantics. Malformed
   or missing keys fail the same way (hard error, never a silent
   fallback to an arbitrary partition).
-- **Replica:** primary by default; secondary for explicitly marked
-  read routes.
+- **Replica role:** `mssf-partition-role` header — a normal HTTP
+  header for HTTP callers, request metadata for gRPC callers —
+  selects `primary` (default) / `secondary` (read-from-secondary)
+  / `any` (all replicas), reusing the base proposal's
+  [replica-role semantics](./GrpcXds.md#partition-key-semantics).
+  **Absent or unmatched ⇒ primary** (fail-*safe*, write-safe), so
+  read routing is opt-in and identical to the in-cluster xDS path.
 
 ## Can SF-YARP be used directly?
 
@@ -267,6 +343,7 @@ SLB. Required LB shape (illustrative ports):
 |---|---|---|---|---|
 | HTTP ingress | `VIP:80` | proxy HTTP port | TCP/HTTP | plaintext / h2c |
 | HTTPS ingress | `VIP:443` | proxy HTTPS port | TCP/HTTPS | TLS termination at the proxy |
+| gRPC ingress | `VIP:443` (h2) | proxy HTTPS port | TCP/HTTPS | **gRPC rides the HTTPS/443 listener** (ALPN `h2`); no separate frontend port. This is the "gRPC ingress rule" the [SLB proposal](./GrpcXdsSlb.md#azure-slb-configuration-required) points at. |
 
 Plus the Standard-SLB essentials from the SLB proposal apply:
 outbound rule (443), NSG opening the ingress ports inbound, and —
@@ -282,10 +359,25 @@ boundary:
 
 - **TLS termination.** The proxy terminates client TLS at the VIP
   and re-originates to the replica with mTLS inside the cluster
-  (cluster certs). For gRPC, upstream must remain HTTP/2.
+  (cluster certs). For gRPC, upstream must remain HTTP/2. **Backend
+  assumption:** this presumes the target replica accepts
+  cluster-cert mTLS on its listener. SF application services
+  commonly present their **own** service/endpoint certificate, or
+  listen plaintext; when a backend does not speak cluster-cert
+  mTLS, the proxy must be configured **per service** with the
+  expected upstream scheme (its service cert / CA to validate, or
+  explicit plaintext for trusted in-cluster networks) rather than
+  assuming every replica is a cluster-cert mTLS peer.
 - **AuthN/AuthZ.** The proxy is the natural place to enforce client
   identity (mTLS client certs, tokens/JWT) and per-service
   authorization before it will proxy.
+- **DoS / abuse surface.** A public, L4-fronted L7 proxy has a
+  real abuse surface (connection floods, slowloris/half-open,
+  HTTP/2 stream-concurrency exhaustion). The proxy enforces basic
+  **connection, stream-concurrency, and header/idle timeouts** to
+  bound this; broader volumetric protection is **delegated to the
+  upstream layer** (SLB/NSG, or a WAF/DDoS front). Application-level
+  rate limiting and quotas remain a Non-Goal (see [Non-Goals](#non-goals)).
 - **NSG posture.** Expose only the ingress ports (and control-plane
   ports if the proxy ingests xDS over the network); everything else
   closed. Prefer per-node-type subnets/NSGs so blast radius is
@@ -294,15 +386,28 @@ boundary:
 ## Phasing
 
 - **Phase P1 — MVP.** `mssf-http-proxy` ingesting the control-tier
-  snapshot (or direct SF naming), terminating external HTTP at
-  `VIP:80/443`, selecting service + primary; **HTTP/1.1 and plain
-  HTTP/2** first, stateless / singleton services.
+  snapshot (or direct SF naming), selecting service + primary;
+  **HTTP/1.1 and plain HTTP/2** first, stateless / singleton
+  services. Until P2 adds `mssf-partition-role` selection, the proxy
+  routes to the partition **primary by default** (role selection
+  deferred), so the default-primary / write-safety contract holds
+  from this first public phase. Because this phase already accepts
+  public traffic, the
+  **baseline security boundary lands here, not later**: TLS
+  termination at `VIP:443` with backend transport policy
+  (cluster-cert mTLS or the per-service upstream scheme), client
+  authN/authZ where the deployment requires it, and the
+  connection / stream-concurrency / header-idle limits from
+  [Security](#security). Plain HTTP at `VIP:80` is for
+  **private or test-only** deployments; public exposure uses `:443`.
 - **Phase P2 — gRPC + partitioning.** End-to-end HTTP/2 with
   **trailer forwarding and streaming** (native gRPC), plus
-  `mssf-partition-key` selection (RDS `Range`/`Exact`) and
-  primary+secondary read routes.
-- **Phase P3 — hardening.** mTLS end-to-end, authN/authZ, outlier
-  ejection, metrics, retry/hedging over failover windows.
+  `mssf-partition-key` / `mssf-partition-role` selection (RDS
+  `Range`/`Exact`) and primary+secondary read routes. The P1
+  security controls remain in force.
+- **Phase P3 — hardening.** Mandatory end-to-end mTLS (beyond the
+  P1 baseline), richer authZ policy, outlier ejection, metrics, and
+  status-aware retry/hedging over failover windows.
 
 Only build this when the client population actually includes
 VIP-only callers (or plain-HTTP services) the direct xDS paths

--- a/docs/proposal/HttpReverseProxy.md
+++ b/docs/proposal/HttpReverseProxy.md
@@ -2,7 +2,7 @@
 
 Status: Proposal / experiment. Nothing shipped.
 
-Date: 2026-07-17
+Date: 2026-07-17 (last updated 2026-07-20)
 
 Owners: mssf maintainers
 
@@ -348,8 +348,8 @@ SLB. Required LB shape (illustrative ports):
 Plus the Standard-SLB essentials from the SLB proposal apply:
 outbound rule (443), NSG opening the ingress ports inbound, and —
 because HTTP/2 and gRPC streams are long-lived — **keepalive tuned
-below the SLB idle timeout** (~4–5 min) so streams are not silently
-dropped. See
+below the SLB idle timeout** (**4 min** by default) so streams are not
+silently dropped. See
 [SLB proposal — Azure SLB configuration](./GrpcXdsSlb.md#azure-slb-configuration-required).
 
 ## Security

--- a/docs/proposal/HttpReverseProxy.md
+++ b/docs/proposal/HttpReverseProxy.md
@@ -53,6 +53,15 @@ partition/primary-aware HTTP reverse proxy that terminates external
 HTTP/HTTP2/gRPC behind the SLB and forwards each request to the
 correct replica.
 
+It **inherits the base proposal's
+[central design principle](./GrpcXds.md#central-design-principle)**: the
+proxy is a **thin, passive** discovery/routing component that exposes
+only what SF Naming provides and invents no correctness logic, while
+the **backend replica owns correctness** — it enforces write-safety
+(`NotPrimary`) and, on failover, terminates its own in-flight stream
+rather than relying on the proxy to sever it (see
+[Failover and retries](#failover-and-retries)).
+
 ## Is this xDS?
 
 **No — and that is why it lives in its own doc.** The defining
@@ -186,7 +195,8 @@ type exposed by the SLB. It:
    replica that is no longer primary) is responsible for ending its
    own stream; the proxy just propagates whatever the backend does
    back to the client (see [Failover and retries](#failover-and-retries)).
-   Retry behavior is bounded by idempotency, not automatic.
+   Retry is **client-owned**; the proxy does not retry on the client's
+   behalf.
 
 ```mermaid
 flowchart LR
@@ -220,24 +230,28 @@ awareness, no SF-specific client code. It does **not** relieve
 the client of the *ordinary* retry and reconnection any HTTP/gRPC
 client must already handle: a `503` / `Code::Unavailable`, or a
 closed stream, is still the client's to retry or re-establish,
-exactly as with any upstream. What the proxy absorbs is only
-**SF-topology failover** — repointing to the new primary — and,
-within that, it may transparently retry only *known-idempotent*
-requests. It cannot delegate SF failover to "the caller's own
-idempotency rules" the way the base proposal does, but it also
-does not take over the caller-owned retry model — that stays
-consistent with the sibling proposal. This constrains what the
-proxy may safely do when a primary moves mid-request:
+exactly as with any upstream. Per the
+[central design principle](./GrpcXds.md#central-design-principle) the
+proxy stays **thin and passive**: what it absorbs is only
+**SF-topology failover** — repointing **new** work to the new
+primary — and **retry and idempotency remain client-owned**, exactly
+as on the base xDS path ("the client adapts"). The proxy cannot know
+an application's idempotency semantics, so it does **not** replay
+requests or buffer request bodies on the client's behalf. This is what
+the proxy does when a primary moves mid-request:
 
-- **Idempotent requests** (safe HTTP methods, or requests the
-  operator explicitly marks idempotent) may be **transparently
-  retried** against the new primary once the topology update
-  lands.
-- **Non-idempotent requests** (unary gRPC, `POST`/`PATCH` and
-  similar) **must not** be auto-retried by the proxy — a replay
-  could double-apply a write. On failover mid-request these
-  surface a `Code::Unavailable` / `503` to the client, which
-  owns the decision to retry.
+- **New work follows the topology.** Once the topology update lands,
+  the proxy routes **new** requests — and any request not yet
+  dispatched upstream — to the new primary. This is routing to the
+  current endpoint, **not** a replay of an already-started request: no
+  idempotency assumption and no body buffering are involved.
+- **In-flight requests surface their error.** A request already
+  dispatched to the old primary when it stops being primary surfaces a
+  `Code::Unavailable` / `503` to the client, which **owns the decision
+  to retry** per its own idempotency rules. The proxy does **not**
+  auto-retry it — a blind replay could double-apply a write, and only
+  the client (or the replica) knows whether the operation is safe to
+  repeat.
 - **Long-lived gRPC streams and streaming bodies cannot be
   transparently replayed.** A primary move is not a graceful drain
   of a *still-valid* backend (which stops **new** streams but lets
@@ -255,11 +269,28 @@ proxy may safely do when a primary moves mid-request:
   proxy-side buffering that would make a stream survive a backend
   change.
 
-So the proxy's default policy is: retry only known-idempotent
-requests, once the pool has been rebuilt to the new primary;
-surface an error for everything else. Status-aware retry/hedging
-over the failover window is Phase P3 work (see [Phasing](#phasing)),
-not an MVP guarantee.
+  **This is a hard backend-app contract, not a best-effort
+  expectation.** Because the proxy stays passive (it issues **no**
+  GOAWAY/RST toward in-flight streams on failover — see the
+  [passive-failover decision](#the-proxy)), write-safety for in-flight
+  streams depends **entirely** on the backend: a replica that is
+  demoted **MUST stop serving as primary and terminate its own
+  in-flight stream(s)** promptly (reject/complete-and-close, surfacing
+  `NotPrimary`), rather than continuing to serve writes after
+  demotion. A backend that only checks role at connection start and
+  keeps serving an established stream would keep accepting writes on a
+  no-longer-primary replica — the proxy does not and will not sever it.
+  This contract is therefore a **conformance requirement** for any
+  write-bearing service placed behind the proxy, and should be covered
+  by a conformance test: demote a primary mid-stream and assert the
+  backend terminates the stream (the proxy remains passive throughout).
+
+So the proxy's default policy is: repoint **new** work to the new
+primary once the pool has been rebuilt, and surface an error for
+anything already in flight — the client retries per its own
+idempotency rules. Any future status-aware behavior stays
+subordinate to that client-owned model (see [Phasing](#phasing)); the
+proxy does not hedge or retry on the client's behalf.
 
 ### Config ingest
 
@@ -415,20 +446,30 @@ boundary:
   from this first public phase. Because this phase already accepts
   public traffic, the
   **baseline security boundary lands here, not later**: TLS
-  termination at `VIP:443` with backend transport policy
-  (cluster-cert mTLS or the per-service upstream scheme), client
-  authN/authZ where the deployment requires it, and the
+  termination at `VIP:443` with a **narrowly-scoped dedicated proxy
+  upstream identity** (not a full cluster cert) speaking mTLS or the
+  per-service upstream scheme, **mandatory client authN/authZ for
+  public exposure (the proxy ships closed — no anonymous public
+  request reaches a backend by default)**, and the
   connection / stream-concurrency / header-idle limits from
-  [Security](#security). Plain HTTP at `VIP:80` is for
-  **private or test-only** deployments; public exposure uses `:443`.
+  [Security](#security). Plain HTTP at `VIP:80`, and any plaintext
+  upstream, are for **private or test-only** deployments; public
+  exposure uses `:443` and never forwards over a plaintext upstream.
 - **Phase P2 — gRPC + partitioning.** End-to-end HTTP/2 with
   **trailer forwarding and streaming** (native gRPC), plus
   `mssf-partition-key` / `mssf-partition-role` selection (RDS
-  `Range`/`Exact`) and primary+secondary read routes. The P1
+  `Range`/`Exact`) and primary+secondary read routes (`secondary` spans
+  `{S1, S2, …}`, `any` spans `{P, S1, S2, …}`, using the base proposal's
+  `P`/`S1, S2, …` replica-role notation). The P1
   security controls remain in force.
 - **Phase P3 — hardening.** Mandatory end-to-end mTLS (beyond the
-  P1 baseline), richer authZ policy, outlier ejection, metrics, and
-  status-aware retry/hedging over failover windows.
+  P1 baseline), richer authZ policy, optional outlier ejection (a
+  convenience that does not supersede naming-driven failover or the
+  replica's `NotPrimary` write-safety) and metrics, and — if pursued —
+  status-awareness used only to repoint /
+  surface failures faster over failover windows. Retry and hedging
+  stay **client-owned**; the proxy does not retry or hedge on the
+  client's behalf.
 
 Only build this when the client population actually includes
 VIP-only callers (or plain-HTTP services) the direct xDS paths
@@ -448,9 +489,9 @@ cannot serve.
   co-resident with the discovery control tier? Isolation vs.
   footprint.
 - **gRPC value-adds.** Should the proxy read `grpc-status` trailers
-  for status-aware retry/hedging during failover, or stay
-  status-agnostic? Reading trailers is more useful but couples the
-  proxy to gRPC semantics.
+  to repoint / surface failover faster (retry and hedging stay
+  client-owned either way), or stay status-agnostic? Reading trailers
+  is more useful but couples the proxy to gRPC semantics.
 - **Per-instance public IPs as an alternative.** Secondary node
   types can get per-instance public IPs; a public client could then
   go direct-to-replica (an xDS path) and skip the proxy. Fragile


### PR DESCRIPTION
## Summary

Adds three design proposals under `docs/proposal/` for exposing Service Fabric
services through xDS-based gRPC discovery and an HTTP reverse proxy, then
iteratively hardens them through multiple high-level review cycles (including
society-of-thought multi-model reviews) and aligns every document to a single
**central design principle**.

Documentation-only — no code changes, nothing shipped. All three docs carry
`Status: Proposal / experiment. Nothing shipped.`

## Central design principle

Everything in these proposals is designed around one governing principle with
two facets:

1. **Thin, naming-only layer** — the xDS agent / reverse proxy surfaces only
   what SF Naming natively provides (discovery + routing). No invented
   aggregation, persistence, health synthesis, buffering, or retry-on-behalf.
   When the layer lacks a behavior, the client adapts.
2. **Fat replica** — each replica owns its own correctness: write-safety /
   `NotPrimary`, terminating its own stream on role loss, role-change handling,
   and idempotency — exactly as SF services are written today.

## Documents

- **`GrpcXds.md`** — base proposal: vanilla xDS gRPC channel over SF Naming;
  establishes the central design principle, replica-role model, and
  `mssf-partition-role` / `mssf-partition-key` selection semantics.
- **`GrpcXdsSlb.md`** — extends the base to Azure Standard Load Balancer;
  `@slb` honors only `role=any` (flat VIP), topology-aware paths honor the full
  naming-provided role set.
- **`HttpReverseProxy.md`** — generalizes the former gRPC-only gateway into a
  generic SF-naming-aware HTTP reverse proxy (HTTP/1.1, HTTP/2, gRPC).

## Key design decisions

- Naming-only replica-role model; removed invented `failover` role and
  P0/P1 priority-cluster aggregation.
- Introduced **P / S1, S2 …** (primary/secondary) and **N1, N2 …** replica-role
  notation.
- Dropped bespoke singleton durable-recovery; clients re-resolve via SF Naming
  on restart, same as any SF service.
- Passive proxy failover: no in-flight stream reset; the backend replica
  terminates its own stream.
- Security/robustness hardening from society-of-thought review: per-identity
  ADS authz, discovery→relay mTLS gate, proxy blast-radius containment,
  rejection of partitioned services in flat-VIP scenarios.
- `mssf-partition-key` fails **closed**; `mssf-partition-role` fails **safe to
  primary** with first-match ordering.

## Testing

Documentation-only change; no build or tests apply.

## Breaking changes

None.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
