### PR TITLE
[Prototype] mssf-net: serve multiple SF services from one xDS/ADS server

### DIFF
--- a/crates/libs/net/README.md
+++ b/crates/libs/net/README.md
@@ -2,8 +2,8 @@
 
 Experimental Service Fabric naming → gRPC xDS (ADS) mapping.
 
-Exposes an SF stateful service through a standard [xDS][xds] control plane, so a
-**stock gRPC client** can reach the service's current primary replica — and keep
+Exposes SF stateful services through a standard [xDS][xds] control plane, so a
+**stock gRPC client** can reach a service's current primary replica — and keep
 reaching it across failover — with **no Service Fabric code in the client**.
 
 > **Experimental — no stable API guarantee.** Items may change or be removed in
@@ -108,6 +108,35 @@ lifetime to an existing scope — an SF replica's `close(cancellation_token)`, f
 instance — construct it with
 `AdsService::with_cancellation(mapping, source, token)`.
 
+### Serving several services from one control plane
+
+Clients subscribe by resource name, so one ADS server can publish any number of
+services. Register them and hand the registry to the server:
+
+```rust
+use mssf_net::{AdsService, ServiceRegistry};
+
+let registry = ServiceRegistry::builder()
+    .add(orders_mapping, orders_source.clone())?
+    .add(inventory_mapping, inventory_source.clone())?
+    .build()?;
+
+let server = AdsService::from_registry(registry)
+    .serve_on_ephemeral_loopback()
+    .await?;
+```
+
+Clients then target `xds:///fabric:/MyApp/Orders` and
+`xds:///fabric:/MyApp/Inventory` through the *same* bootstrap, and each service's
+failovers are pushed independently. Duplicate xDS names are rejected by `add`,
+so a configuration mistake fails at startup rather than silently shadowing a
+route.
+
+Each `FabricEndpointSource` still owns its own `FabricClient` and notification
+filter, so this consolidates ports and streams, not SF-side naming load.
+`AdsService::from_registry_with_cancellation(registry, token)` is the
+cancellation-aware form.
+
 ### Endpoint addresses need an interpreter
 
 An SF endpoint address is a **service-defined string**. It may be `host:port`, a
@@ -148,11 +177,13 @@ See `tests/scripted_ads.rs` for the full end-to-end version.
 
 Deliberately a prototype:
 
-- One mapped service per ADS server (serving N services means N servers).
 - Stateful **singleton partition, primary only** — no partition-key routing and
   no secondaries.
+- One `FabricClient` and one notification filter per registered service; there
+  is no shared SF-facing tier.
 - No TLS/mTLS, RDS, delta xDS, federation, or load reporting.
 - No agent/relay deployment shape; the ADS server is hosted in-process.
+- The registry is fixed at build time — no dynamic add/remove while serving.
 - Depends on the pre-release `tonic-xds` crate.
 
 Design and rationale: [`docs/design/XdsNamingDesign.md`](../../../docs/design/XdsNamingDesign.md).

--- a/crates/libs/net/README.md
+++ b/crates/libs/net/README.md
@@ -111,29 +111,46 @@ instance — construct it with
 ### Serving several services from one control plane
 
 Clients subscribe by resource name, so one ADS server can publish any number of
-services. Register them and hand the registry to the server:
+services. Build **one** `FabricNaming` — one `FabricClient` for the whole
+process — and derive a source per service from it:
 
 ```rust
-use mssf_net::{AdsService, ServiceRegistry};
+use mssf_net::{AdsService, FabricNaming, ServiceRegistry};
+
+let naming = FabricNaming::new(vec![WString::from("localhost:19000")])?;
+
+let orders = naming.source_for(&orders_mapping, Duration::from_secs(10)).await?;
+let inventory = naming.source_for(&inventory_mapping, Duration::from_secs(10)).await?;
 
 let registry = ServiceRegistry::builder()
-    .add(orders_mapping, orders_source.clone())?
-    .add(inventory_mapping, inventory_source.clone())?
+    .add(orders_mapping, orders.clone())?
+    .add(inventory_mapping, inventory.clone())?
     .build()?;
 
 let server = AdsService::from_registry(registry)
     .serve_on_ephemeral_loopback()
     .await?;
+
+// ... serve ...
+
+server.shutdown().await?;
+orders.shutdown().await;     // drops its filter and notification route
+inventory.shutdown().await;
+naming.shutdown().await;     // releases the one FabricClient
 ```
 
 Clients then target `xds:///fabric:/MyApp/Orders` and
 `xds:///fabric:/MyApp/Inventory` through the *same* bootstrap, and each service's
-failovers are pushed independently. Duplicate xDS names are rejected by `add`,
-so a configuration mistake fails at startup rather than silently shadowing a
-route.
+failovers are pushed independently.
 
-Each `FabricEndpointSource` still owns its own `FabricClient` and notification
-filter, so this consolidates ports and streams, not SF-side naming load.
+Sharing the client matters: SF installs the notification callback when the
+client is **built**, so a client per service would also mean a naming connection
+and a callback per service. `FabricNaming` installs one callback that dispatches
+by service name instead. Registering the same SF service twice is rejected —
+two sources would race for the same notifications.
+
+Duplicate xDS names are likewise rejected by `add`, so a configuration mistake
+fails at startup rather than silently shadowing a route.
 `AdsService::from_registry_with_cancellation(registry, token)` is the
 cancellation-aware form.
 
@@ -179,8 +196,6 @@ Deliberately a prototype:
 
 - Stateful **singleton partition, primary only** — no partition-key routing and
   no secondaries.
-- One `FabricClient` and one notification filter per registered service; there
-  is no shared SF-facing tier.
 - No TLS/mTLS, RDS, delta xDS, federation, or load reporting.
 - No agent/relay deployment shape; the ADS server is hosted in-process.
 - The registry is fixed at build time — no dynamic add/remove while serving.

