### PR TITLE
Made changes to support "DeployedApplication / DeployedServicePackage" entities in the QueryClient. Also added missing fields and additional utility functions to some entities.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "async-trait",
  "bitflags",

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.8.3"
+version = "0.8.4"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true

--- a/crates/libs/core/src/client/query_client.rs
+++ b/crates/libs/core/src/client/query_client.rs
@@ -163,6 +163,44 @@ impl QueryClient {
             cancellation_token,
         )
     }
+
+    fn get_deployed_application_list_internal(
+        &self,
+        desc: &mssf_com::FabricTypes::FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> FabricReceiver<
+        crate::Result<mssf_com::FabricClient::IFabricGetDeployedApplicationListResult>,
+    > {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginGetDeployedApplicationList(desc, timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndGetDeployedApplicationList(ctx) },
+            cancellation_token,
+        )
+    }
+
+    fn get_deployed_service_package_list_internal(
+        &self,
+        desc: &mssf_com::FabricTypes::FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_DESCRIPTION,
+        timeout_milliseconds: u32,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> FabricReceiver<
+        crate::Result<mssf_com::FabricClient::IFabricGetDeployedServicePackageListResult>,
+    > {
+        let com1 = &self.com;
+        let com2 = self.com.clone();
+        fabric_begin_end_proxy(
+            move |callback| unsafe {
+                com1.BeginGetDeployedServicePackageList(desc, timeout_milliseconds, callback)
+            },
+            move |ctx| unsafe { com2.EndGetDeployedServicePackageList(ctx) },
+            cancellation_token,
+        )
+    }
 }
 
 impl From<IFabricQueryClient13> for QueryClient {
@@ -289,5 +327,39 @@ impl QueryClient {
         }
         .await??;
         Ok(DeployedServiceReplicaDetailQueryResult::new(com))
+    }
+
+    /// Lists the applications deployed on a node.
+    pub async fn get_deployed_application_list(
+        &self,
+        desc: &crate::types::DeployedApplicationQueryDescription,
+        timeout: Duration,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> crate::Result<crate::types::DeployedApplicationList> {
+        let com = {
+            let raw: mssf_com::FabricTypes::FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION =
+                desc.into();
+            let timeout_ms = timeout.as_millis() as u32;
+            self.get_deployed_application_list_internal(&raw, timeout_ms, cancellation_token)
+        }
+        .await??;
+        Ok(crate::types::DeployedApplicationList::from(&com))
+    }
+
+    /// Lists the service packages deployed for an application on a node.
+    pub async fn get_deployed_service_package_list(
+        &self,
+        desc: &crate::types::DeployedServicePackageQueryDescription,
+        timeout: Duration,
+        cancellation_token: Option<BoxedCancelToken>,
+    ) -> crate::Result<crate::types::DeployedServicePackageList> {
+        let com = {
+            let raw: mssf_com::FabricTypes::FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_DESCRIPTION =
+                desc.into();
+            let timeout_ms = timeout.as_millis() as u32;
+            self.get_deployed_service_package_list_internal(&raw, timeout_ms, cancellation_token)
+        }
+        .await??;
+        Ok(crate::types::DeployedServicePackageList::from(&com))
     }
 }

--- a/crates/libs/core/src/types/client/deployed_application.rs
+++ b/crates/libs/core/src/types/client/deployed_application.rs
@@ -3,10 +3,13 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use mssf_com::FabricClient::IFabricDeployedApplicationHealthResult;
+use mssf_com::FabricClient::{
+    IFabricDeployedApplicationHealthResult, IFabricGetDeployedApplicationListResult,
+};
 use mssf_com::FabricTypes::{
     FABRIC_DEPLOYED_APPLICATION_HEALTH, FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION,
     FABRIC_DEPLOYED_APPLICATION_HEALTH_QUERY_DESCRIPTION_EX1,
+    FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION, FABRIC_DEPLOYED_APPLICATION_QUERY_RESULT_ITEM,
 };
 use windows_core::WString;
 
@@ -115,6 +118,59 @@ impl From<&FABRIC_DEPLOYED_APPLICATION_HEALTH> for DeployedApplicationHealth {
     }
 }
 
+/// FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION
+#[derive(Debug, Clone, Default)]
+pub struct DeployedApplicationQueryDescription {
+    pub node_name: WString,
+    pub application_name_filter: Option<Uri>,
+}
+
+impl From<&DeployedApplicationQueryDescription> for FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION {
+    fn from(value: &DeployedApplicationQueryDescription) -> Self {
+        Self {
+            NodeName: value.node_name.as_pcwstr(),
+            ApplicationNameFilter: value
+                .application_name_filter
+                .as_ref()
+                .map_or(Uri::default().as_raw(), |u| u.as_raw()),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// FABRIC_DEPLOYED_APPLICATION_QUERY_RESULT_ITEM
+#[derive(Debug, Clone)]
+pub struct DeployedApplicationQueryResultItem {
+    pub application_name: Uri,
+    pub application_type_name: WString,
+    pub status: super::DeploymentStatus,
+}
+
+impl From<&FABRIC_DEPLOYED_APPLICATION_QUERY_RESULT_ITEM> for DeployedApplicationQueryResultItem {
+    fn from(value: &FABRIC_DEPLOYED_APPLICATION_QUERY_RESULT_ITEM) -> Self {
+        Self {
+            application_name: Uri::from(value.ApplicationName),
+            application_type_name: WString::from(value.ApplicationTypeName),
+            status: value.DeployedApplicationStatus.into(),
+        }
+    }
+}
+
+/// IFabricGetDeployedApplicationListResult
+#[derive(Debug, Clone)]
+pub struct DeployedApplicationList {
+    pub items: Vec<DeployedApplicationQueryResultItem>,
+}
+
+impl From<&IFabricGetDeployedApplicationListResult> for DeployedApplicationList {
+    fn from(value: &IFabricGetDeployedApplicationListResult) -> Self {
+        let items = unsafe { value.get_DeployedApplicationList().as_ref() }
+            .map(|list| crate::iter::vec_from_raw_com(list.Count as usize, list.Items))
+            .unwrap_or_default();
+        Self { items }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +203,45 @@ mod tests {
             HealthStateFilterFlags::ERROR.bits() as u32
         );
         assert!(!raw.Reserved.is_null());
+    }
+
+    #[test]
+    fn test_deployed_application_query_description_raw() {
+        let desc = DeployedApplicationQueryDescription {
+            node_name: WString::from("Node1"),
+            application_name_filter: Some(Uri::from("fabric:/App1")),
+        };
+        let raw = FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION::from(&desc);
+        assert_eq!(WString::from(raw.NodeName).to_string_lossy(), "Node1");
+        assert_eq!(
+            Uri::from(raw.ApplicationNameFilter).to_string(),
+            "fabric:/App1"
+        );
+    }
+
+    #[test]
+    fn test_deployed_application_query_description_no_filter_raw() {
+        let desc = DeployedApplicationQueryDescription {
+            node_name: WString::from("Node1"),
+            application_name_filter: None,
+        };
+        let raw = FABRIC_DEPLOYED_APPLICATION_QUERY_DESCRIPTION::from(&desc);
+        assert_eq!(Uri::from(raw.ApplicationNameFilter).to_string(), "");
+    }
+
+    #[test]
+    fn test_deployed_application_query_result_item_from_raw() {
+        let app_name = Uri::from("fabric:/App1");
+        let app_type_name = WString::from("AppType1");
+        let raw = FABRIC_DEPLOYED_APPLICATION_QUERY_RESULT_ITEM {
+            ApplicationName: app_name.as_raw(),
+            ApplicationTypeName: app_type_name.as_pcwstr(),
+            DeployedApplicationStatus: mssf_com::FabricTypes::FABRIC_DEPLOYMENT_STATUS_ACTIVE,
+            Reserved: std::ptr::null_mut(),
+        };
+        let item = DeployedApplicationQueryResultItem::from(&raw);
+        assert_eq!(item.application_name.to_string(), "fabric:/App1");
+        assert_eq!(item.application_type_name.to_string_lossy(), "AppType1");
+        assert_eq!(item.status, crate::types::DeploymentStatus::Active);
     }
 }

--- a/crates/libs/core/src/types/client/deployed_service_package.rs
+++ b/crates/libs/core/src/types/client/deployed_service_package.rs
@@ -3,13 +3,21 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-use mssf_com::FabricClient::IFabricDeployedServicePackageHealthResult;
+use mssf_com::FabricClient::{
+    IFabricDeployedServicePackageHealthResult, IFabricGetDeployedServicePackageListResult,
+};
 use mssf_com::FabricTypes::{
     FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH,
     FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION,
     FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_QUERY_DESCRIPTION_EX1,
     FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATE,
     FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH_STATES_FILTER,
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_DESCRIPTION,
+    FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_RESULT_ITEM, FABRIC_DEPLOYMENT_STATUS,
+    FABRIC_DEPLOYMENT_STATUS_ACTIVATING, FABRIC_DEPLOYMENT_STATUS_ACTIVE,
+    FABRIC_DEPLOYMENT_STATUS_DEACTIVATING, FABRIC_DEPLOYMENT_STATUS_DOWNLOADING,
+    FABRIC_DEPLOYMENT_STATUS_FAILED, FABRIC_DEPLOYMENT_STATUS_INVALID,
+    FABRIC_DEPLOYMENT_STATUS_RAN_TO_COMPLETION, FABRIC_DEPLOYMENT_STATUS_UPGRADING,
 };
 use windows_core::{PCWSTR, WString};
 
@@ -145,6 +153,94 @@ impl From<&FABRIC_DEPLOYED_SERVICE_PACKAGE_HEALTH> for DeployedServicePackageHea
     }
 }
 
+// FABRIC_DEPLOYMENT_STATUS
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeploymentStatus {
+    Invalid,
+    Downloading,
+    Activating,
+    Active,
+    Upgrading,
+    Deactivating,
+    RanToCompletion,
+    Failed,
+}
+
+impl From<FABRIC_DEPLOYMENT_STATUS> for DeploymentStatus {
+    fn from(value: FABRIC_DEPLOYMENT_STATUS) -> Self {
+        match value {
+            FABRIC_DEPLOYMENT_STATUS_DOWNLOADING => Self::Downloading,
+            FABRIC_DEPLOYMENT_STATUS_ACTIVATING => Self::Activating,
+            FABRIC_DEPLOYMENT_STATUS_ACTIVE => Self::Active,
+            FABRIC_DEPLOYMENT_STATUS_UPGRADING => Self::Upgrading,
+            FABRIC_DEPLOYMENT_STATUS_DEACTIVATING => Self::Deactivating,
+            FABRIC_DEPLOYMENT_STATUS_RAN_TO_COMPLETION => Self::RanToCompletion,
+            FABRIC_DEPLOYMENT_STATUS_FAILED => Self::Failed,
+            FABRIC_DEPLOYMENT_STATUS_INVALID => Self::Invalid,
+            _ => Self::Invalid,
+        }
+    }
+}
+
+/// FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_DESCRIPTION
+#[derive(Debug, Clone, Default)]
+pub struct DeployedServicePackageQueryDescription {
+    pub node_name: WString,
+    pub application_name: Uri,
+    pub service_manifest_name_filter: Option<WString>,
+}
+
+impl From<&DeployedServicePackageQueryDescription>
+    for FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_DESCRIPTION
+{
+    fn from(value: &DeployedServicePackageQueryDescription) -> Self {
+        Self {
+            NodeName: value.node_name.as_pcwstr(),
+            ApplicationName: value.application_name.as_raw(),
+            ServiceManifestNameFilter: value
+                .service_manifest_name_filter
+                .as_ref()
+                .map_or(PCWSTR::null(), |s| s.as_pcwstr()),
+            Reserved: std::ptr::null_mut(),
+        }
+    }
+}
+
+/// FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_RESULT_ITEM
+#[derive(Debug, Clone)]
+pub struct DeployedServicePackageQueryResultItem {
+    pub service_manifest_name: WString,
+    pub service_manifest_version: WString,
+    pub status: DeploymentStatus,
+}
+
+impl From<&FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_RESULT_ITEM>
+    for DeployedServicePackageQueryResultItem
+{
+    fn from(value: &FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_RESULT_ITEM) -> Self {
+        Self {
+            service_manifest_name: WString::from(value.ServiceManifestName),
+            service_manifest_version: WString::from(value.ServiceManifestVersion),
+            status: value.DeployedServicePackageStatus.into(),
+        }
+    }
+}
+
+/// IFabricGetDeployedServicePackageListResult
+#[derive(Debug, Clone)]
+pub struct DeployedServicePackageList {
+    pub items: Vec<DeployedServicePackageQueryResultItem>,
+}
+
+impl From<&IFabricGetDeployedServicePackageListResult> for DeployedServicePackageList {
+    fn from(value: &IFabricGetDeployedServicePackageListResult) -> Self {
+        let items = unsafe { value.get_DeployedServicePackageList().as_ref() }
+            .map(|list| crate::iter::vec_from_raw_com(list.Count as usize, list.Items))
+            .unwrap_or_default();
+        Self { items }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,5 +291,37 @@ mod tests {
             raw.HealthStateFilter,
             HealthStateFilterFlags::WARNING.bits() as u32
         );
+    }
+
+    #[test]
+    fn test_deployed_service_package_query_description_raw() {
+        let desc = DeployedServicePackageQueryDescription {
+            node_name: WString::from("Node1"),
+            application_name: Uri::from("fabric:/App1"),
+            service_manifest_name_filter: Some(WString::from("Pkg1")),
+        };
+        let raw = FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_DESCRIPTION::from(&desc);
+        assert_eq!(WString::from(raw.NodeName).to_string_lossy(), "Node1");
+        assert_eq!(Uri::from(raw.ApplicationName).to_string(), "fabric:/App1");
+        assert_eq!(
+            WString::from(raw.ServiceManifestNameFilter).to_string_lossy(),
+            "Pkg1"
+        );
+    }
+
+    #[test]
+    fn test_deployed_service_package_query_result_item_from_raw() {
+        let manifest_name = WString::from("Pkg1");
+        let manifest_version = WString::from("1.0.0");
+        let raw = FABRIC_DEPLOYED_SERVICE_PACKAGE_QUERY_RESULT_ITEM {
+            ServiceManifestName: manifest_name.as_pcwstr(),
+            ServiceManifestVersion: manifest_version.as_pcwstr(),
+            DeployedServicePackageStatus: FABRIC_DEPLOYMENT_STATUS_ACTIVE,
+            Reserved: std::ptr::null_mut(),
+        };
+        let item = DeployedServicePackageQueryResultItem::from(&raw);
+        assert_eq!(item.service_manifest_name.to_string_lossy(), "Pkg1");
+        assert_eq!(item.service_manifest_version.to_string_lossy(), "1.0.0");
+        assert_eq!(item.status, DeploymentStatus::Active);
     }
 }

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -4,8 +4,10 @@
 // ------------------------------------------------------------
 
 use crate::mem::{BoxPool, GetRawWithBoxPool};
+use crate::types::HealthState;
 use crate::{WString, types::Uri};
 use bitflags::bitflags;
+use mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS;
 use mssf_com::{
     FabricClient::IFabricGetNodeListResult2,
     FabricTypes::{
@@ -116,9 +118,9 @@ pub struct NodeQueryResultItem {
     pub node_type: WString,
     pub code_version: WString,
     pub config_version: WString,
-    // pub node_status
+    pub status: NodeStatus,
     pub node_up_time_in_seconds: i64,
-    // pub AggregatedHealthState
+    pub health_state: HealthState,
     pub is_seed_node: bool,
     pub upgrade_domain: WString,
     pub fault_domain: Uri,
@@ -145,7 +147,9 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for NodeQueryResultItem {
             node_type: WString::from(raw.NodeType),
             code_version: WString::from(raw.CodeVersion),
             config_version: WString::from(raw.ConfigVersion),
+            status: value.NodeStatus.into(),
             node_up_time_in_seconds: raw.NodeUpTimeInSeconds,
+            health_state: (&value.AggregatedHealthState).into(),
             is_seed_node: raw.IsSeedNode,
             upgrade_domain: WString::from(raw.UpgradeDomain),
             fault_domain: Uri::from(raw.FaultDomain),
@@ -166,6 +170,34 @@ impl From<FABRIC_NODE_ID> for NodeId {
         Self {
             low: value.Low,
             high: value.High,
+        }
+    }
+}
+
+// FABRIC_QUERY_NODE_STATUS
+#[derive(Debug, Clone, Copy)]
+#[repr(i32)]
+pub enum NodeStatus {
+    Up = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_UP.0,
+    Down = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_DOWN.0,
+    Enabling = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_ENABLING.0,
+    Disabled = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_DISABLED.0,
+    Disabling = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_DISABLING.0,
+    Removed = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_REMOVED.0,
+    Unknown = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_UNKNOWN.0,
+    Invalid = mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_INVALID.0,
+}
+impl From<FABRIC_QUERY_NODE_STATUS> for NodeStatus {
+    fn from(value: FABRIC_QUERY_NODE_STATUS) -> Self {
+        match value {
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_UP => NodeStatus::Up,
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_DOWN => NodeStatus::Down,
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_ENABLING => NodeStatus::Enabling,
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_DISABLED => NodeStatus::Disabled,
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_DISABLING => NodeStatus::Disabling,
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_REMOVED => NodeStatus::Removed,
+            mssf_com::FabricTypes::FABRIC_QUERY_NODE_STATUS_UNKNOWN => NodeStatus::Unknown,
+            _ => NodeStatus::Invalid,
         }
     }
 }

--- a/crates/libs/core/src/types/client/partition.rs
+++ b/crates/libs/core/src/types/client/partition.rs
@@ -119,6 +119,24 @@ impl ServicePartitionQueryResultItem {
             ServicePartitionQueryResultItem::Invalid => HealthState::Invalid,
         }
     }
+    pub fn get_partition_information(&self) -> Option<&ServicePartitionInformation> {
+        match self {
+            ServicePartitionQueryResultItem::Stateful(stateful) => {
+                Some(&stateful.partition_information)
+            }
+            ServicePartitionQueryResultItem::Stateless(stateless) => {
+                Some(&stateless.partition_information)
+            }
+            ServicePartitionQueryResultItem::Invalid => None,
+        }
+    }
+    pub fn get_partition_status(&self) -> ServicePartitionStatus {
+        match self {
+            ServicePartitionQueryResultItem::Stateful(stateful) => stateful.partition_status,
+            ServicePartitionQueryResultItem::Stateless(stateless) => stateless.partition_status,
+            ServicePartitionQueryResultItem::Invalid => ServicePartitionStatus::Invalid,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -118,6 +118,20 @@ impl ServiceReplicaQueryResultItem {
             ServiceReplicaQueryResultItem::Invalid => HealthState::Invalid,
         }
     }
+    pub fn get_replica_status(&self) -> QueryServiceReplicaStatus {
+        match self {
+            ServiceReplicaQueryResultItem::Stateful(stateful) => stateful.replica_status,
+            ServiceReplicaQueryResultItem::Stateless(stateless) => stateless.replica_status,
+            ServiceReplicaQueryResultItem::Invalid => QueryServiceReplicaStatus::Invalid,
+        }
+    }
+    pub fn get_node_name(&self) -> Option<&WString> {
+        match self {
+            ServiceReplicaQueryResultItem::Stateful(stateful) => Some(&stateful.node_name),
+            ServiceReplicaQueryResultItem::Stateless(stateless) => Some(&stateless.node_name),
+            ServiceReplicaQueryResultItem::Invalid => None,
+        }
+    }
 }
 
 // FABRIC_STATEFUL_SERVICE_REPLICA_QUERY_RESULT_ITEM
@@ -461,6 +475,24 @@ impl ReplicaHealth {
         match self {
             ReplicaHealth::Stateful(stateful) => stateful.aggregated_health_state,
             ReplicaHealth::Stateless(stateless) => stateless.aggregated_health_state,
+        }
+    }
+    pub fn get_health_events(&self) -> &Vec<super::HealthEvent> {
+        match self {
+            ReplicaHealth::Stateful(stateful) => &stateful.health_events,
+            ReplicaHealth::Stateless(stateless) => &stateless.health_events,
+        }
+    }
+    pub fn get_replica_or_instance_id(&self) -> i64 {
+        match self {
+            ReplicaHealth::Stateful(stateful) => stateful.replica_id,
+            ReplicaHealth::Stateless(stateless) => stateless.instance_id,
+        }
+    }
+    pub fn get_partition_id(&self) -> GUID {
+        match self {
+            ReplicaHealth::Stateful(stateful) => stateful.partition_id,
+            ReplicaHealth::Stateless(stateless) => stateless.partition_id,
         }
     }
 }

--- a/crates/libs/core/src/types/client/service.rs
+++ b/crates/libs/core/src/types/client/service.rs
@@ -1117,6 +1117,27 @@ impl ServiceQueryResultItem {
             ServiceQueryResultItem::Stateless(item) => &item.service_name,
         }
     }
+
+    pub fn get_service_type_name(&self) -> &WString {
+        match self {
+            ServiceQueryResultItem::Stateful(item) => &item.service_type_name,
+            ServiceQueryResultItem::Stateless(item) => &item.service_type_name,
+        }
+    }
+
+    pub fn get_service_manifest_version(&self) -> &WString {
+        match self {
+            ServiceQueryResultItem::Stateful(item) => &item.service_manifest_version,
+            ServiceQueryResultItem::Stateless(item) => &item.service_manifest_version,
+        }
+    }
+
+    pub fn get_service_status(&self) -> QueryServiceStatus {
+        match self {
+            ServiceQueryResultItem::Stateful(item) => item.service_status,
+            ServiceQueryResultItem::Stateless(item) => item.service_status,
+        }
+    }
 }
 
 // FABRIC_QUERY_SERVICE_STATUS


### PR DESCRIPTION
Made changes to support "DeployedApplication / DeployedServicePackage" entities in the QueryClient. Also added missing fields and additional utility functions to some entities.

Also bumped mssf-core from 0.8.3 -> 0.8.4

QueryClient
- get_deployed_application_list / get_deployed_service_package_list

NodeQueryResultItem:
- Added missing 'NodeStatus' and 'HealthState' mappings

'ServiceQueryResultItem':
- get_service_type_name
- get_service_manifest_version
- get_service_status

'ServicePartitionQueryResultItem':
- get_partition_information
- get_partition_status

'ServiceReplicaQueryResultItem':
- get_replica_status
- get_node_name

'ReplicaHealth'
- get_health_events
- get_replica_or_instance_id
- get_partition_id