--- a/crates/libs/net/src/ads.rs
+++ b/crates/libs/net/src/ads.rs
@@ -260,19 +260,33 @@ impl AdsService {
         type_url: &str,
         resource_names: &[String],
     ) -> Vec<Any> {
-        let wants =
-            |name: &str| resource_names.is_empty() || resource_names.iter().any(|n| n == name);
+        // An empty request set is xDS's wildcard: everything of this type.
+        // Otherwise resolve each requested name through the registry's
+        // `(type_url, name)` index, so name resolution has exactly one
+        // implementation. Sorting restores registry order; dedup tolerates a
+        // client naming the same resource twice.
+        let selected: Vec<usize> = if resource_names.is_empty() {
+            (0..registry.len()).collect()
+        } else {
+            let mut selected: Vec<usize> = resource_names
+                .iter()
+                .filter_map(|name| registry.index_of(type_url, name))
+                .collect();
+            selected.sort_unstable();
+            selected.dedup();
+            selected
+        };
 
         let mut out = Vec::new();
-        for (entry, snapshot) in registry.entries().iter().zip(snapshots) {
-            let mapping = entry.mapping();
+        for i in selected {
+            let mapping = registry.entries()[i].mapping();
+            let snapshot = &snapshots[i];
             match type_url {
                 LISTENER_TYPE_URL => {
                     // A missing service withholds the Listener. Because
                     // Listeners are "all resources required" in SotW, omission
                     // is a deletion.
-                    if matches!(snapshot, EndpointSnapshot::NotFound) || !wants(mapping.xds_name())
-                    {
+                    if matches!(snapshot, EndpointSnapshot::NotFound) {
                         continue;
                     }
                     out.push(any(
@@ -281,9 +295,7 @@ impl AdsService {
                     ));
                 }
                 CLUSTER_TYPE_URL => {
-                    if matches!(snapshot, EndpointSnapshot::NotFound)
-                        || !wants(&mapping.cluster_name())
-                    {
+                    if matches!(snapshot, EndpointSnapshot::NotFound) {
                         continue;
                     }
                     out.push(any(
@@ -292,9 +304,6 @@ impl AdsService {
                     ));
                 }
                 ENDPOINT_TYPE_URL => {
-                    if !wants(&mapping.cluster_name()) {
-                        continue;
-                    }
                     out.push(any(
                         ENDPOINT_TYPE_URL,
                         build_endpoints(mapping, snapshot).encode_to_vec(),
@@ -314,24 +323,63 @@ fn any(type_url: &str, value: Vec<u8>) -> Any {
     }
 }
 
-/// Await the next endpoint change across every registered service.
+/// Await the next endpoint change across the still-live registered services.
 ///
-/// Returns the entry index and its new snapshot, or `None` once a source has
-/// been dropped (nothing can revive it, and `changed()` would then complete
-/// immediately forever).
+/// Returns the index of the entry that changed.
 ///
-/// This exists as a standalone future rather than inline in the `select!`
-/// because the fan-in borrows `receivers` mutably for as long as it is alive;
-/// resolving the new snapshot here releases that borrow before the caller's
-/// handler runs. `changed()` is cancel-safe, so rebuilding the set on every
+/// A source whose sender has been dropped is retired from the fan-in rather
+/// than ending the stream. This matters far more with several services than it
+/// did with one: a closed receiver reports "changed" immediately and forever,
+/// and because every reconnecting stream re-subscribes to the same dead
+/// channel, one torn-down source would otherwise break every *other* service
+/// on the server, permanently.
+///
+/// A retired source is deliberately **not** published as `NotFound`. A dropped
+/// sender is a host-process lifecycle event, not naming reporting that the
+/// service is gone, and `NotFound` is a permanent deletion on the client. The
+/// last published state is served instead.
+///
+/// If every source is gone this never resolves, leaving the `select!`'s other
+/// branches -- cancellation above all -- free to run.
+///
+/// This is a standalone future rather than inline in the `select!` because the
+/// fan-in borrows `receivers` mutably for as long as it is alive; resolving
+/// here releases that borrow before the caller's handler runs.
+/// `watch::Receiver::changed` is cancel-safe, so rebuilding the set on every
 /// call is correct.
 async fn next_endpoint_change(
     receivers: &mut [watch::Receiver<EndpointSnapshot>],
-) -> Option<(usize, EndpointSnapshot)> {
-    let (result, which, _) =
-        select_all(receivers.iter_mut().map(|rx| Box::pin(rx.changed()))).await;
-    result.ok()?;
-    Some((which, receivers[which].borrow_and_update().clone()))
+    alive: &mut [bool],
+) -> usize {
+    loop {
+        let pending: Vec<_> = receivers
+            .iter_mut()
+            .enumerate()
+            .filter(|(i, _)| alive[*i])
+            .map(|(i, rx)| Box::pin(async move { (i, rx.changed().await) }))
+            .collect();
+
+        if pending.is_empty() {
+            std::future::pending::<()>().await;
+        }
+
+        let ((which, result), _, _) = select_all(pending).await;
+        if result.is_ok() {
+            receivers[which].borrow_and_update();
+            return which;
+        }
+
+        tracing::debug!(
+            entry = which,
+            "endpoint source dropped; retiring it from the fan-in"
+        );
+        alive[which] = false;
+    }
+}
+
+/// Every registered service's current snapshot, in registry order.
+fn current_snapshots(readers: &[watch::Receiver<EndpointSnapshot>]) -> Vec<EndpointSnapshot> {
+    readers.iter().map(|rx| rx.borrow().clone()).collect()
 }
 
 /// Whether a request is a new subscription (needing a response) rather than an
@@ -374,17 +422,22 @@ impl AggregatedDiscoveryService for AdsService {
             .iter()
             .map(|e| e.source().subscribe())
             .collect();
+        // Independent clones used only for reading. `changed()` needs `&mut`,
+        // and that borrow lives for as long as the fan-in future does -- which
+        // is the whole `select!` -- so no arm can read through the same
+        // handles. Reading through clones keeps every response built from the
+        // live value rather than a cached copy that could drift.
+        let readers: Vec<watch::Receiver<EndpointSnapshot>> = receivers.to_vec();
+        let mut alive: Vec<bool> = vec![true; receivers.len()];
         let token = self.token.clone();
 
         let outbound = async_stream::try_stream! {
             let mut version = Versioning(0);
-            // Latest known snapshot per registry entry, kept in registry order.
-            // Held separately from the receivers so the change handler does not
-            // have to re-borrow them while the fan-in future is alive.
-            let mut snapshots: Vec<EndpointSnapshot> = receivers
-                .iter_mut()
-                .map(|rx| rx.borrow_and_update().clone())
-                .collect();
+            // Mark the seeded values seen, so the fan-in does not immediately
+            // report a change the client is about to be told about anyway.
+            for rx in receivers.iter_mut() {
+                rx.borrow_and_update();
+            }
             // Resource names this stream has subscribed to, per type URL.
             // Tracked for every type (not just EDS) so a state change can be
             // pushed to whatever the client actually asked for.
@@ -461,6 +514,7 @@ impl AggregatedDiscoveryService for AdsService {
                             continue;
                         }
 
+                        let snapshots = current_snapshots(&readers);
                         let resources = Self::resources_for(
                             &registry, &snapshots, &req.type_url, &req.resource_names,
                         );
@@ -475,17 +529,12 @@ impl AggregatedDiscoveryService for AdsService {
                     }
 
                     // Some service's endpoint state changed.
-                    changed = next_endpoint_change(&mut receivers) => {
-                        let Some((which, snapshot)) = changed else {
-                            // A source was dropped; nothing more will ever be
-                            // pushed for it and the fan-in would spin on the
-                            // closed channel. Nothing can revive it, so end the
-                            // stream rather than serve a frozen view.
-                            tracing::debug!("ads stream ending: an endpoint source was dropped");
-                            break;
-                        };
-                        tracing::debug!(entry = which, ?snapshot, "pushing updated resources");
-                        snapshots[which] = snapshot;
+                    which = next_endpoint_change(&mut receivers, &mut alive) => {
+                        let snapshots = current_snapshots(&readers);
+                        tracing::debug!(
+                            entry = which, snapshot = ?snapshots[which], "pushing updated resources",
+                        );
+
                         // Push all subscribed types, not just EDS. A transition
                         // into or out of `NotFound` changes whether the Listener
                         // and Cluster exist at all, and a SotW client never
@@ -494,20 +543,38 @@ impl AggregatedDiscoveryService for AdsService {
                         // deleted listener even after the service came back.
                         //
                         // LDS and CDS carry the *whole* subscribed set because
-                        // they are "all resources required"; EDS is tracked
-                        // per-resource, so it carries only the cluster that
-                        // actually changed.
-                        let changed_cluster = registry.entries()[which].mapping().cluster_name();
+                        // they are "all resources required": a response that
+                        // omitted a subscribed Listener would delete it on the
+                        // client, so pushing only the service that changed
+                        // would break every other service on this stream. EDS
+                        // is tracked per-resource, so it carries only the
+                        // cluster that actually changed.
+                        let changed_mapping = registry.entries()[which].mapping();
+                        let changed_listener = changed_mapping.xds_name().to_string();
+                        let changed_cluster = changed_mapping.cluster_name();
+
                         for type_url in [LISTENER_TYPE_URL, CLUSTER_TYPE_URL, ENDPOINT_TYPE_URL] {
                             let Some(names) = subscriptions.get(type_url) else { continue };
+
+                            // An empty request set is the wildcard, and always
+                            // wants the update. Otherwise a stream that is not
+                            // subscribed to the changed service has nothing new
+                            // to learn, and re-sending its unchanged set would
+                            // make every service's churn cost every client a
+                            // response.
+                            let changed_name = if type_url == LISTENER_TYPE_URL {
+                                &changed_listener
+                            } else {
+                                &changed_cluster
+                            };
+                            if !names.is_empty() && !names.contains(changed_name) {
+                                continue;
+                            }
+
                             let names: Vec<String> = if type_url == ENDPOINT_TYPE_URL {
-                                // An empty request set means "wildcard", so it
-                                // must be narrowed explicitly, not passed on.
-                                if names.is_empty() || names.contains(&changed_cluster) {
-                                    vec![changed_cluster.clone()]
-                                } else {
-                                    continue;
-                                }
+                                // Narrow the wildcard explicitly: only the
+                                // cluster that moved needs a new assignment.
+                                vec![changed_cluster.clone()]
                             } else {
                                 names.clone()
                             };

--- a/crates/libs/net/src/ads.rs
+++ b/crates/libs/net/src/ads.rs
@@ -6,7 +6,7 @@
 //! State-of-the-World Aggregated Discovery Service (ADS).
 //!
 //! Serves the resource graph built by [`crate::resources`] and *pushes* a fresh
-//! `ClusterLoadAssignment` to every connected stream whenever the mapped
+//! `ClusterLoadAssignment` to every connected stream whenever a mapped
 //! service's authoritative endpoint changes.
 //!
 //! Delta/incremental xDS is not implemented; State-of-the-World is sufficient
@@ -25,6 +25,7 @@ use envoy_types::pb::envoy::service::discovery::v3::{
 };
 use envoy_types::pb::google::protobuf::Any;
 use futures::Stream;
+use futures::future::select_all;
 use prost::Message;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -32,20 +33,20 @@ use tonic::{Request, Response, Status};
 
 use crate::config::XdsMapping;
 use crate::endpoint::{EndpointSnapshot, EndpointSource};
+use crate::registry::ServiceRegistry;
 use crate::resources::{
     CLUSTER_TYPE_URL, ENDPOINT_TYPE_URL, LISTENER_TYPE_URL, build_cluster, build_endpoints,
     build_listener,
 };
 
-/// Serves one [`XdsMapping`] over ADS, backed by an [`EndpointSource`].
+/// Serves a [`ServiceRegistry`] over ADS, backed by each entry's
+/// [`EndpointSource`].
 ///
-/// **One mapping per service instance.** Serving several SF services requires
-/// several `AdsService`s on separate ports. This is a limitation of this crate,
-/// not of xDS — see the "Known limitations" section of
-/// `docs/design/XdsNamingDesign.md` for what lifting it would involve.
+/// One server publishes any number of services; clients subscribe by resource
+/// name. Use [`AdsService::new`] for the single-service case, or
+/// [`AdsService::from_registry`] to serve several.
 pub struct AdsService {
-    mapping: Arc<XdsMapping>,
-    source: Arc<dyn EndpointSource>,
+    registry: Arc<ServiceRegistry>,
     /// Cancelling ends every open ADS stream and stops the server.
     ///
     /// An ADS stream is long-lived by design, and `tonic`'s graceful shutdown
@@ -57,12 +58,12 @@ pub struct AdsService {
 }
 
 impl AdsService {
-    /// Create the service with its own cancellation token.
+    /// Create a single-service instance with its own cancellation token.
     pub fn new(mapping: XdsMapping, source: Arc<dyn EndpointSource>) -> Self {
         Self::with_cancellation(mapping, source, CancellationToken::new())
     }
 
-    /// Create the service driven by a caller-supplied cancellation token.
+    /// Create a single-service instance driven by a caller-supplied token.
     ///
     /// Use this to tie the server's lifetime to an existing scope — for
     /// example an SF service's `close(cancellation_token)`, so the ADS server
@@ -75,11 +76,28 @@ impl AdsService {
         source: Arc<dyn EndpointSource>,
         token: CancellationToken,
     ) -> Self {
+        Self::from_registry_with_cancellation(ServiceRegistry::single(mapping, source), token)
+    }
+
+    /// Serve every service in `registry`, with a fresh cancellation token.
+    pub fn from_registry(registry: ServiceRegistry) -> Self {
+        Self::from_registry_with_cancellation(registry, CancellationToken::new())
+    }
+
+    /// Serve every service in `registry`, driven by a caller-supplied token.
+    pub fn from_registry_with_cancellation(
+        registry: ServiceRegistry,
+        token: CancellationToken,
+    ) -> Self {
         Self {
-            mapping: Arc::new(mapping),
-            source,
+            registry: Arc::new(registry),
             token,
         }
+    }
+
+    /// The services this server publishes.
+    pub fn registry(&self) -> &ServiceRegistry {
+        &self.registry
     }
 
     /// A clone of the token that stops this service.
@@ -223,53 +241,69 @@ impl AdsService {
         })
     }
 
-    /// Build the resources for one type URL at a given endpoint state.
+    /// Build the resources for one type URL across every registered service.
     ///
-    /// Returns an empty vector when the request names a resource this mapping
-    /// does not serve, which the client reports as resource-not-found. The
-    /// Listener is likewise withheld when the service does not exist.
+    /// `snapshots` is parallel to `registry.entries()`.
+    ///
+    /// Returns an empty vector when the request names only resources this
+    /// server does not publish, which the client reports as resource-not-found.
+    /// A `NotFound` entry withholds *its own* Listener and Cluster and leaves
+    /// the others untouched.
+    ///
+    /// The full subscribed set is always returned for a given type. Listeners
+    /// and Clusters are "all resources required" in State-of-the-World, so
+    /// answering with a subset silently **deletes** the omitted ones on the
+    /// client.
     fn resources_for(
-        mapping: &XdsMapping,
-        snapshot: &EndpointSnapshot,
+        registry: &ServiceRegistry,
+        snapshots: &[EndpointSnapshot],
         type_url: &str,
         resource_names: &[String],
     ) -> Vec<Any> {
         let wants =
             |name: &str| resource_names.is_empty() || resource_names.iter().any(|n| n == name);
 
-        match type_url {
-            LISTENER_TYPE_URL => {
-                // A missing service withholds the Listener. Because Listeners
-                // are "all resources required" in SotW, omission is a deletion.
-                if matches!(snapshot, EndpointSnapshot::NotFound) || !wants(mapping.xds_name()) {
-                    return vec![];
+        let mut out = Vec::new();
+        for (entry, snapshot) in registry.entries().iter().zip(snapshots) {
+            let mapping = entry.mapping();
+            match type_url {
+                LISTENER_TYPE_URL => {
+                    // A missing service withholds the Listener. Because
+                    // Listeners are "all resources required" in SotW, omission
+                    // is a deletion.
+                    if matches!(snapshot, EndpointSnapshot::NotFound) || !wants(mapping.xds_name())
+                    {
+                        continue;
+                    }
+                    out.push(any(
+                        LISTENER_TYPE_URL,
+                        build_listener(mapping).encode_to_vec(),
+                    ));
                 }
-                vec![any(
-                    LISTENER_TYPE_URL,
-                    build_listener(mapping).encode_to_vec(),
-                )]
-            }
-            CLUSTER_TYPE_URL => {
-                if matches!(snapshot, EndpointSnapshot::NotFound) || !wants(&mapping.cluster_name())
-                {
-                    return vec![];
+                CLUSTER_TYPE_URL => {
+                    if matches!(snapshot, EndpointSnapshot::NotFound)
+                        || !wants(&mapping.cluster_name())
+                    {
+                        continue;
+                    }
+                    out.push(any(
+                        CLUSTER_TYPE_URL,
+                        build_cluster(mapping).encode_to_vec(),
+                    ));
                 }
-                vec![any(
-                    CLUSTER_TYPE_URL,
-                    build_cluster(mapping).encode_to_vec(),
-                )]
-            }
-            ENDPOINT_TYPE_URL => {
-                if !wants(&mapping.cluster_name()) {
-                    return vec![];
+                ENDPOINT_TYPE_URL => {
+                    if !wants(&mapping.cluster_name()) {
+                        continue;
+                    }
+                    out.push(any(
+                        ENDPOINT_TYPE_URL,
+                        build_endpoints(mapping, snapshot).encode_to_vec(),
+                    ));
                 }
-                vec![any(
-                    ENDPOINT_TYPE_URL,
-                    build_endpoints(mapping, snapshot).encode_to_vec(),
-                )]
+                _ => return vec![],
             }
-            _ => vec![],
         }
+        out
     }
 }
 
@@ -278,6 +312,26 @@ fn any(type_url: &str, value: Vec<u8>) -> Any {
         type_url: type_url.to_string(),
         value,
     }
+}
+
+/// Await the next endpoint change across every registered service.
+///
+/// Returns the entry index and its new snapshot, or `None` once a source has
+/// been dropped (nothing can revive it, and `changed()` would then complete
+/// immediately forever).
+///
+/// This exists as a standalone future rather than inline in the `select!`
+/// because the fan-in borrows `receivers` mutably for as long as it is alive;
+/// resolving the new snapshot here releases that borrow before the caller's
+/// handler runs. `changed()` is cancel-safe, so rebuilding the set on every
+/// call is correct.
+async fn next_endpoint_change(
+    receivers: &mut [watch::Receiver<EndpointSnapshot>],
+) -> Option<(usize, EndpointSnapshot)> {
+    let (result, which, _) =
+        select_all(receivers.iter_mut().map(|rx| Box::pin(rx.changed()))).await;
+    result.ok()?;
+    Some((which, receivers[which].borrow_and_update().clone()))
 }
 
 /// Whether a request is a new subscription (needing a response) rather than an
@@ -314,12 +368,23 @@ impl AggregatedDiscoveryService for AdsService {
         request: Request<tonic::Streaming<DiscoveryRequest>>,
     ) -> Result<Response<Self::StreamAggregatedResourcesStream>, Status> {
         let mut inbound = request.into_inner();
-        let mapping = self.mapping.clone();
-        let mut rx: watch::Receiver<EndpointSnapshot> = self.source.subscribe();
+        let registry = self.registry.clone();
+        let mut receivers: Vec<watch::Receiver<EndpointSnapshot>> = registry
+            .entries()
+            .iter()
+            .map(|e| e.source().subscribe())
+            .collect();
         let token = self.token.clone();
 
         let outbound = async_stream::try_stream! {
             let mut version = Versioning(0);
+            // Latest known snapshot per registry entry, kept in registry order.
+            // Held separately from the receivers so the change handler does not
+            // have to re-borrow them while the fan-in future is alive.
+            let mut snapshots: Vec<EndpointSnapshot> = receivers
+                .iter_mut()
+                .map(|rx| rx.borrow_and_update().clone())
+                .collect();
             // Resource names this stream has subscribed to, per type URL.
             // Tracked for every type (not just EDS) so a state change can be
             // pushed to whatever the client actually asked for.
@@ -396,9 +461,8 @@ impl AggregatedDiscoveryService for AdsService {
                             continue;
                         }
 
-                        let snapshot = rx.borrow().clone();
                         let resources = Self::resources_for(
-                            &mapping, &snapshot, &req.type_url, &req.resource_names,
+                            &registry, &snapshots, &req.type_url, &req.resource_names,
                         );
                         let (v, nonce) = version.next();
                         yield DiscoveryResponse {
@@ -410,25 +474,45 @@ impl AggregatedDiscoveryService for AdsService {
                         };
                     }
 
-                    // The endpoint state changed: push to every subscribed type.
-                    changed = rx.changed() => {
-                        if changed.is_err() {
-                            // Source dropped; nothing more will ever be pushed.
+                    // Some service's endpoint state changed.
+                    changed = next_endpoint_change(&mut receivers) => {
+                        let Some((which, snapshot)) = changed else {
+                            // A source was dropped; nothing more will ever be
+                            // pushed for it and the fan-in would spin on the
+                            // closed channel. Nothing can revive it, so end the
+                            // stream rather than serve a frozen view.
+                            tracing::debug!("ads stream ending: an endpoint source was dropped");
                             break;
-                        }
-                        let snapshot = rx.borrow_and_update().clone();
-                        tracing::debug!(?snapshot, "pushing updated resources");
-
+                        };
+                        tracing::debug!(entry = which, ?snapshot, "pushing updated resources");
+                        snapshots[which] = snapshot;
                         // Push all subscribed types, not just EDS. A transition
                         // into or out of `NotFound` changes whether the Listener
                         // and Cluster exist at all, and a SotW client never
                         // re-requests LDS on its own -- so an EDS-only push would
                         // leave a client that saw `NotFound` with a permanently
                         // deleted listener even after the service came back.
+                        //
+                        // LDS and CDS carry the *whole* subscribed set because
+                        // they are "all resources required"; EDS is tracked
+                        // per-resource, so it carries only the cluster that
+                        // actually changed.
+                        let changed_cluster = registry.entries()[which].mapping().cluster_name();
                         for type_url in [LISTENER_TYPE_URL, CLUSTER_TYPE_URL, ENDPOINT_TYPE_URL] {
                             let Some(names) = subscriptions.get(type_url) else { continue };
+                            let names: Vec<String> = if type_url == ENDPOINT_TYPE_URL {
+                                // An empty request set means "wildcard", so it
+                                // must be narrowed explicitly, not passed on.
+                                if names.is_empty() || names.contains(&changed_cluster) {
+                                    vec![changed_cluster.clone()]
+                                } else {
+                                    continue;
+                                }
+                            } else {
+                                names.clone()
+                            };
                             let resources = Self::resources_for(
-                                &mapping, &snapshot, type_url, names,
+                                &registry, &snapshots, type_url, &names,
                             );
                             let (v, nonce) = version.next();
                             yield DiscoveryResponse {
@@ -512,26 +596,36 @@ mod tests {
         XdsMapping::new("reflection", "fabric:/App/Svc", host_port_interpreter()).unwrap()
     }
 
+    fn scripted() -> Arc<dyn EndpointSource> {
+        ScriptedEndpointSource::new(EndpointSnapshot::NoPrimary).0
+    }
+
+    /// `resources_for` over a one-service registry, which is what most of these
+    /// cases are about. Multi-service behaviour is covered separately below.
+    fn resources_for_one(snap: &EndpointSnapshot, type_url: &str, names: &[String]) -> Vec<Any> {
+        let registry = ServiceRegistry::single(mapping(), scripted());
+        AdsService::resources_for(&registry, std::slice::from_ref(snap), type_url, names)
+    }
+
     fn decode_cla(resources: &[Any]) -> ClusterLoadAssignment {
         ClusterLoadAssignment::decode(resources[0].value.as_slice()).unwrap()
     }
 
     #[test]
     fn serves_listener_cluster_and_endpoints_for_wildcard_requests() {
-        let m = mapping();
         let snap = EndpointSnapshot::Primary(HostPort::new("h", 1));
 
-        let l = AdsService::resources_for(&m, &snap, LISTENER_TYPE_URL, &[]);
+        let l = resources_for_one(&snap, LISTENER_TYPE_URL, &[]);
         assert_eq!(l.len(), 1);
         assert_eq!(
             Listener::decode(l[0].value.as_slice()).unwrap().name,
             "reflection"
         );
 
-        let c = AdsService::resources_for(&m, &snap, CLUSTER_TYPE_URL, &[]);
+        let c = resources_for_one(&snap, CLUSTER_TYPE_URL, &[]);
         assert_eq!(c.len(), 1);
 
-        let e = AdsService::resources_for(&m, &snap, ENDPOINT_TYPE_URL, &[]);
+        let e = resources_for_one(&snap, ENDPOINT_TYPE_URL, &[]);
         assert_eq!(decode_cla(&e).endpoints.len(), 1);
     }
 
@@ -539,39 +633,30 @@ mod tests {
     /// reports as resource-not-found rather than hanging.
     #[test]
     fn unknown_resource_name_yields_empty_response() {
-        let m = mapping();
         let snap = EndpointSnapshot::Primary(HostPort::new("h", 1));
         let names = vec!["some-other-service".to_string()];
 
-        assert!(AdsService::resources_for(&m, &snap, LISTENER_TYPE_URL, &names).is_empty());
-        assert!(AdsService::resources_for(&m, &snap, CLUSTER_TYPE_URL, &names).is_empty());
-        assert!(AdsService::resources_for(&m, &snap, ENDPOINT_TYPE_URL, &names).is_empty());
+        assert!(resources_for_one(&snap, LISTENER_TYPE_URL, &names).is_empty());
+        assert!(resources_for_one(&snap, CLUSTER_TYPE_URL, &names).is_empty());
+        assert!(resources_for_one(&snap, ENDPOINT_TYPE_URL, &names).is_empty());
     }
 
     /// NotFound withholds the Listener; because Listeners are "all resources
     /// required" in SotW, omission is a deletion on the client.
     #[test]
     fn not_found_withholds_the_listener() {
-        let m = mapping();
         let snap = EndpointSnapshot::NotFound;
-        assert!(AdsService::resources_for(&m, &snap, LISTENER_TYPE_URL, &[]).is_empty());
+        assert!(resources_for_one(&snap, LISTENER_TYPE_URL, &[]).is_empty());
     }
 
     /// NoPrimary keeps a valid Listener and Cluster but empties the endpoints,
     /// so the client reports "no ready endpoints" rather than a missing route.
     #[test]
     fn no_primary_keeps_listener_but_empties_endpoints() {
-        let m = mapping();
         let snap = EndpointSnapshot::NoPrimary;
-        assert_eq!(
-            AdsService::resources_for(&m, &snap, LISTENER_TYPE_URL, &[]).len(),
-            1
-        );
-        assert_eq!(
-            AdsService::resources_for(&m, &snap, CLUSTER_TYPE_URL, &[]).len(),
-            1
-        );
-        let e = AdsService::resources_for(&m, &snap, ENDPOINT_TYPE_URL, &[]);
+        assert_eq!(resources_for_one(&snap, LISTENER_TYPE_URL, &[]).len(), 1);
+        assert_eq!(resources_for_one(&snap, CLUSTER_TYPE_URL, &[]).len(), 1);
+        let e = resources_for_one(&snap, ENDPOINT_TYPE_URL, &[]);
         assert_eq!(e.len(), 1, "the EDS resource must still exist");
         assert!(
             decode_cla(&e).endpoints.is_empty(),
@@ -581,9 +666,94 @@ mod tests {
 
     #[test]
     fn unknown_type_url_yields_nothing() {
-        let m = mapping();
         let snap = EndpointSnapshot::NoPrimary;
-        assert!(AdsService::resources_for(&m, &snap, "type.googleapis.com/nope", &[]).is_empty());
+        assert!(resources_for_one(&snap, "type.googleapis.com/nope", &[]).is_empty());
+    }
+
+    // ---- multi-service -------------------------------------------------
+
+    fn two_service_registry() -> ServiceRegistry {
+        ServiceRegistry::builder()
+            .add(
+                XdsMapping::new("a", "fabric:/App/A", host_port_interpreter()).unwrap(),
+                scripted(),
+            )
+            .unwrap()
+            .add(
+                XdsMapping::new("b", "fabric:/App/B", host_port_interpreter()).unwrap(),
+                scripted(),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    fn listener_names(resources: &[Any]) -> Vec<String> {
+        resources
+            .iter()
+            .map(|r| Listener::decode(r.value.as_slice()).unwrap().name)
+            .collect()
+    }
+
+    /// A wildcard request must return *every* registered Listener: Listeners
+    /// are "all resources required" in SotW, so returning a subset would delete
+    /// the rest on the client.
+    #[test]
+    fn wildcard_returns_every_registered_service() {
+        let registry = two_service_registry();
+        let snaps = vec![
+            EndpointSnapshot::Primary(HostPort::new("ha", 1)),
+            EndpointSnapshot::Primary(HostPort::new("hb", 2)),
+        ];
+
+        let l = AdsService::resources_for(&registry, &snaps, LISTENER_TYPE_URL, &[]);
+        assert_eq!(listener_names(&l), vec!["a", "b"]);
+        assert_eq!(
+            AdsService::resources_for(&registry, &snaps, CLUSTER_TYPE_URL, &[]).len(),
+            2
+        );
+        assert_eq!(
+            AdsService::resources_for(&registry, &snaps, ENDPOINT_TYPE_URL, &[]).len(),
+            2
+        );
+    }
+
+    #[test]
+    fn a_named_request_returns_only_that_service() {
+        let registry = two_service_registry();
+        let snaps = vec![
+            EndpointSnapshot::Primary(HostPort::new("ha", 1)),
+            EndpointSnapshot::Primary(HostPort::new("hb", 2)),
+        ];
+
+        let l = AdsService::resources_for(&registry, &snaps, LISTENER_TYPE_URL, &["b".to_string()]);
+        assert_eq!(listener_names(&l), vec!["b"]);
+
+        let e = AdsService::resources_for(
+            &registry,
+            &snaps,
+            ENDPOINT_TYPE_URL,
+            &["a-primary".to_string()],
+        );
+        assert_eq!(e.len(), 1);
+        assert_eq!(decode_cla(&e).cluster_name, "a-primary");
+    }
+
+    /// One service disappearing must not take its neighbours' routing with it.
+    #[test]
+    fn not_found_on_one_service_leaves_the_other_intact() {
+        let registry = two_service_registry();
+        let snaps = vec![
+            EndpointSnapshot::NotFound,
+            EndpointSnapshot::Primary(HostPort::new("hb", 2)),
+        ];
+
+        let l = AdsService::resources_for(&registry, &snaps, LISTENER_TYPE_URL, &[]);
+        assert_eq!(listener_names(&l), vec!["b"]);
+        assert_eq!(
+            AdsService::resources_for(&registry, &snaps, CLUSTER_TYPE_URL, &[]).len(),
+            1
+        );
     }
 
     #[test]
@@ -601,8 +771,8 @@ mod tests {
         let (src, handle) = ScriptedEndpointSource::new(EndpointSnapshot::NoPrimary);
         let svc = AdsService::new(mapping(), src.clone());
 
-        let mut a = svc.source.subscribe();
-        let mut b = svc.source.subscribe();
+        let mut a = svc.registry().entries()[0].source().subscribe();
+        let mut b = svc.registry().entries()[0].source().subscribe();
 
         handle.set(EndpointSnapshot::Primary(HostPort::new("moved", 9)));
 
@@ -724,28 +894,14 @@ mod tests {
     /// broken forever once the service comes back.
     #[test]
     fn recovering_from_not_found_requires_listener_and_cluster_again() {
-        let m = mapping();
-
         // While NotFound, LDS and CDS are empty.
-        assert!(
-            AdsService::resources_for(&m, &EndpointSnapshot::NotFound, LISTENER_TYPE_URL, &[])
-                .is_empty()
-        );
-        assert!(
-            AdsService::resources_for(&m, &EndpointSnapshot::NotFound, CLUSTER_TYPE_URL, &[])
-                .is_empty()
-        );
+        assert!(resources_for_one(&EndpointSnapshot::NotFound, LISTENER_TYPE_URL, &[]).is_empty());
+        assert!(resources_for_one(&EndpointSnapshot::NotFound, CLUSTER_TYPE_URL, &[]).is_empty());
 
         // Once a primary exists they must be populated again -- which only
         // reaches the client if the push covers these type URLs.
         let snap = EndpointSnapshot::Primary(HostPort::new("h", 1));
-        assert_eq!(
-            AdsService::resources_for(&m, &snap, LISTENER_TYPE_URL, &[]).len(),
-            1
-        );
-        assert_eq!(
-            AdsService::resources_for(&m, &snap, CLUSTER_TYPE_URL, &[]).len(),
-            1
-        );
+        assert_eq!(resources_for_one(&snap, LISTENER_TYPE_URL, &[]).len(), 1);
+        assert_eq!(resources_for_one(&snap, CLUSTER_TYPE_URL, &[]).len(), 1);
     }
 }

--- a/crates/libs/net/src/fabric.rs
+++ b/crates/libs/net/src/fabric.rs
@@ -5,18 +5,24 @@
 
 //! Service Fabric-backed [`EndpointSource`].
 //!
-//! Owns its own `FabricClient`, registers its own notification filter, and
-//! publishes the mapped service's current stateful-primary endpoint.
+//! [`FabricNaming`] owns **one** `FabricClient` for the whole process and
+//! dispatches its notifications to the per-service [`FabricEndpointSource`]s
+//! built from it. Registering N services therefore costs one naming
+//! connection and one notification callback, not N of each — which is the
+//! point of serving many services from one ADS server in the first place.
 //!
 //! # COM callback constraints
 //!
 //! The SF notification callback is **synchronous** and runs on an SF COM
 //! thread. It must not await, block, or do heavy work. This module therefore
-//! does the absolute minimum there — a non-blocking `send_replace` of the raw
-//! notification — and interprets addresses on a Tokio task instead.
+//! does the absolute minimum there — a read-lock, one hash lookup and a
+//! non-blocking `send_replace` of the raw notification — and interprets
+//! addresses on a Tokio task instead.
 
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use mssf_core::client::svc_mgmt_client::{
@@ -100,6 +106,10 @@ fn snapshot_from_endpoints(
 }
 
 /// An [`EndpointSource`] backed by Service Fabric naming.
+///
+/// Build these through [`FabricNaming::source_for`] so several services share
+/// one `FabricClient`. [`FabricEndpointSource::new`] remains for the
+/// single-service case, where sharing has nothing to share with.
 pub struct FabricEndpointSource {
     rx: watch::Receiver<EndpointSnapshot>,
     /// Held behind interior mutability because `shutdown` takes `Arc<Self>`
@@ -108,26 +118,144 @@ pub struct FabricEndpointSource {
 }
 
 struct Releasable {
-    client: FabricClient,
+    /// The shared naming host. Released here only when this source created it.
+    naming: Arc<FabricNaming>,
+    /// Whether `shutdown` must also release `naming`.
+    owns_naming: bool,
+    /// The SF service URI, used to drop this source's notification route.
+    service_name: String,
     filter: FilterIdHandle,
     /// Stops the notification-interpreting task.
     task_token: CancellationToken,
     task: tokio::task::JoinHandle<()>,
 }
 
-impl FabricEndpointSource {
-    /// Build a source for `mapping`, connecting to `connection_strings`.
+/// Where a raw notification is handed off to, per service.
+///
+/// Generic over the payload purely so the routing rules can be unit-tested
+/// without constructing a `ServiceNotification`, which wraps a COM object.
+struct Routes<T> {
+    by_service: HashMap<String, Arc<watch::Sender<Option<T>>>>,
+}
+
+impl<T> Default for Routes<T> {
+    fn default() -> Self {
+        Self {
+            by_service: HashMap::new(),
+        }
+    }
+}
+
+impl<T> Routes<T> {
+    /// Claim `service_name`, rejecting a second claim on the same service.
     ///
-    /// Registers the notification callback and the service filter **before**
-    /// the initial resolve, so a change occurring during startup is not lost.
-    /// The initial resolve then seeds the state, and is applied only if no
+    /// Two sources for one SF service would each register a filter and then
+    /// race for the same notifications, with only one of them winning the
+    /// route. Refusing is better than silently starving one of them.
+    fn insert(
+        &mut self,
+        service_name: String,
+        tx: Arc<watch::Sender<Option<T>>>,
+    ) -> Result<(), Error> {
+        match self.by_service.entry(service_name) {
+            Entry::Occupied(e) => Err(Error::Config(format!(
+                "service {:?} already has an endpoint source on this naming client",
+                e.key()
+            ))),
+            Entry::Vacant(e) => {
+                e.insert(tx);
+                Ok(())
+            }
+        }
+    }
+
+    fn remove(&mut self, service_name: &str) {
+        self.by_service.remove(service_name);
+    }
+
+    fn get(&self, service_name: &str) -> Option<Arc<watch::Sender<Option<T>>>> {
+        self.by_service.get(service_name).cloned()
+    }
+}
+
+/// One `FabricClient` shared by every service this process maps.
+///
+/// SF installs the notification callback when the client is *built*, so a
+/// shared client needs a callback that dispatches by service name rather than
+/// one closure per service. That dispatch table is the whole of this type.
+///
+/// Teardown order is: every [`FabricEndpointSource`] first, then
+/// [`FabricNaming::shutdown`], which releases the client.
+pub struct FabricNaming {
+    /// `None` once released by [`FabricNaming::shutdown`].
+    client: Mutex<Option<FabricClient>>,
+    routes: Arc<RwLock<Routes<ServiceNotification>>>,
+}
+
+impl FabricNaming {
+    /// Connect to naming, installing the dispatching notification callback.
+    pub fn new(connection_strings: Vec<mssf_core::WString>) -> Result<Arc<Self>, Error> {
+        let routes: Arc<RwLock<Routes<ServiceNotification>>> =
+            Arc::new(RwLock::new(Routes::<ServiceNotification>::default()));
+        let cb_routes = routes.clone();
+
+        let client = FabricClient::builder()
+            .with_connection_strings(connection_strings)
+            .with_on_service_notification(move |n: ServiceNotification| {
+                // COM thread: no await, no blocking, no parsing. A poisoned
+                // lock must not panic here either -- unwinding through a COM
+                // callback is undefined behaviour -- so the guard is recovered
+                // instead. The map is only ever fully-formed under the lock.
+                let name = n.service_name.to_string();
+                let route = cb_routes
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get(&name);
+                if let Some(tx) = route {
+                    tx.send_replace(Some(n));
+                }
+                Ok(())
+            })
+            .build()
+            .map_err(|e| Error::Source(format!("failed to build FabricClient: {e:?}")))?;
+
+        Ok(Arc::new(Self {
+            client: Mutex::new(Some(client)),
+            routes,
+        }))
+    }
+
+    /// A handle to the shared client, or an error once it has been released.
+    fn client(&self) -> Result<FabricClient, Error> {
+        self.client
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| Error::Source("naming client has been shut down".into()))
+    }
+
+    /// Build an [`EndpointSource`] for `mapping` on this shared client.
+    ///
+    /// Registers the notification route and the SF filter **before** the
+    /// initial resolve, so a change occurring during startup is not lost. The
+    /// initial resolve then seeds the state, and is applied only if no
     /// notification has already produced one — a later notification must never
     /// be overwritten by an older resolve result.
-    pub async fn new(
+    pub async fn source_for(
+        self: &Arc<Self>,
         mapping: &XdsMapping,
-        connection_strings: Vec<mssf_core::WString>,
         timeout: Duration,
-    ) -> Result<Arc<Self>, Error> {
+    ) -> Result<Arc<FabricEndpointSource>, Error> {
+        self.build_source(mapping, timeout, false).await
+    }
+
+    async fn build_source(
+        self: &Arc<Self>,
+        mapping: &XdsMapping,
+        timeout: Duration,
+        owns_naming: bool,
+    ) -> Result<Arc<FabricEndpointSource>, Error> {
+        let client = self.client()?;
         let (tx, rx) = watch::channel(EndpointSnapshot::NoPrimary);
         let tx = Arc::new(tx);
 
@@ -136,27 +264,20 @@ impl FabricEndpointSource {
         let (raw_tx, mut raw_rx) = watch::channel::<Option<ServiceNotification>>(None);
         let raw_tx = Arc::new(raw_tx);
 
-        let cb_tx = raw_tx.clone();
         let uri = Uri::from(mapping.service_uri());
-        let want = mapping.service_uri().to_string();
+        let service_name = mapping.service_uri().to_string();
 
-        // 1. Install the callback while building the client. This must happen
-        //    at construction time; it cannot be added later.
-        let client = FabricClient::builder()
-            .with_connection_strings(connection_strings)
-            .with_on_service_notification(move |n: ServiceNotification| {
-                // COM thread: no await, no blocking, no parsing.
-                if n.service_name.to_string() == want {
-                    cb_tx.send_replace(Some(n));
-                }
-                Ok(())
-            })
-            .build()
-            .map_err(|e| Error::Source(format!("failed to build FabricClient: {e:?}")))?;
+        // 1. Claim the route before anything can deliver to it.
+        self.routes
+            .write()
+            .unwrap()
+            .insert(service_name.clone(), raw_tx)?;
 
         // 2. Register the filter for exactly this service, primary endpoints
-        //    only. Done before the seeding resolve.
-        let filter = client
+        //    only. Done before the seeding resolve. On failure the route must
+        //    be released again, or the name stays claimed by a source that
+        //    was never returned.
+        let filter = match client
             .get_service_manager()
             .register_service_notification_filter(
                 &ServiceNotificationFilterDescription {
@@ -167,7 +288,15 @@ impl FabricEndpointSource {
                 None,
             )
             .await
-            .map_err(|e| Error::Source(format!("failed to register notification filter: {e:?}")))?;
+        {
+            Ok(filter) => filter,
+            Err(e) => {
+                self.routes.write().unwrap().remove(&service_name);
+                return Err(Error::Source(format!(
+                    "failed to register notification filter: {e:?}"
+                )));
+            }
+        };
 
         // 3. Drive interpretation of notifications on a Tokio task.
         let interp = mapping.interpreter().clone();
@@ -177,9 +306,8 @@ impl FabricEndpointSource {
         let published = Arc::new(AtomicBool::new(false));
         let task_published = published.clone();
         // Stopping the task is explicit rather than inferred. It would in fact
-        // exit on its own once every sender drops (the callback closure owned by
-        // the FabricClient holds the last one), but that couples teardown to a
-        // non-obvious ownership chain; an owned token plus the JoinHandle lets
+        // exit on its own once every sender drops, but that couples teardown to
+        // a non-obvious ownership chain; an owned token plus the JoinHandle lets
         // `shutdown` stop and *await* it directly.
         let task_token = CancellationToken::new();
         let loop_token = task_token.clone();
@@ -227,7 +355,9 @@ impl FabricEndpointSource {
         //    (the notification won, we skip), or it is not, in which case the
         //    task has not published yet and its later send correctly supersedes
         //    ours.
-        let seeded = Self::initial_resolve(&client, &uri, mapping.interpreter(), timeout).await;
+        let seeded =
+            FabricEndpointSource::initial_resolve(&client, &uri, mapping.interpreter(), timeout)
+                .await;
         tx.send_if_modified(|current| {
             if published.load(Ordering::SeqCst) {
                 false
@@ -237,15 +367,51 @@ impl FabricEndpointSource {
             }
         });
 
-        Ok(Arc::new(Self {
+        Ok(Arc::new(FabricEndpointSource {
             rx,
             releasable: Mutex::new(Some(Releasable {
-                client,
+                naming: self.clone(),
+                owns_naming,
+                service_name,
                 filter,
                 task_token,
                 task,
             })),
         }))
+    }
+
+    /// Release the shared `FabricClient`.
+    ///
+    /// Call **after** every [`FabricEndpointSource`] built from this naming has
+    /// been shut down. The delay before returning works around issue #184.
+    pub async fn shutdown(self: Arc<Self>) {
+        let client = self.client.lock().unwrap().take();
+        if client.is_none() {
+            return;
+        }
+        drop(client);
+        tokio::time::sleep(DROP_DELAY).await;
+    }
+}
+
+impl FabricEndpointSource {
+    /// Build a source for a single `mapping` on its own `FabricClient`.
+    ///
+    /// Convenience for the one-service case. When mapping several services,
+    /// build one [`FabricNaming`] and call [`FabricNaming::source_for`] per
+    /// service instead: SF installs the notification callback when the client
+    /// is built, so a client per service also means a naming connection and a
+    /// callback per service.
+    ///
+    /// The returned source owns its naming host and releases it on
+    /// [`EndpointSource::shutdown`].
+    pub async fn new(
+        mapping: &XdsMapping,
+        connection_strings: Vec<mssf_core::WString>,
+        timeout: Duration,
+    ) -> Result<Arc<Self>, Error> {
+        let naming = FabricNaming::new(connection_strings)?;
+        naming.build_source(mapping, timeout, true).await
     }
 
     async fn initial_resolve(
@@ -276,17 +442,22 @@ impl EndpointSource for FabricEndpointSource {
         self.rx.clone()
     }
 
-    /// Stop the interpretation task, unregister the filter, release the client,
-    /// then delay.
+    /// Stop the interpretation task, unregister the filter, drop the
+    /// notification route, and release the naming host if this source owns it.
     ///
     /// The ordering matters: the task is stopped and awaited first so nothing
     /// publishes during teardown, unregistration is async (so it cannot happen
-    /// in `Drop`), and the delay before the client is fully released works
-    /// around issue #184.
+    /// in `Drop`), and the route is dropped last so a notification arriving
+    /// mid-teardown has nowhere to go rather than reaching a half-torn source.
+    ///
+    /// When several sources share a [`FabricNaming`], the client outlives them
+    /// all and the caller releases it with [`FabricNaming::shutdown`].
     async fn shutdown(self: Arc<Self>) {
         let taken = self.releasable.lock().unwrap().take();
         let Some(Releasable {
-            client,
+            naming,
+            owns_naming,
+            service_name,
             filter,
             task_token,
             task,
@@ -302,16 +473,26 @@ impl EndpointSource for FabricEndpointSource {
             tracing::warn!(error = ?e, "notification task did not complete cleanly");
         }
 
-        if let Err(e) = client
-            .get_service_manager()
-            .unregister_service_notification_filter(filter, Duration::from_secs(10), None)
-            .await
-        {
-            tracing::warn!(error = ?e, "best-effort filter unregistration failed");
+        match naming.client() {
+            Ok(client) => {
+                if let Err(e) = client
+                    .get_service_manager()
+                    .unregister_service_notification_filter(filter, Duration::from_secs(10), None)
+                    .await
+                {
+                    tracing::warn!(error = ?e, "best-effort filter unregistration failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "naming already released; skipping unregistration")
+            }
         }
 
-        drop(client);
-        tokio::time::sleep(DROP_DELAY).await;
+        naming.routes.write().unwrap().remove(&service_name);
+
+        if owns_naming {
+            naming.shutdown().await;
+        }
     }
 }
 
@@ -324,6 +505,69 @@ mod tests {
 
     fn err(code: ErrorCode) -> mssf_core::Error {
         code.into()
+    }
+
+    /// The routing table is generic over its payload so the rules can be
+    /// checked with no `FabricClient` and no COM object in sight.
+    mod routes {
+        use super::*;
+
+        fn tx() -> Arc<watch::Sender<Option<String>>> {
+            Arc::new(watch::channel(None).0)
+        }
+
+        #[test]
+        fn dispatches_by_service_name() {
+            let mut routes = Routes::<String>::default();
+            let a = tx();
+            let b = tx();
+            routes.insert("fabric:/App/A".into(), a.clone()).unwrap();
+            routes.insert("fabric:/App/B".into(), b.clone()).unwrap();
+
+            let mut rx_a = a.subscribe();
+            let mut rx_b = b.subscribe();
+
+            routes
+                .get("fabric:/App/A")
+                .expect("route for A")
+                .send_replace(Some("for-a".into()));
+
+            assert_eq!(rx_a.borrow_and_update().clone(), Some("for-a".to_string()));
+            assert_eq!(
+                rx_b.borrow_and_update().clone(),
+                None,
+                "a notification for A must not reach B"
+            );
+        }
+
+        /// Two sources for one service would each register a filter and then
+        /// race for the same notifications, with only one winning the route.
+        #[test]
+        fn rejects_a_second_source_for_the_same_service() {
+            let mut routes = Routes::<String>::default();
+            routes.insert("fabric:/App/A".into(), tx()).unwrap();
+            let err = routes.insert("fabric:/App/A".into(), tx()).unwrap_err();
+            assert!(err.to_string().contains("already has an endpoint source"));
+        }
+
+        #[test]
+        fn an_unknown_service_has_no_route() {
+            let routes = Routes::<String>::default();
+            assert!(routes.get("fabric:/App/Nope").is_none());
+        }
+
+        /// Removal frees the name, so a service can be re-registered after its
+        /// source is shut down.
+        #[test]
+        fn removal_frees_the_name() {
+            let mut routes = Routes::<String>::default();
+            routes.insert("fabric:/App/A".into(), tx()).unwrap();
+            routes.remove("fabric:/App/A");
+            assert!(routes.get("fabric:/App/A").is_none());
+            routes
+                .insert("fabric:/App/A".into(), tx())
+                .expect("the name must be reusable once removed");
+        }
     }
 
     #[test]

--- a/crates/libs/net/src/lib.rs
+++ b/crates/libs/net/src/lib.rs
@@ -23,6 +23,9 @@
 //! - [`config`] — the per-service mapping configuration.
 //! - [`registry`] — the set of services one ADS server publishes.
 //!
+//! - [`fabric`] — `FabricNaming`, one shared `FabricClient`, and the SF-backed
+//!   [`FabricEndpointSource`].
+//!
 //! # Experimental
 //!
 //! This crate is experimental and there is **no stable API guarantee**: items
@@ -50,5 +53,5 @@ pub use crate::endpoint::{
     EndpointSnapshot, EndpointSource, HostPort, ScriptedEndpointHandle, ScriptedEndpointSource,
 };
 pub use crate::error::Error;
-pub use crate::fabric::{FabricEndpointSource, classify_resolve_error};
+pub use crate::fabric::{FabricEndpointSource, FabricNaming, classify_resolve_error};
 pub use crate::registry::{RegisteredService, ServiceRegistry, ServiceRegistryBuilder};

--- a/crates/libs/net/src/lib.rs
+++ b/crates/libs/net/src/lib.rs
@@ -5,10 +5,13 @@
 
 //! Service Fabric naming → gRPC xDS (ADS) mapping.
 //!
-//! Exposes one configured SF stateful singleton service through an Envoy v3
+//! Exposes configured SF stateful singleton services through an Envoy v3
 //! State-of-the-World [Aggregated Discovery Service][ads] so that a stock
-//! xDS-capable gRPC client (e.g. [`tonic-xds`]) can reach the service's
+//! xDS-capable gRPC client (e.g. [`tonic-xds`]) can reach a service's
 //! current primary replica with **no SF-specific client code**.
+//!
+//! One ADS server can publish any number of services: clients subscribe by
+//! resource name, and [`registry::ServiceRegistry`] holds the set.
 //!
 //! The crate publishes the minimum resource chain such a client accepts:
 //! LDS (with an *inline* `RouteConfiguration`) → CDS → EDS. RDS is not used.
@@ -17,7 +20,8 @@
 //!
 //! - [`endpoint`] — SF-independent endpoint state and the subscription contract.
 //! - [`address`] — pluggable interpretation of the opaque SF endpoint address.
-//! - [`config`] — the one-service mapping configuration.
+//! - [`config`] — the per-service mapping configuration.
+//! - [`registry`] — the set of services one ADS server publishes.
 //!
 //! # Experimental
 //!
@@ -36,6 +40,7 @@ pub mod config;
 pub mod endpoint;
 pub mod error;
 pub mod fabric;
+pub mod registry;
 pub mod resources;
 
 pub use crate::address::{AddressError, AddressInterpreter, host_port_interpreter};
@@ -46,3 +51,4 @@ pub use crate::endpoint::{
 };
 pub use crate::error::Error;
 pub use crate::fabric::{FabricEndpointSource, classify_resolve_error};
+pub use crate::registry::{RegisteredService, ServiceRegistry, ServiceRegistryBuilder};

--- a/crates/libs/net/src/registry.rs
+++ b/crates/libs/net/src/registry.rs
@@ -1,0 +1,294 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+//! The set of services one ADS server publishes.
+//!
+//! xDS is designed for a single control plane serving many resources: clients
+//! subscribe by resource name, so one ADS server can back an arbitrary number
+//! of Service Fabric services. This module holds that set and the index used
+//! to answer a subscription.
+//!
+//! # Why the index is keyed by `(type_url, name)`
+//!
+//! Every entry contributes two names: a Listener named after
+//! [`XdsMapping::xds_name`] and a Cluster named after
+//! [`XdsMapping::cluster_name`] (which EDS reuses). A map keyed by the bare
+//! string would conflate the Listener of a mapping named `x-primary` with the
+//! Cluster derived from a *different* mapping named `x`. Including the type URL
+//! in the key makes that impossible.
+//!
+//! Consequently the only uniqueness rule the builder has to enforce is that
+//! `xds_name` is unique across entries: cluster names are derived from it by
+//! appending a constant suffix, which is injective, so distinct xDS names can
+//! never yield colliding cluster names.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::config::XdsMapping;
+use crate::endpoint::EndpointSource;
+use crate::error::Error;
+use crate::resources::{CLUSTER_TYPE_URL, ENDPOINT_TYPE_URL, LISTENER_TYPE_URL};
+
+/// One mapped service: its xDS naming and the source of its endpoint state.
+#[derive(Clone)]
+pub struct RegisteredService {
+    mapping: Arc<XdsMapping>,
+    source: Arc<dyn EndpointSource>,
+}
+
+impl RegisteredService {
+    /// The service's xDS naming configuration.
+    pub fn mapping(&self) -> &XdsMapping {
+        &self.mapping
+    }
+
+    /// The service's endpoint source.
+    pub fn source(&self) -> &Arc<dyn EndpointSource> {
+        &self.source
+    }
+}
+
+impl std::fmt::Debug for RegisteredService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisteredService")
+            .field("mapping", &self.mapping)
+            .finish_non_exhaustive()
+    }
+}
+
+/// An immutable set of services served by one [`crate::ads::AdsService`].
+///
+/// Build one with [`ServiceRegistry::builder`], or use
+/// [`ServiceRegistry::single`] for the one-service case.
+#[derive(Clone, Debug)]
+pub struct ServiceRegistry {
+    entries: Vec<RegisteredService>,
+    /// `(type_url, resource_name)` → index into `entries`.
+    index: HashMap<(&'static str, String), usize>,
+}
+
+impl ServiceRegistry {
+    /// Start building a registry.
+    pub fn builder() -> ServiceRegistryBuilder {
+        ServiceRegistryBuilder::default()
+    }
+
+    /// A registry holding exactly one service.
+    ///
+    /// Cannot fail: a single entry has nothing to collide with, and the mapping
+    /// was already validated when it was constructed.
+    pub fn single(mapping: XdsMapping, source: Arc<dyn EndpointSource>) -> Self {
+        let mut index = HashMap::new();
+        insert_names(&mut index, &mapping, 0);
+        Self {
+            entries: vec![RegisteredService {
+                mapping: Arc::new(mapping),
+                source,
+            }],
+            index,
+        }
+    }
+
+    /// The registered services, in registration order.
+    pub fn entries(&self) -> &[RegisteredService] {
+        &self.entries
+    }
+
+    /// How many services are registered. Always at least one.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Always `false`: a registry cannot be built empty.
+    ///
+    /// Present because clippy asks for it alongside [`ServiceRegistry::len`],
+    /// and because callers reading `len()` should not have to know the
+    /// invariant to satisfy the lint.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Which entry owns `name` for the given resource type, if any.
+    pub fn index_of(&self, type_url: &str, name: &str) -> Option<usize> {
+        // The key borrows a `&'static str` for the type URL, so look up by the
+        // canonical constant rather than the caller's (possibly unknown) string.
+        let type_url = canonical_type_url(type_url)?;
+        self.index.get(&(type_url, name.to_string())).copied()
+    }
+}
+
+/// Accumulates services, rejecting name collisions as they are added.
+#[derive(Default, Debug)]
+pub struct ServiceRegistryBuilder {
+    entries: Vec<RegisteredService>,
+    index: HashMap<(&'static str, String), usize>,
+}
+
+impl ServiceRegistryBuilder {
+    /// Register one service.
+    ///
+    /// Fails if `mapping`'s xDS name is already registered. Validating here
+    /// rather than at serve time keeps a configuration mistake cheap to
+    /// diagnose: a duplicate would otherwise silently shadow a resource on a
+    /// live stream, which looks like a routing bug rather than a config bug.
+    pub fn add(
+        mut self,
+        mapping: XdsMapping,
+        source: Arc<dyn EndpointSource>,
+    ) -> Result<Self, Error> {
+        let position = self.entries.len();
+        for (type_url, name) in names_of(&mapping) {
+            if self.index.contains_key(&(type_url, name.clone())) {
+                return Err(Error::Config(format!(
+                    "duplicate xds resource name {name:?} for type {type_url}"
+                )));
+            }
+        }
+        insert_names(&mut self.index, &mapping, position);
+        self.entries.push(RegisteredService {
+            mapping: Arc::new(mapping),
+            source,
+        });
+        Ok(self)
+    }
+
+    /// Finish, rejecting an empty registry.
+    ///
+    /// An ADS server with nothing to serve would answer every subscription with
+    /// an empty response, which a client reports as a resource-not-found — a
+    /// confusing way to learn that nothing was registered.
+    pub fn build(self) -> Result<ServiceRegistry, Error> {
+        if self.entries.is_empty() {
+            return Err(Error::Config(
+                "an ads registry must contain at least one service".into(),
+            ));
+        }
+        Ok(ServiceRegistry {
+            entries: self.entries,
+            index: self.index,
+        })
+    }
+}
+
+/// The `(type_url, name)` pairs one mapping answers to.
+///
+/// EDS is looked up by the *cluster* name, because a cluster without an
+/// explicit EDS service name falls back to its own name.
+fn names_of(mapping: &XdsMapping) -> [(&'static str, String); 3] {
+    [
+        (LISTENER_TYPE_URL, mapping.xds_name().to_string()),
+        (CLUSTER_TYPE_URL, mapping.cluster_name()),
+        (ENDPOINT_TYPE_URL, mapping.cluster_name()),
+    ]
+}
+
+fn insert_names(
+    index: &mut HashMap<(&'static str, String), usize>,
+    mapping: &XdsMapping,
+    position: usize,
+) {
+    for key in names_of(mapping) {
+        index.insert(key, position);
+    }
+}
+
+/// Map a request's type URL onto the crate's `'static` constant.
+fn canonical_type_url(type_url: &str) -> Option<&'static str> {
+    match type_url {
+        LISTENER_TYPE_URL => Some(LISTENER_TYPE_URL),
+        CLUSTER_TYPE_URL => Some(CLUSTER_TYPE_URL),
+        ENDPOINT_TYPE_URL => Some(ENDPOINT_TYPE_URL),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::address::host_port_interpreter;
+    use crate::endpoint::{EndpointSnapshot, ScriptedEndpointSource};
+
+    fn source() -> Arc<dyn EndpointSource> {
+        ScriptedEndpointSource::new(EndpointSnapshot::NoPrimary).0
+    }
+
+    fn mapping(name: &str) -> XdsMapping {
+        XdsMapping::new(name, "fabric:/App/Svc", host_port_interpreter()).unwrap()
+    }
+
+    #[test]
+    fn registers_several_services() {
+        let registry = ServiceRegistry::builder()
+            .add(mapping("a"), source())
+            .unwrap()
+            .add(mapping("b"), source())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(registry.len(), 2);
+        assert!(!registry.is_empty());
+        assert_eq!(registry.index_of(LISTENER_TYPE_URL, "a"), Some(0));
+        assert_eq!(registry.index_of(LISTENER_TYPE_URL, "b"), Some(1));
+        assert_eq!(registry.index_of(CLUSTER_TYPE_URL, "a-primary"), Some(0));
+        assert_eq!(registry.index_of(ENDPOINT_TYPE_URL, "b-primary"), Some(1));
+        assert_eq!(registry.entries()[0].mapping().xds_name(), "a");
+    }
+
+    #[test]
+    fn rejects_a_duplicate_xds_name() {
+        let err = ServiceRegistry::builder()
+            .add(mapping("a"), source())
+            .unwrap()
+            .add(mapping("a"), source())
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "{err}");
+    }
+
+    #[test]
+    fn rejects_an_empty_registry() {
+        assert!(ServiceRegistry::builder().build().is_err());
+    }
+
+    /// The reason the index is keyed by `(type_url, name)`: a Listener and a
+    /// Cluster may legitimately share a string while belonging to different
+    /// services. A bare-name map would collapse them.
+    #[test]
+    fn a_listener_and_a_cluster_may_share_a_name() {
+        let registry = ServiceRegistry::builder()
+            .add(mapping("x"), source())
+            .unwrap()
+            // Listener "x-primary" collides textually with entry 0's cluster.
+            .add(mapping("x-primary"), source())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(registry.index_of(CLUSTER_TYPE_URL, "x-primary"), Some(0));
+        assert_eq!(registry.index_of(LISTENER_TYPE_URL, "x-primary"), Some(1));
+        assert_eq!(
+            registry.index_of(CLUSTER_TYPE_URL, "x-primary-primary"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn unknown_names_and_types_are_not_found() {
+        let registry = ServiceRegistry::single(mapping("a"), source());
+        assert_eq!(registry.index_of(LISTENER_TYPE_URL, "nope"), None);
+        assert_eq!(
+            registry.index_of("type.googleapis.com/what.Ever", "a"),
+            None
+        );
+    }
+
+    #[test]
+    fn single_holds_exactly_one_entry() {
+        let registry = ServiceRegistry::single(mapping("a"), source());
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.index_of(LISTENER_TYPE_URL, "a"), Some(0));
+    }
+}

--- a/crates/libs/net/tests/readme_check.rs
+++ b/crates/libs/net/tests/readme_check.rs
@@ -19,7 +19,7 @@ use mssf_core::WString;
 use mssf_net::endpoint::EndpointSource;
 use mssf_net::{
     AddressError, AddressInterpreter, AdsService, EndpointSnapshot, FabricEndpointSource, HostPort,
-    ScriptedEndpointSource, XdsMapping, host_port_interpreter,
+    ScriptedEndpointSource, ServiceRegistry, XdsMapping, host_port_interpreter,
 };
 
 /// README — "Hosting the mapping".
@@ -42,6 +42,29 @@ async fn readme_host_example() -> Result<(), Box<dyn std::error::Error>> {
 
     server.shutdown().await?;
     source.shutdown().await;
+    Ok(())
+}
+
+/// README — "Serving several services from one control plane".
+#[allow(dead_code)]
+async fn readme_multi_service_example(
+    orders_mapping: XdsMapping,
+    orders_source: Arc<dyn EndpointSource>,
+    inventory_mapping: XdsMapping,
+    inventory_source: Arc<dyn EndpointSource>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let registry = ServiceRegistry::builder()
+        .add(orders_mapping, orders_source.clone())?
+        .add(inventory_mapping, inventory_source.clone())?
+        .build()?;
+
+    let server = AdsService::from_registry(registry)
+        .serve_on_ephemeral_loopback()
+        .await?;
+
+    server.shutdown().await?;
+    orders_source.shutdown().await;
+    inventory_source.shutdown().await;
     Ok(())
 }
 

--- a/crates/libs/net/tests/readme_check.rs
+++ b/crates/libs/net/tests/readme_check.rs
@@ -18,8 +18,9 @@ use std::time::Duration;
 use mssf_core::WString;
 use mssf_net::endpoint::EndpointSource;
 use mssf_net::{
-    AddressError, AddressInterpreter, AdsService, EndpointSnapshot, FabricEndpointSource, HostPort,
-    ScriptedEndpointSource, ServiceRegistry, XdsMapping, host_port_interpreter,
+    AddressError, AddressInterpreter, AdsService, EndpointSnapshot, FabricEndpointSource,
+    FabricNaming, HostPort, ScriptedEndpointSource, ServiceRegistry, XdsMapping,
+    host_port_interpreter,
 };
 
 /// README — "Hosting the mapping".
@@ -49,13 +50,20 @@ async fn readme_host_example() -> Result<(), Box<dyn std::error::Error>> {
 #[allow(dead_code)]
 async fn readme_multi_service_example(
     orders_mapping: XdsMapping,
-    orders_source: Arc<dyn EndpointSource>,
     inventory_mapping: XdsMapping,
-    inventory_source: Arc<dyn EndpointSource>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let naming = FabricNaming::new(vec![WString::from("localhost:19000")])?;
+
+    let orders = naming
+        .source_for(&orders_mapping, Duration::from_secs(10))
+        .await?;
+    let inventory = naming
+        .source_for(&inventory_mapping, Duration::from_secs(10))
+        .await?;
+
     let registry = ServiceRegistry::builder()
-        .add(orders_mapping, orders_source.clone())?
-        .add(inventory_mapping, inventory_source.clone())?
+        .add(orders_mapping, orders.clone())?
+        .add(inventory_mapping, inventory.clone())?
         .build()?;
 
     let server = AdsService::from_registry(registry)
@@ -63,8 +71,9 @@ async fn readme_multi_service_example(
         .await?;
 
     server.shutdown().await?;
-    orders_source.shutdown().await;
-    inventory_source.shutdown().await;
+    orders.shutdown().await;
+    inventory.shutdown().await;
+    naming.shutdown().await;
     Ok(())
 }
 

--- a/crates/libs/net/tests/scripted_ads.rs
+++ b/crates/libs/net/tests/scripted_ads.rs
@@ -17,14 +17,18 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use envoy_types::pb::envoy::config::listener::v3::Listener;
+use envoy_types::pb::envoy::service::discovery::v3::aggregated_discovery_service_client::AggregatedDiscoveryServiceClient;
+use envoy_types::pb::envoy::service::discovery::v3::{DiscoveryRequest, DiscoveryResponse};
 use mssf_net::ads::{AdsService, ServerHandle, bootstrap_json};
 use mssf_net::resources::{CLUSTER_TYPE_URL, LISTENER_TYPE_URL};
 use mssf_net::{
     EndpointSnapshot, EndpointSource, HostPort, ScriptedEndpointHandle, ScriptedEndpointSource,
     ServiceRegistry, XdsMapping, host_port_interpreter,
 };
+use prost::Message;
 use tokio::net::TcpListener;
-use tokio_stream::wrappers::TcpListenerStream;
+use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status};
 use tonic_xds::{BootstrapConfig, XdsChannelBuilder, XdsChannelConfig, XdsUri};
@@ -481,9 +485,10 @@ struct TwoServices {
     backend_b: BackendHandle,
     source_a: Arc<ScriptedEndpointSource>,
     source_b: Arc<ScriptedEndpointSource>,
-    handle_a: ScriptedEndpointHandle,
+    /// `Option` so a test can drop the only sender and close `svc-a`'s channel.
+    handle_a: Option<ScriptedEndpointHandle>,
     /// Held rather than used: the handle owns the watch sender, so dropping the
-    /// last one closes the channel and ends every ADS stream.
+    /// last one closes the channel.
     _handle_b: ScriptedEndpointHandle,
 }
 
@@ -514,9 +519,22 @@ impl TwoServices {
             backend_b,
             source_a,
             source_b,
-            handle_a,
+            handle_a: Some(handle_a),
             _handle_b,
         }
+    }
+
+    /// Publish a new endpoint for `svc-a`.
+    fn set_a(&self, snapshot: EndpointSnapshot) {
+        self.handle_a
+            .as_ref()
+            .expect("svc-a's handle was dropped")
+            .set(snapshot);
+    }
+
+    /// Drop the only sender for `svc-a`, closing its watch channel.
+    fn drop_handle_a(&mut self) {
+        self.handle_a = None;
     }
 
     /// Clients for both services, built from the **same** bootstrap — i.e. the
@@ -576,10 +594,13 @@ async fn two_services_on_one_ads_server_route_independently() {
 /// Relocating one service must not disturb any other service on the same
 /// server.
 ///
-/// This is the regression guard for the ALL_RESOURCES_REQUIRED trap: Listeners
-/// and Clusters are ALL_RESOURCES_REQUIRED_IN_SOTW, so a push that carried only
-/// the changed service's Listener would silently DELETE `svc-b`'s Listener on
-/// the client and break it, even though nothing about `svc-b` changed.
+/// Note this is an **isolation** test, not a proof of the
+/// ALL_RESOURCES_REQUIRED rule: each `tonic-xds` client opens its own ADS
+/// stream with its own single-resource subscription, so a subset push on one
+/// stream cannot delete the other's Listener. What it does prove is that the
+/// per-entry fan-in routes a change to the right entry and leaves the rest
+/// alone. `a_change_repeats_every_subscribed_listener` below is the actual
+/// guard for the deletion trap, on a single shared stream.
 #[tokio::test]
 #[test_log::test]
 async fn relocating_one_service_leaves_the_other_routing() {
@@ -597,7 +618,7 @@ async fn relocating_one_service_leaves_the_other_routing() {
 
     // Move only svc-a, on the live streams: neither client nor server restarts.
     let c = start_backend("backend-c").await;
-    env.handle_a.set(primary(c.addr));
+    env.set_a(primary(c.addr));
 
     who_am_i_until(&mut a, "backend-c", Duration::from_secs(20)).await;
     who_am_i_until(&mut b, "backend-b", Duration::from_secs(20)).await;
@@ -629,7 +650,7 @@ async fn not_found_for_one_service_leaves_the_other_routing() {
         "backend-b"
     );
 
-    env.handle_a.set(EndpointSnapshot::NotFound);
+    env.set_a(EndpointSnapshot::NotFound);
 
     let failure = who_am_i_until_err(&mut a, Duration::from_secs(20)).await;
     tracing::info!(%failure, "observed not-found failure for svc-a");
@@ -676,4 +697,157 @@ fn from_registry_round_trips_the_registered_services() {
         registry.index_of(CLUSTER_TYPE_URL, "svc-a-primary"),
         Some(0)
     );
+}
+
+// ---- protocol-level: the ALL_RESOURCES_REQUIRED rule -----------------------
+
+/// Drive a raw ADS stream, subscribed to both Listeners at once.
+///
+/// The `tonic-xds` client opens one stream per channel and subscribes only to
+/// its own target, so it structurally cannot observe a cross-service deletion.
+/// Speaking the protocol directly is the only way to put two subscriptions on
+/// one stream and see what a change actually pushes.
+async fn open_ads_stream(
+    ads_addr: SocketAddr,
+    requests: tokio::sync::mpsc::Receiver<DiscoveryRequest>,
+) -> tonic::Streaming<DiscoveryResponse> {
+    let channel = tonic::transport::Channel::from_shared(format!("http://{ads_addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to the ADS server");
+
+    AggregatedDiscoveryServiceClient::new(channel)
+        .stream_aggregated_resources(ReceiverStream::new(requests))
+        .await
+        .expect("failed to open the ADS stream")
+        .into_inner()
+}
+
+/// Read responses until one carries `type_url`, or panic.
+async fn next_response_of_type(
+    stream: &mut tonic::Streaming<DiscoveryResponse>,
+    type_url: &str,
+    timeout: Duration,
+) -> DiscoveryResponse {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let next = tokio::time::timeout(remaining, stream.message())
+            .await
+            .unwrap_or_else(|_| panic!("no {type_url} response within {timeout:?}"))
+            .expect("ads stream failed");
+        match next {
+            Some(resp) if resp.type_url == type_url => return resp,
+            Some(_) => continue,
+            None => panic!("ads stream closed while waiting for {type_url}"),
+        }
+    }
+}
+
+fn listener_names(resp: &DiscoveryResponse) -> Vec<String> {
+    let mut names: Vec<String> = resp
+        .resources
+        .iter()
+        .map(|r| Listener::decode(r.value.as_slice()).unwrap().name)
+        .collect();
+    names.sort();
+    names
+}
+
+/// **The** regression guard for the ALL_RESOURCES_REQUIRED trap.
+///
+/// One stream subscribes to both `svc-a` and `svc-b`. Only `svc-a` then moves.
+/// Listeners are ALL_RESOURCES_REQUIRED_IN_SOTW, so the resulting LDS response
+/// must still enumerate BOTH: a response carrying only `svc-a` would not be a
+/// partial update, it would silently DELETE `svc-b`'s Listener on the client
+/// and break a service that never changed.
+///
+/// Verified to fail as intended by narrowing the LDS push to the changed entry,
+/// which makes the assertion below report `["svc-a"]`.
+#[tokio::test]
+#[test_log::test]
+async fn a_change_repeats_every_subscribed_listener() {
+    let env = TwoServices::start().await;
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<DiscoveryRequest>(8);
+    let mut stream = open_ads_stream(env.ads.addr(), rx).await;
+
+    // Subscribe to both Listeners on this one stream. An empty nonce marks it
+    // as a new subscription rather than an ACK.
+    tx.send(DiscoveryRequest {
+        type_url: LISTENER_TYPE_URL.to_string(),
+        resource_names: vec!["svc-a".to_string(), "svc-b".to_string()],
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let initial =
+        next_response_of_type(&mut stream, LISTENER_TYPE_URL, Duration::from_secs(10)).await;
+    assert_eq!(
+        listener_names(&initial),
+        ["svc-a", "svc-b"],
+        "the initial subscription must be answered with both Listeners"
+    );
+
+    // ACK, so the server does not treat the next request as a re-subscription.
+    tx.send(DiscoveryRequest {
+        type_url: LISTENER_TYPE_URL.to_string(),
+        resource_names: vec!["svc-a".to_string(), "svc-b".to_string()],
+        version_info: initial.version_info.clone(),
+        response_nonce: initial.nonce.clone(),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    // Move only svc-a.
+    let c = start_backend("backend-c").await;
+    env.set_a(primary(c.addr));
+
+    let pushed =
+        next_response_of_type(&mut stream, LISTENER_TYPE_URL, Duration::from_secs(10)).await;
+    assert_eq!(
+        listener_names(&pushed),
+        ["svc-a", "svc-b"],
+        "a change to svc-a must repeat svc-b's Listener; omitting it deletes it",
+    );
+
+    drop(tx);
+    env.shutdown().await;
+    c.shutdown().await;
+}
+
+/// A source torn down must not take the rest of the server with it.
+///
+/// A closed `watch` channel reports "changed" immediately and forever, and
+/// every reconnecting stream re-subscribes to it — so a source that ended the
+/// stream would break every *other* service on the server, permanently. The
+/// retired entry keeps serving its last known state.
+#[tokio::test]
+#[test_log::test]
+async fn dropping_one_source_leaves_the_other_serving() {
+    let mut env = TwoServices::start().await;
+    let (mut a, mut b) = env.clients();
+
+    assert_eq!(
+        who_am_i_until_ok(&mut a, Duration::from_secs(20)).await,
+        "backend-a"
+    );
+    assert_eq!(
+        who_am_i_until_ok(&mut b, Duration::from_secs(20)).await,
+        "backend-b"
+    );
+
+    // Drop svc-a's sender: its channel closes while the streams are live.
+    env.drop_handle_a();
+
+    // svc-b is unaffected, and svc-a still serves its last known endpoint.
+    who_am_i_until(&mut b, "backend-b", Duration::from_secs(20)).await;
+    who_am_i_until(&mut a, "backend-a", Duration::from_secs(20)).await;
+
+    drop(a);
+    drop(b);
+    env.shutdown().await;
 }

--- a/crates/libs/net/tests/scripted_ads.rs
+++ b/crates/libs/net/tests/scripted_ads.rs
@@ -18,8 +18,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mssf_net::ads::{AdsService, ServerHandle, bootstrap_json};
+use mssf_net::resources::{CLUSTER_TYPE_URL, LISTENER_TYPE_URL};
 use mssf_net::{
-    EndpointSnapshot, HostPort, ScriptedEndpointSource, XdsMapping, host_port_interpreter,
+    EndpointSnapshot, EndpointSource, HostPort, ScriptedEndpointHandle, ScriptedEndpointSource,
+    ServiceRegistry, XdsMapping, host_port_interpreter,
 };
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -458,4 +460,220 @@ async fn unknown_resource_name_fails_bounded() {
     drop(client);
     ads.shutdown().await.expect("ads server failed");
     a.shutdown().await;
+}
+
+// ---- multi-service ---------------------------------------------------------
+
+/// A mapping for one entry of a multi-service registry.
+fn mapping_named(name: &str) -> XdsMapping {
+    XdsMapping::new(name, format!("fabric:/App/{name}"), host_port_interpreter()).unwrap()
+}
+
+fn primary(addr: SocketAddr) -> EndpointSnapshot {
+    EndpointSnapshot::Primary(HostPort::new(addr.ip().to_string(), addr.port()))
+}
+
+/// One ADS server publishing two services, each with its own scripted source
+/// and its own stand-in backend.
+struct TwoServices {
+    ads: ServerHandle,
+    backend_a: BackendHandle,
+    backend_b: BackendHandle,
+    source_a: Arc<ScriptedEndpointSource>,
+    source_b: Arc<ScriptedEndpointSource>,
+    handle_a: ScriptedEndpointHandle,
+    /// Held rather than used: the handle owns the watch sender, so dropping the
+    /// last one closes the channel and ends every ADS stream.
+    _handle_b: ScriptedEndpointHandle,
+}
+
+impl TwoServices {
+    async fn start() -> Self {
+        let backend_a = start_backend("backend-a").await;
+        let backend_b = start_backend("backend-b").await;
+
+        let (source_a, handle_a) = ScriptedEndpointSource::new(primary(backend_a.addr));
+        let (source_b, _handle_b) = ScriptedEndpointSource::new(primary(backend_b.addr));
+
+        let registry = ServiceRegistry::builder()
+            .add(mapping_named("svc-a"), source_a.clone())
+            .unwrap()
+            .add(mapping_named("svc-b"), source_b.clone())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let ads = AdsService::from_registry(registry)
+            .serve_on_ephemeral_loopback()
+            .await
+            .expect("failed to start the ADS server");
+
+        Self {
+            ads,
+            backend_a,
+            backend_b,
+            source_a,
+            source_b,
+            handle_a,
+            _handle_b,
+        }
+    }
+
+    /// Clients for both services, built from the **same** bootstrap — i.e. the
+    /// same ADS address — so the only thing that can distinguish them is the
+    /// xDS resource name each one targets.
+    fn clients(
+        &self,
+    ) -> (
+        IdentityClient<tonic_xds::XdsChannelGrpc>,
+        IdentityClient<tonic_xds::XdsChannelGrpc>,
+    ) {
+        (
+            xds_client(self.ads.addr(), "xds:///svc-a"),
+            xds_client(self.ads.addr(), "xds:///svc-b"),
+        )
+    }
+
+    /// Stop everything this fixture owns, in dependency order, so nothing is
+    /// left detached and a stuck stream fails loudly instead of hanging.
+    async fn shutdown(self) {
+        tokio::time::timeout(Duration::from_secs(15), self.ads.shutdown())
+            .await
+            .expect("ads shutdown timed out")
+            .expect("ads server failed");
+        self.source_a.shutdown().await;
+        self.source_b.shutdown().await;
+        self.backend_a.shutdown().await;
+        self.backend_b.shutdown().await;
+    }
+}
+
+/// One ADS server, two services: each client reaches its own backend.
+///
+/// Both channels share a bootstrap, so a registry lookup that ignored the
+/// requested resource name — or keyed it by the wrong type URL — would show up
+/// here as one client landing on the other's backend.
+#[tokio::test]
+#[test_log::test]
+async fn two_services_on_one_ads_server_route_independently() {
+    let env = TwoServices::start().await;
+    let (mut a, mut b) = env.clients();
+
+    assert_eq!(
+        who_am_i_until_ok(&mut a, Duration::from_secs(20)).await,
+        "backend-a"
+    );
+    assert_eq!(
+        who_am_i_until_ok(&mut b, Duration::from_secs(20)).await,
+        "backend-b"
+    );
+
+    drop(a);
+    drop(b);
+    env.shutdown().await;
+}
+
+/// Relocating one service must not disturb any other service on the same
+/// server.
+///
+/// This is the regression guard for the ALL_RESOURCES_REQUIRED trap: Listeners
+/// and Clusters are ALL_RESOURCES_REQUIRED_IN_SOTW, so a push that carried only
+/// the changed service's Listener would silently DELETE `svc-b`'s Listener on
+/// the client and break it, even though nothing about `svc-b` changed.
+#[tokio::test]
+#[test_log::test]
+async fn relocating_one_service_leaves_the_other_routing() {
+    let env = TwoServices::start().await;
+    let (mut a, mut b) = env.clients();
+
+    assert_eq!(
+        who_am_i_until_ok(&mut a, Duration::from_secs(20)).await,
+        "backend-a"
+    );
+    assert_eq!(
+        who_am_i_until_ok(&mut b, Duration::from_secs(20)).await,
+        "backend-b"
+    );
+
+    // Move only svc-a, on the live streams: neither client nor server restarts.
+    let c = start_backend("backend-c").await;
+    env.handle_a.set(primary(c.addr));
+
+    who_am_i_until(&mut a, "backend-c", Duration::from_secs(20)).await;
+    who_am_i_until(&mut b, "backend-b", Duration::from_secs(20)).await;
+
+    drop(a);
+    drop(b);
+    env.shutdown().await;
+    c.shutdown().await;
+}
+
+/// `NotFound` withholds only its own entry's Listener and Cluster.
+///
+/// The unaffected service must keep routing; the missing one must fail in a
+/// bounded way. The failure is asserted on failure-versus-success and timing
+/// only — `tonic-xds` is `0.1.0-alpha.2` and its error text is not a stable
+/// contract.
+#[tokio::test]
+#[test_log::test]
+async fn not_found_for_one_service_leaves_the_other_routing() {
+    let env = TwoServices::start().await;
+    let (mut a, mut b) = env.clients();
+
+    assert_eq!(
+        who_am_i_until_ok(&mut a, Duration::from_secs(20)).await,
+        "backend-a"
+    );
+    assert_eq!(
+        who_am_i_until_ok(&mut b, Duration::from_secs(20)).await,
+        "backend-b"
+    );
+
+    env.handle_a.set(EndpointSnapshot::NotFound);
+
+    let failure = who_am_i_until_err(&mut a, Duration::from_secs(20)).await;
+    tracing::info!(%failure, "observed not-found failure for svc-a");
+
+    who_am_i_until(&mut b, "backend-b", Duration::from_secs(20)).await;
+
+    drop(a);
+    drop(b);
+    env.shutdown().await;
+}
+
+/// A server built from a registry reports exactly what it publishes, so a
+/// caller does not have to keep a parallel copy of the configuration to know
+/// which names are served.
+#[test]
+fn from_registry_round_trips_the_registered_services() {
+    let (source_a, _handle_a) = ScriptedEndpointSource::new(EndpointSnapshot::NoPrimary);
+    let (source_b, _handle_b) = ScriptedEndpointSource::new(EndpointSnapshot::NoPrimary);
+
+    let registry = ServiceRegistry::builder()
+        .add(mapping_named("svc-a"), source_a)
+        .unwrap()
+        .add(mapping_named("svc-b"), source_b)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let svc = AdsService::from_registry(registry);
+    let registry = svc.registry();
+
+    assert_eq!(registry.len(), 2);
+    let names: Vec<&str> = registry
+        .entries()
+        .iter()
+        .map(|e| e.mapping().xds_name())
+        .collect();
+    assert_eq!(names, ["svc-a", "svc-b"]);
+    assert_eq!(
+        registry.entries()[0].mapping().cluster_name(),
+        "svc-a-primary"
+    );
+    assert_eq!(registry.index_of(LISTENER_TYPE_URL, "svc-b"), Some(1));
+    assert_eq!(
+        registry.index_of(CLUSTER_TYPE_URL, "svc-a-primary"),
+        Some(0)
+    );
 }

--- a/crates/samples/reflection/tests/xds_failover.rs
+++ b/crates/samples/reflection/tests/xds_failover.rs
@@ -30,8 +30,8 @@ use mssf_core::{
 use mssf_net::ads::ServerHandle;
 use mssf_net::endpoint::{EndpointSnapshot, EndpointSource};
 use mssf_net::{
-    AddressError, AddressInterpreter, AdsService, FabricEndpointSource, HostPort, ServiceRegistry,
-    XdsMapping, bootstrap_json,
+    AddressError, AddressInterpreter, AdsService, FabricEndpointSource, FabricNaming, HostPort,
+    ServiceRegistry, XdsMapping, bootstrap_json,
 };
 use samples_reflection::grpc::ReflectionUrl;
 use samples_reflection::grpc::hello_world::{ReplicaRole, greeter_client::GreeterClient};
@@ -295,17 +295,15 @@ fn snapshot_of(source: &Arc<FabricEndpointSource>) -> EndpointSnapshot {
     source.subscribe().borrow().clone()
 }
 
-/// Two SF services published by **one** ADS server, each with its own
-/// `FabricEndpointSource`.
+/// Two SF services published by **one** ADS server, sharing **one**
+/// `FabricClient`.
 ///
 /// What this adds over `tests/scripted_ads.rs`, which already covers the
 /// registry, the ALL_RESOURCES_REQUIRED rule and routing isolation with
-/// scripted sources: this is the only test where **two `FabricEndpointSource`s
-/// exist in one process**. That means two `FabricClient`s and two SF
-/// notification filters registered simultaneously, plus their teardown
-/// ordering under issue #184. The per-callback `service_name` filter in
-/// `fabric.rs` only *means* anything when several filters coexist, and nothing
-/// else exercises that.
+/// scripted sources: this is the only test that exercises [`FabricNaming`]
+/// against a real cluster — one client, one notification callback, two
+/// filters, dispatching to two sources by service name. It also covers the
+/// teardown ordering (sources, then the shared client) under issue #184.
 ///
 /// The load-bearing assertion is the failover one: relocating A's primary must
 /// leave B's published endpoint and serving replica **unchanged**, which is
@@ -338,21 +336,36 @@ async fn two_services_share_one_ads_server() {
     // `xds:///fabric:/ReflectionApp/XdsMultiA` with no alias to maintain.
     let mapping_a = XdsMapping::for_service_uri(SERVICE_URI_A, reflection_interpreter()).unwrap();
     let mapping_b = XdsMapping::for_service_uri(SERVICE_URI_B, reflection_interpreter()).unwrap();
+    // A distinct xDS name for the same SF service, to prove the duplicate
+    // check keys on the service, not on the xDS name.
+    let mapping_a_again =
+        XdsMapping::new("alias-for-a", SERVICE_URI_A, reflection_interpreter()).unwrap();
 
-    let source_a = FabricEndpointSource::new(
-        &mapping_a,
-        vec![WString::from("localhost:19000")],
-        Duration::from_secs(10),
-    )
-    .await
-    .expect("failed to build svc-a's endpoint source");
-    let source_b = FabricEndpointSource::new(
-        &mapping_b,
-        vec![WString::from("localhost:19000")],
-        Duration::from_secs(10),
-    )
-    .await
-    .expect("failed to build svc-b's endpoint source");
+    // ONE FabricClient for both services. SF installs the notification
+    // callback when the client is built, so a client per service would also
+    // mean a naming connection and a callback per service -- exactly the cost
+    // that serving many services from one ADS server is meant to avoid.
+    let naming = FabricNaming::new(vec![WString::from("localhost:19000")])
+        .expect("failed to build the shared naming client");
+
+    let source_a = naming
+        .source_for(&mapping_a, Duration::from_secs(10))
+        .await
+        .expect("failed to build svc-a's endpoint source");
+    let source_b = naming
+        .source_for(&mapping_b, Duration::from_secs(10))
+        .await
+        .expect("failed to build svc-b's endpoint source");
+
+    // A second source for a service already mapped on this client would race
+    // for the same notifications, so it is refused.
+    assert!(
+        naming
+            .source_for(&mapping_a_again, Duration::from_secs(10))
+            .await
+            .is_err(),
+        "a duplicate source for the same service must be rejected"
+    );
 
     let registry = ServiceRegistry::builder()
         .add(mapping_a, source_a.clone())
@@ -444,14 +457,15 @@ async fn two_services_share_one_ads_server() {
     );
 
     // Teardown in dependency order: clients, then the server, then both
-    // sources (each owns a FabricClient subject to issue #184), then the
-    // services, then the admin client. Two sources releasing two FabricClients
-    // is precisely the path this test exists to exercise.
+    // sources (each drops its notification filter and route), and only then
+    // the shared naming client, which is what actually releases the single
+    // FabricClient under issue #184.
     drop(client_a);
     drop(client_b);
     ads.shutdown().await.expect("ads server failed");
     source_a.shutdown().await;
     source_b.shutdown().await;
+    naming.shutdown().await;
 
     delete_service(&fc, &uri_a).await;
     delete_service(&fc, &uri_b).await;

--- a/crates/samples/reflection/tests/xds_failover.rs
+++ b/crates/samples/reflection/tests/xds_failover.rs
@@ -28,10 +28,10 @@ use mssf_core::{
     types::{DeleteServiceDescription, Uri},
 };
 use mssf_net::ads::ServerHandle;
-use mssf_net::endpoint::EndpointSource;
+use mssf_net::endpoint::{EndpointSnapshot, EndpointSource};
 use mssf_net::{
-    AddressError, AddressInterpreter, AdsService, FabricEndpointSource, HostPort, XdsMapping,
-    bootstrap_json,
+    AddressError, AddressInterpreter, AdsService, FabricEndpointSource, HostPort, ServiceRegistry,
+    XdsMapping, bootstrap_json,
 };
 use samples_reflection::grpc::ReflectionUrl;
 use samples_reflection::grpc::hello_world::{ReplicaRole, greeter_client::GreeterClient};
@@ -231,5 +231,229 @@ async fn xds_client_recovers_after_primary_restart() {
         .await
         .expect("failed to delete the test service");
 
+    fabric_client_drop_hack(fc).await;
+}
+
+// ---- two services, one ADS server -----------------------------------------
+
+const SERVICE_URI_A: &str = "fabric:/ReflectionApp/XdsMultiA";
+const SERVICE_URI_B: &str = "fabric:/ReflectionApp/XdsMultiB";
+
+/// Delete `uri` if it exists, then create it with a 3-replica set.
+///
+/// Returns the partition id once the service is ready.
+async fn recreate_service(fc: &FabricClient, uri: &Uri) -> mssf_core::GUID {
+    if let Err(e) = fc
+        .get_service_manager()
+        .delete_service2(
+            &DeleteServiceDescription::new(uri.clone()),
+            Duration::from_secs(10),
+            None,
+        )
+        .await
+    {
+        tracing::debug!(?e, %uri, "pre-cleanup delete (expected if service doesn't exist)");
+    }
+
+    TestCreateUpdateClient::new(fc.clone())
+        .create_service(
+            uri,
+            &mssf_core::types::PartitionSchemeDescription::Singleton,
+            TestPartitionReplicaLayout::TargetMinAux(3, 3, 0),
+        )
+        .await;
+
+    wait_for_ready(fc, uri).await
+}
+
+async fn delete_service(fc: &FabricClient, uri: &Uri) {
+    fc.get_service_manager()
+        .delete_service2(
+            &DeleteServiceDescription::new(uri.clone()),
+            Duration::from_secs(10),
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("failed to delete {uri}: {e:?}"));
+}
+
+/// Build a stock xDS client for `target` against `ads_addr`.
+fn xds_greeter(
+    ads_addr: std::net::SocketAddr,
+    target: &str,
+) -> GreeterClient<tonic_xds::XdsChannelGrpc> {
+    let bootstrap =
+        BootstrapConfig::from_json(&bootstrap_json(ads_addr, "mssf-net-live-multi")).unwrap();
+    let uri = XdsUri::parse(target).unwrap();
+    let channel = XdsChannelBuilder::new(XdsChannelConfig::new(uri).with_bootstrap(bootstrap))
+        .build_grpc_channel()
+        .unwrap();
+    GreeterClient::new(channel)
+}
+
+fn snapshot_of(source: &Arc<FabricEndpointSource>) -> EndpointSnapshot {
+    source.subscribe().borrow().clone()
+}
+
+/// Two SF services published by **one** ADS server, each with its own
+/// `FabricEndpointSource`.
+///
+/// What this adds over `tests/scripted_ads.rs`, which already covers the
+/// registry, the ALL_RESOURCES_REQUIRED rule and routing isolation with
+/// scripted sources: this is the only test where **two `FabricEndpointSource`s
+/// exist in one process**. That means two `FabricClient`s and two SF
+/// notification filters registered simultaneously, plus their teardown
+/// ordering under issue #184. The per-callback `service_name` filter in
+/// `fabric.rs` only *means* anything when several filters coexist, and nothing
+/// else exercises that.
+///
+/// The load-bearing assertion is the failover one: relocating A's primary must
+/// leave B's published endpoint and serving replica **unchanged**, which is
+/// what proves the two notification paths do not cross-talk.
+///
+/// Note what is deliberately *not* asserted. The reflection sample runs one
+/// gRPC server per activated process with a process-wide replica registry, so
+/// if SF happens to co-locate A's and B's primaries, both clients reach the
+/// same endpoint and no response content can tell them apart. Likewise A's
+/// endpoint only moves if its new primary lands in a different process. The
+/// test detects and logs both cases rather than pretending to discriminate;
+/// the assertions it does make hold either way. Endpoint-level isolation is
+/// proven exhaustively and deterministically in `mssf-net`'s
+/// `tests/scripted_ads.rs`, which is where that belongs.
+#[tokio::test]
+#[test_log::test]
+async fn two_services_share_one_ads_server() {
+    let fc = FabricClient::builder()
+        .with_connection_strings(vec![WString::from("localhost:19000")])
+        .build()
+        .unwrap();
+    let uri_a = Uri::from(SERVICE_URI_A);
+    let uri_b = Uri::from(SERVICE_URI_B);
+
+    let partition_a = recreate_service(&fc, &uri_a).await;
+    let partition_b = recreate_service(&fc, &uri_b).await;
+    assert_ne!(partition_a, partition_b);
+
+    // The SF URI doubles as the xDS resource name, so clients target
+    // `xds:///fabric:/ReflectionApp/XdsMultiA` with no alias to maintain.
+    let mapping_a = XdsMapping::for_service_uri(SERVICE_URI_A, reflection_interpreter()).unwrap();
+    let mapping_b = XdsMapping::for_service_uri(SERVICE_URI_B, reflection_interpreter()).unwrap();
+
+    let source_a = FabricEndpointSource::new(
+        &mapping_a,
+        vec![WString::from("localhost:19000")],
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("failed to build svc-a's endpoint source");
+    let source_b = FabricEndpointSource::new(
+        &mapping_b,
+        vec![WString::from("localhost:19000")],
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("failed to build svc-b's endpoint source");
+
+    let registry = ServiceRegistry::builder()
+        .add(mapping_a, source_a.clone())
+        .unwrap()
+        .add(mapping_b, source_b.clone())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let ads = AdsService::from_registry(registry)
+        .serve_on_ephemeral_loopback()
+        .await
+        .expect("failed to start the ADS server");
+
+    // Two stock xDS clients, one bootstrap, one ADS server.
+    let mut client_a = xds_greeter(ads.addr(), &format!("xds:///{SERVICE_URI_A}"));
+    let mut client_b = xds_greeter(ads.addr(), &format!("xds:///{SERVICE_URI_B}"));
+
+    let replica_a_before =
+        serving_primary_until(&mut client_a, partition_a, Duration::from_secs(60)).await;
+    let replica_b_before =
+        serving_primary_until(&mut client_b, partition_b, Duration::from_secs(60)).await;
+
+    let endpoint_a_before = snapshot_of(&source_a);
+    let endpoint_b_before = snapshot_of(&source_b);
+    tracing::info!(
+        ?endpoint_a_before,
+        ?endpoint_b_before,
+        replica_a_before,
+        replica_b_before,
+        "steady state",
+    );
+    if endpoint_a_before == endpoint_b_before {
+        tracing::warn!(
+            "svc-a and svc-b are co-located in one activated process; this run \
+             cannot discriminate routing by response content"
+        );
+    }
+
+    // Relocate only A's primary.
+    TestClient::with_uri(fc.clone(), uri_a.clone())
+        .restart_primary_wait_for_replica_id_change(partition_a)
+        .await;
+
+    // A recovers on a different replica, without the client or server
+    // restarting.
+    let replica_a_after =
+        serving_primary_until(&mut client_a, partition_a, Duration::from_secs(90)).await;
+    assert_ne!(
+        replica_a_before, replica_a_after,
+        "after restart_replica svc-a must be served by a different replica"
+    );
+
+    // B is untouched: still routing, and its published endpoint never moved.
+    // A stale or cross-wired notification filter would show up here.
+    let replica_b_after =
+        serving_primary_until(&mut client_b, partition_b, Duration::from_secs(60)).await;
+    assert_eq!(
+        replica_b_before, replica_b_after,
+        "svc-b's primary must not have changed"
+    );
+    assert_eq!(
+        endpoint_b_before,
+        snapshot_of(&source_b),
+        "svc-a's failover must not perturb svc-b's endpoint"
+    );
+
+    // Log rather than assert: whether A's *endpoint* moves depends on whether
+    // SF placed the new primary in a different activated process. The replica
+    // id changing is the guaranteed signal; the endpoint changing is the
+    // stronger one when it happens, and is what makes "B unchanged" a contrast
+    // rather than a tautology.
+    let endpoint_a_after = snapshot_of(&source_a);
+    if endpoint_a_after == endpoint_a_before {
+        tracing::warn!(
+            ?endpoint_a_after,
+            "svc-a's new primary landed in the same process, so its endpoint is \
+             unchanged; this run proves replica movement but not endpoint movement"
+        );
+    }
+
+    tracing::info!(
+        replica_a_before,
+        replica_a_after,
+        replica_b_after,
+        ?endpoint_a_before,
+        ?endpoint_a_after,
+        "svc-a failed over; svc-b undisturbed",
+    );
+
+    // Teardown in dependency order: clients, then the server, then both
+    // sources (each owns a FabricClient subject to issue #184), then the
+    // services, then the admin client. Two sources releasing two FabricClients
+    // is precisely the path this test exists to exercise.
+    drop(client_a);
+    drop(client_b);
+    ads.shutdown().await.expect("ads server failed");
+    source_a.shutdown().await;
+    source_b.shutdown().await;
+
+    delete_service(&fc, &uri_a).await;
+    delete_service(&fc, &uri_b).await;
     fabric_client_drop_hack(fc).await;
 }

--- a/docs/design/XdsNamingDesign.md
+++ b/docs/design/XdsNamingDesign.md
@@ -196,20 +196,53 @@ service on that stream.
 EDS has no such rule; it is tracked per-resource. An endpoint change therefore
 pushes exactly one `ClusterLoadAssignment`, for the cluster that actually moved.
 
-`tests/scripted_ads.rs` guards this directly: it relocates one service's
-endpoint and then asserts a *second* service's client still routes.
+`tests/scripted_ads.rs` guards this directly, and the guard had to be built
+carefully: each `tonic-xds` client opens its *own* ADS stream subscribed only to
+its own target, so two clients cannot observe a cross-service deletion no matter
+how badly the server behaves. The real guard,
+`a_change_repeats_every_subscribed_listener`, therefore speaks the ADS protocol
+directly, puts both Listeners on **one** stream, changes one service, and
+asserts the pushed LDS response still enumerates both. It was verified to fail —
+reporting `["svc-a"]` — when the push is narrowed to the changed entry.
+
+A stream that is subscribed to *neither* the changed Listener nor the changed
+Cluster is skipped entirely. Re-sending its unchanged set would be correct but
+would make every service's churn cost every client a response.
 
 ### Fan-in across sources
 
 Each entry has its own `watch::Receiver`, and a stream awaits the first change
 across all of them. `watch::Receiver::changed` is cancel-safe, so the fan-in set
 is rebuilt on each loop iteration rather than held across them — which would
-otherwise require a self-referential future. The resolved snapshot is returned
-by the fan-in future itself, releasing the mutable borrow before the handler
-runs.
+otherwise require a self-referential future. The registry is non-empty by
+construction, which is load-bearing: the underlying `select_all` panics on an
+empty set.
 
-The registry is non-empty by construction, which is load-bearing: the underlying
-`select_all` panics on an empty set.
+Reads go through *separate cloned receivers*. `changed()` needs `&mut`, and that
+borrow lives for as long as the fan-in future does — the whole `select!` — so no
+arm could otherwise read the current state. Cloning is an `Arc` bump and means
+every response is built from the live value rather than a cached copy that could
+drift out of step with the registry.
+
+**A source whose sender is dropped is retired from the fan-in, not fatal.** A
+closed `watch` channel reports "changed" immediately and forever, so a dead
+source would spin; worse, because every reconnecting stream re-subscribes to the
+same dead channel, one torn-down source would break every *other* service on the
+server, permanently. That blast radius is new with multi-service and is the
+reason for the `alive` mask. A retired entry is deliberately **not** published as
+`NotFound`: a dropped sender is a host-process lifecycle event, not naming
+reporting the service gone, and `NotFound` is a permanent client-side deletion.
+Its last published state is served instead. If every source retires, the fan-in
+simply never resolves, leaving cancellation free to run.
+
+### Name resolution has one implementation
+
+`resources_for` resolves a non-wildcard request through
+`ServiceRegistry::index_of` rather than scanning entries and re-deriving names.
+The wildcard (empty `resource_names`) case still means "every entry", which no
+index can express. Routing the named case through the index keeps the
+`(type_url, name)` rules in exactly one place instead of having the serving path
+quietly reimplement them.
 
 ### What this does not consolidate
 
@@ -418,6 +451,12 @@ The test creates and deletes its own service, so re-runs are idempotent.
   while the server runs. Lifting this means making the registry observable and
   re-pushing LDS/CDS to every open stream on a change, since both are
   `ALL_RESOURCES_REQUIRED_IN_SOTW`.
+- **The fan-in boxes one future per live entry per wakeup.** At prototype scale
+  (a handful of services) this is not worth optimizing, and the obvious
+  alternative — `WatchStream` in a `StreamMap` — yields its initial value
+  immediately, which would produce a spurious push on every stream. If the
+  service count grows enough for this to matter, the fix is a hand-rolled
+  `poll_fn` over the receivers, not a stream adapter.
 - **A NACK is logged and then forgotten.** `stream_aggregated_resources` traces
   the `error_detail` and does not advance state, which is correct, but a
   persistently rejected resource is never re-sent and raises no metric or health

--- a/docs/design/XdsNamingDesign.md
+++ b/docs/design/XdsNamingDesign.md
@@ -44,8 +44,8 @@ See also the broader proposal: [`docs/proposal/GrpcXds.md`](../proposal/GrpcXds.
 ## Non-Goals
 
 - Dynamic registration: the set of mapped services is fixed at build time.
-- A shared SF-facing tier: each mapped service still owns its own
-  `FabricClient` and notification filter.
+- A cluster-wide SF-facing tier: the `FabricClient` is shared per *process*,
+  not per cluster.
 - Multiple partitions, partition keys, stateless services, secondaries, or
   read-from-secondary routing.
 - RDS, delta/incremental xDS, federation (`xdstp://`), or LRS/ORCA load
@@ -75,7 +75,7 @@ therefore structurally guarantees the successor does not link the incumbent.
 | `registry.rs` | `ServiceRegistry` — the set of services one ADS server publishes |
 | `resources.rs` | Pure LDS / CDS / EDS construction |
 | `ads.rs` | The SotW ADS service, and `bootstrap_json` |
-| `fabric.rs` | `FabricEndpointSource` — the SF-backed source |
+| `fabric.rs` | `FabricNaming` (one shared `FabricClient`) and `FabricEndpointSource` |
 
 ## Architecture
 
@@ -246,13 +246,64 @@ quietly reimplement them.
 
 ### What this does not consolidate
 
-Each `FabricEndpointSource` still owns its own `FabricClient` and its own
-notification filter. Multi-service serving consolidates *ports and streams*, not
-SF-side naming load; collapsing N registrations into one cluster-wide
-subscription is the two-tier discovery work in the proposal.
+`FabricNaming` gives the whole process **one** `FabricClient` and one
+notification callback, so the SF-side cost of mapping N services is one naming
+connection and N filters — not N of everything. What is still not consolidated
+is *cluster-wide*: every node running this crate maintains its own filters.
+Collapsing those into one cluster-wide subscription with a relay is the
+two-tier discovery work in the proposal.
 
 The registry is also immutable once built — there is no dynamic
 registration while serving.
+
+## One `FabricClient` for the process
+
+SF installs the service-notification callback when the `FabricClient` is
+**built**; it cannot be attached afterwards. A naive "one source owns one
+client" design therefore silently makes the callback per-service too, and N
+mapped services become N naming connections and N callbacks — precisely the
+naming load this work exists to reduce.
+
+`FabricNaming` owns the client and installs a single callback that dispatches on
+`service_name` through a `HashMap` of per-service `watch` senders.
+`FabricNaming::source_for` claims a name in that map, registers the SF filter,
+and returns the source; `FabricEndpointSource::new` remains for the
+single-service case, where it simply builds a private `FabricNaming` and marks
+the source as owning it.
+
+Registering the same SF service twice is **rejected**. Both sources would
+register a filter and then race for the same notifications, with only one
+winning the route — starving the other silently. Note the check keys on the SF
+service URI, not the xDS name: two different xDS aliases for one service collide
+here even though the registry would accept them.
+
+The dispatch table is generic over its payload purely so the routing rules can
+be unit-tested without constructing a `ServiceNotification`, which wraps a COM
+object.
+
+### Callback constraints, revisited
+
+The callback still runs synchronously on an SF COM thread, so the shared path is
+a read-lock, one hash lookup and a non-blocking `send_replace`. Two details
+matter: the lock is an `RwLock` so concurrent notifications never serialize
+against each other (writes happen only when a source is added or removed), and a
+poisoned lock is **recovered rather than unwrapped** — unwinding out of a COM
+callback is undefined behaviour, so a panic there is not an acceptable failure
+mode.
+
+### Teardown order
+
+Sources first, then the naming host:
+
+1. each `FabricEndpointSource::shutdown` stops its interpretation task,
+   unregisters its filter, and drops its route — the route last, so a
+   notification arriving mid-teardown has nowhere to go rather than reaching a
+   half-torn source;
+2. `FabricNaming::shutdown` releases the client and applies the issue #184
+   delay, once.
+
+A source that owns its naming (the single-service constructor) does step 2
+itself, so existing single-service callers are unaffected.
 
 ## Endpoint state: three values, not two
 
@@ -443,10 +494,10 @@ The test creates and deletes its own service, so re-runs are idempotent.
 
 ## Known limitations and deferred work
 
-- **One `FabricClient` and one notification filter per registered service.**
-  Multi-service serving consolidated ports and ADS streams, not SF-side naming
-  load — which is the concern the proposal's two-tier design addresses, and the
-  one that matters at cluster scale.
+- **One `FabricClient` per process, not per cluster.** Every node running this
+  crate keeps its own naming connection and its own filters. Collapsing those
+  into one cluster-wide subscription plus a relay is the proposal's two-tier
+  design, and is what matters at cluster scale.
 - **The registry is fixed at build time.** Services cannot be added or removed
   while the server runs. Lifting this means making the registry observable and
   re-pushing LDS/CDS to every open stream on a change, since both are

--- a/docs/design/XdsNamingDesign.md
+++ b/docs/design/XdsNamingDesign.md
@@ -43,7 +43,9 @@ See also the broader proposal: [`docs/proposal/GrpcXds.md`](../proposal/GrpcXds.
 
 ## Non-Goals
 
-- Multiple mapped services per server instance.
+- Dynamic registration: the set of mapped services is fixed at build time.
+- A shared SF-facing tier: each mapped service still owns its own
+  `FabricClient` and notification filter.
 - Multiple partitions, partition keys, stateless services, secondaries, or
   read-from-secondary routing.
 - RDS, delta/incremental xDS, federation (`xdstp://`), or LRS/ORCA load
@@ -70,6 +72,7 @@ therefore structurally guarantees the successor does not link the incumbent.
 | `endpoint.rs` | `HostPort`, `EndpointSnapshot`, the `EndpointSource` trait, `ScriptedEndpointSource` |
 | `address.rs` | `AddressInterpreter` — pluggable interpretation of the opaque SF address |
 | `config.rs` | `XdsMapping` — one SF service ↔ one xDS resource name |
+| `registry.rs` | `ServiceRegistry` — the set of services one ADS server publishes |
 | `resources.rs` | Pure LDS / CDS / EDS construction |
 | `ads.rs` | The SotW ADS service, and `bootstrap_json` |
 | `fabric.rs` | `FabricEndpointSource` — the SF-backed source |
@@ -79,9 +82,9 @@ therefore structurally guarantees the successor does not link the incumbent.
 ```
  SF Naming ──notify──► FabricEndpointSource ──watch──► AdsService ──ADS──► stock xDS client
                           (fabric.rs)                    (ads.rs)                │
-                                                                                │ direct gRPC
-                                                                                ▼
-                                                                        primary replica
+                                                        serves a                │ direct gRPC
+                                                   ServiceRegistry              ▼
+                                                     (registry.rs)      primary replica
 ```
 
 Only *configuration* flows through this crate. Client RPCs go **directly** to
@@ -107,8 +110,10 @@ The minimum accepted chain is therefore **LDS → CDS → EDS**.
 
 ### Why State-of-the-World, not delta
 
-Delta xDS is `unimplemented` in the target client. SotW is sufficient, and for a
-single mapped service the "send everything" semantics cost nothing.
+Delta xDS is `unimplemented` in the target client. SotW is sufficient, and at
+this scale the "send everything" semantics cost little — though see
+[Serving several services](#serving-several-services) for the one place where
+they are genuinely dangerous.
 
 ### Why a `watch` channel
 
@@ -155,6 +160,66 @@ These are not stylistic. Each one prevents a client-side rejection:
 
 Each of these has a dedicated unit test in `resources.rs`, so a regression is
 caught without needing a live client to reject it.
+
+## Serving several services
+
+One ADS server publishes any number of services. Clients subscribe by resource
+name, so this is what xDS is designed for; `ServiceRegistry` holds the set and
+`AdsService::from_registry` serves it. The single-service constructors remain as
+one-entry sugar.
+
+### The index is keyed by `(type_url, name)`, not by name
+
+Each entry contributes two names — a `Listener` named `<xds_name>` and a
+`Cluster` named `<xds_name>-primary`, which EDS reuses. Deriving the cluster
+name by appending a constant suffix is injective, so distinct xDS names can
+never produce colliding cluster names; unique `xds_name` is therefore the only
+rule the builder has to enforce, and it does so at registration time, where a
+configuration mistake is cheap to diagnose.
+
+What a bare-name index *would* get wrong is the cross-type case: a mapping named
+`x-primary` has a Listener whose name equals the Cluster of a different mapping
+named `x`. Both are legitimate and must resolve to different entries. Including
+the type URL in the key makes conflating them impossible rather than merely
+unlikely.
+
+### LDS and CDS carry the whole subscribed set; EDS carries only what changed
+
+This is the sharpest correctness constraint in the multi-service design.
+Listeners and Clusters are `ALL_RESOURCES_REQUIRED_IN_SOTW`: a response that
+omits a resource the client is subscribed to is not a no-op, it is a
+**deletion**. So any LDS or CDS response must enumerate every subscribed entry —
+including when the response was triggered by a change to just one of them.
+Pushing only the changed service's Listener would silently break every *other*
+service on that stream.
+
+EDS has no such rule; it is tracked per-resource. An endpoint change therefore
+pushes exactly one `ClusterLoadAssignment`, for the cluster that actually moved.
+
+`tests/scripted_ads.rs` guards this directly: it relocates one service's
+endpoint and then asserts a *second* service's client still routes.
+
+### Fan-in across sources
+
+Each entry has its own `watch::Receiver`, and a stream awaits the first change
+across all of them. `watch::Receiver::changed` is cancel-safe, so the fan-in set
+is rebuilt on each loop iteration rather than held across them — which would
+otherwise require a self-referential future. The resolved snapshot is returned
+by the fan-in future itself, releasing the mutable borrow before the handler
+runs.
+
+The registry is non-empty by construction, which is load-bearing: the underlying
+`select_all` panics on an empty set.
+
+### What this does not consolidate
+
+Each `FabricEndpointSource` still owns its own `FabricClient` and its own
+notification filter. Multi-service serving consolidates *ports and streams*, not
+SF-side naming load; collapsing N registrations into one cluster-wide
+subscription is the two-tier discovery work in the proposal.
+
+The registry is also immutable once built — there is no dynamic
+registration while serving.
 
 ## Endpoint state: three values, not two
 
@@ -345,26 +410,14 @@ The test creates and deletes its own service, so re-runs are idempotent.
 
 ## Known limitations and deferred work
 
-- **One mapped service per ADS server.** `AdsService` holds exactly one
-  `XdsMapping` and one `EndpointSource`, so serving N services means N ADS
-  servers on N ports. Note the SF-side cost is unchanged either way — one
-  `FabricClient` and one notification filter *per service* — but the naming load
-  is the same concern the proposal's two-tier design addresses, so this matters
-  at cluster scale.
-
-  The limitation is this crate's, not xDS's: xDS is designed for one control
-  plane serving many resources, clients subscribe by resource name, and
-  `resources_for` already filters on `resource_names`. Lifting it means (a) a
-  map of xDS name → (mapping, source), (b) **returning every subscribed Listener
-  and Cluster in one response** — both are `ALL_RESOURCES_REQUIRED_IN_SOTW`, so
-  emitting a subset silently deletes the others on the client — and (c) fanning
-  in over N `watch` receivers to push only the affected cluster's EDS.
-
-  When it lands, **validate that xDS names are unique across mappings**. The
-  `<xds_name>-primary` cluster derivation is itself injective (appending a
-  constant suffix cannot make two distinct names collide), but a registry keyed
-  by bare name rather than by `(type_url, name)` would conflate a Listener and a
-  Cluster that happen to share a string.
+- **One `FabricClient` and one notification filter per registered service.**
+  Multi-service serving consolidated ports and ADS streams, not SF-side naming
+  load — which is the concern the proposal's two-tier design addresses, and the
+  one that matters at cluster scale.
+- **The registry is fixed at build time.** Services cannot be added or removed
+  while the server runs. Lifting this means making the registry observable and
+  re-pushing LDS/CDS to every open stream on a change, since both are
+  `ALL_RESOURCES_REQUIRED_IN_SOTW`.
 - **A NACK is logged and then forgotten.** `stream_aggregated_resources` traces
   the `error_detail` and does not advance state, which is correct, but a
   persistently rejected resource is never re-sent and raises no metric or health


### PR DESCRIPTION
> **Prototype.** This continues the `mssf-net` prototype merged in #322 and is
> still explicitly scoped: happy path, singleton partition, primary only. It
> lifts one documented limitation and nothing else.

## What

`AdsService` held exactly one `XdsMapping` and one `EndpointSource`, so serving
N Service Fabric services meant N ADS servers on N ports. That was the first
limitation listed in `docs/design/XdsNamingDesign.md` and a hard prerequisite
for a standalone xDS agent, which must serve whatever a client subscribes to
over one connection.

This adds `ServiceRegistry` — an immutable, ordered set of `(mapping, source)`
entries indexed by `(type_url, name)` — and rewires `AdsService` to serve it.

```rust
let registry = ServiceRegistry::builder()
    .add(orders_mapping, orders_source.clone())?
    .add(inventory_mapping, inventory_source.clone())?
    .build()?;

let server = AdsService::from_registry(registry)
    .serve_on_ephemeral_loopback()
    .await?;
```

Clients then target `xds:///fabric:/MyApp/Orders` and
`xds:///fabric:/MyApp/Inventory` through the *same* bootstrap, and each
service's failovers are pushed independently.

`AdsService::new(mapping, source)` is unchanged and now builds a one-entry
registry, so nothing downstream changes.

## Why the design is the way it is

**The index is keyed by `(type_url, name)`, not by name.** Each entry
contributes a Listener named `<xds_name>` and a Cluster named
`<xds_name>-primary`. A mapping named `x-primary` therefore has a Listener whose
name equals the Cluster of a *different* mapping named `x`. Both are legitimate
and must resolve to different entries; including the type URL makes conflating
them impossible. Deriving the cluster name by appending a constant suffix is
injective, so unique `xds_name` is the only rule the builder has to enforce —
and it enforces it at registration time, where a config mistake is cheap to
diagnose rather than a silently shadowed route on a live stream.

**LDS and CDS responses enumerate every subscribed entry; EDS carries only what
changed.** Listeners and Clusters are `ALL_RESOURCES_REQUIRED_IN_SOTW`: a
response omitting a subscribed resource is a **deletion**, not a no-op. So a
change to one service must still repeat every other subscribed Listener, or it
silently breaks services that did not change. EDS is tracked per-resource, so an
endpoint change pushes exactly one `ClusterLoadAssignment`. A stream subscribed
to neither the changed Listener nor the changed Cluster is skipped entirely.

**A dropped endpoint source is retired from the fan-in, not fatal.** A closed
`watch` channel reports "changed" immediately and forever, and every
reconnecting stream re-subscribes to the same dead channel — so one torn-down
source would otherwise break every *other* service on the server, permanently.
This blast radius is new with multi-service. A retired entry is deliberately not
published as `NotFound`, because a dropped sender is a host lifecycle event, not
naming reporting the service gone, and `NotFound` is a permanent client-side
deletion.

**One `FabricClient` for the whole process.** SF installs the service-notification
callback when the client is *built* and it cannot be attached afterwards, so the
original "one source owns one client" shape silently made the callback
per-service too — meaning N mapped services cost N naming connections and N
callbacks. That is backwards for a crate whose purpose is to *reduce* naming
load: consolidating ports and ADS streams while multiplying the expensive part.
`FabricNaming` now owns the client and installs a single callback that
dispatches on `service_name`:

```rust
let naming = FabricNaming::new(vec![WString::from("localhost:19000")])?;
let orders    = naming.source_for(&orders_mapping, timeout).await?;
let inventory = naming.source_for(&inventory_mapping, timeout).await?;
```

`FabricEndpointSource::new` is unchanged for the single-service case and now
builds a private `FabricNaming` internally. Registering the same SF service
twice is rejected — both sources would register a filter and race for the same
notifications, with one starving silently. The callback path is a read-lock, one
hash lookup and a non-blocking send; a poisoned lock is recovered rather than
unwrapped, since unwinding out of a COM callback is undefined behaviour.

## Testing

`cargo test -p mssf-net`: **72 passing** (58 unit, 13 cluster-free e2e, 1 README
compile guard). No Service Fabric cluster, no SF runtime and no `FabricClient`
is needed for any of them. Run three consecutive times with no flakiness.
Clippy clean with `-D warnings`. `cargo test --all` is green.

The end-to-end tests drive a **stock, unmodified `tonic-xds` client**. New ones:

| Test | Proves |
|---|---|
| `two_services_on_one_ads_server_route_independently` | two clients, one bootstrap, one server → each reaches its own backend |
| `a_change_repeats_every_subscribed_listener` | the ALL_RESOURCES_REQUIRED rule, on a single shared stream |
| `relocating_one_service_leaves_the_other_routing` | per-entry fan-in isolation |
| `not_found_for_one_service_leaves_the_other_routing` | `NotFound` withholds only its own entry |
| `dropping_one_source_leaves_the_other_serving` | a retired source does not take the server with it |

### Live cluster

`two_services_share_one_ads_server` (in the reflection sample) adds the one
thing no cluster-free test can: **`FabricNaming` against a real cluster** — one
`FabricClient`, one notification callback, two filters, dispatching to two
sources by service name, plus the teardown ordering (sources, then the shared
client) under issue #184. It creates two services from the already-deployed
`ReflectionApp`, so no manifest or deploy-script change was needed.

Verified on a live onebox — both `xds_failover` tests pass serially and in
parallel, and `cargo test --all` is green. On the recorded run both primaries
were co-located at `:28004`, then A's failover moved it to `:28000` while B
stayed at `:28004` — one client, one callback, dispatched correctly.

Two things there are deliberately logged rather than asserted, because the
reflection sample runs one gRPC server per activated process with a
process-wide replica registry: if SF co-locates the two primaries, no response
content can tell the clients apart, and A's endpoint only moves if its new
primary lands in a different process. Both cases are detected and warned about
rather than papered over. (On the recorded run the primaries *were* co-located
at `:28000`, and A's failover moved it to `:28003` while B stayed at `:28000` —
so the isolation assertion was load-bearing, though the test does not depend on
it being so.)

### A note on test honesty

The relocation test was originally labelled the regression guard for the
ALL_RESOURCES_REQUIRED trap. It is not: each `tonic-xds` client opens its own
ADS stream subscribed only to its own target, so a subset push on one stream
*cannot* delete the other's Listener — the test would have passed even with the
bug. It is relabelled as the isolation test it actually is, and
`a_change_repeats_every_subscribed_listener` was added to speak the ADS protocol
directly, put both Listeners on one stream, and assert both are still enumerated
after one service moves. That guard was verified to fail — reporting
`["svc-a"]` — when the push is narrowed to the changed entry.

## Review

Two independent reviewers (GPT-5.6, Gemini 3.1 Pro) reviewed the change. Both
converged on the dropped-source blast radius; one caught the test-claim problem
above. Four findings were adopted. One — replacing the fan-in's per-wakeup
`Box::pin` with a `StreamMap` — was rejected and recorded in the design doc:
at this scale it is not worth optimizing, and `WatchStream` yields its initial
value immediately, which would produce a spurious push on every stream.

## Not in scope

Still deferred and documented: dynamic registration (the registry is fixed at
build time), a *cluster-wide* SF-facing tier (the `FabricClient` is now shared
per process, but each node still keeps its own naming connection and filters),
partition-key routing, secondaries, RDS, delta xDS, TLS/mTLS, ORCA/LRS, and
NACK observability.
