### PR TITLE
Change usage of 'FILETIME' in mssf-core to 'SystemTime'.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "mssf-core"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "bitflags",

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssf-core"
-version = "0.8.5"
+version = "0.8.6"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod mem;
 pub mod runtime;
 pub mod strings;
 pub mod sync;
+mod time;
 pub mod types;
 
 // Rename the mssf_pal dependency

--- a/crates/libs/core/src/time.rs
+++ b/crates/libs/core/src/time.rs
@@ -19,7 +19,7 @@ const FILETIME_UNIX_EPOCH_OFFSET_TICKS: u64 = 116_444_736_000_000_000;
 /// 100-nanosecond precision. Both epochs denote UTC instants, although
 /// [`SystemTime`] itself has no timezone. Returns [`None`] when the result is
 /// outside the range supported by the current platform.
-pub(crate) fn filetime_to_system_time(filetime: FILETIME) -> Option<SystemTime> {
+pub(crate) fn try_filetime_to_system_time(filetime: FILETIME) -> Option<SystemTime> {
     // FILETIME represents one unsigned 64-bit tick count as separate high and
     // low 32-bit words. Shifting the high word restores bits 32 through 63.
     let ticks = (u64::from(filetime.dwHighDateTime) << 32) | u64::from(filetime.dwLowDateTime);

--- a/crates/libs/core/src/time.rs
+++ b/crates/libs/core/src/time.rs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use windows_core::Win32::Foundation::FILETIME;
+
+/// A [`FILETIME`] tick is 100 nanoseconds
+const FILETIME_NS_PER_TICK: u64 = 100;
+const FILETIME_TICKS_PER_SECOND: u64 = 10_000_000;
+/// Number of [`FILETIME`] ticks between its epoch (`1601-01-01 00:00:00 UTC`)
+/// and Rust's [`UNIX_EPOCH`] (`1970-01-01 00:00:00 UTC`). The two epochs are
+/// 134,774 days, or 11,644,473,600 seconds, apart:
+/// `11,644,473,600 seconds * 10,000,000 ticks/second`.
+const FILETIME_UNIX_EPOCH_OFFSET_TICKS: u64 = 116_444_736_000_000_000;
+
+/// Converts a Windows [`FILETIME`] to a [`SystemTime`], preserving its
+/// 100-nanosecond precision. Both epochs denote UTC instants, although
+/// [`SystemTime`] itself has no timezone. Returns [`None`] when the result is
+/// outside the range supported by the current platform.
+pub(crate) fn filetime_to_system_time(filetime: FILETIME) -> Option<SystemTime> {
+    // FILETIME represents one unsigned 64-bit tick count as separate high and
+    // low 32-bit words. Shifting the high word restores bits 32 through 63.
+    let ticks = (u64::from(filetime.dwHighDateTime) << 32) | u64::from(filetime.dwLowDateTime);
+
+    // Express the value as a positive duration on the appropriate side of the
+    // Unix epoch so this also handles FILETIME values before 1970.
+    let (after_unix_epoch, delta_ticks) = if ticks >= FILETIME_UNIX_EPOCH_OFFSET_TICKS {
+        (true, ticks - FILETIME_UNIX_EPOCH_OFFSET_TICKS)
+    } else {
+        (false, FILETIME_UNIX_EPOCH_OFFSET_TICKS - ticks)
+    };
+
+    // Duration stores whole seconds and a nanosecond remainder.
+    let delta = Duration::new(
+        delta_ticks / FILETIME_TICKS_PER_SECOND,
+        ((delta_ticks % FILETIME_TICKS_PER_SECOND) * FILETIME_NS_PER_TICK) as u32,
+    );
+
+    if after_unix_epoch {
+        UNIX_EPOCH.checked_add(delta)
+    } else {
+        UNIX_EPOCH.checked_sub(delta)
+    }
+}

--- a/crates/libs/core/src/time.rs
+++ b/crates/libs/core/src/time.rs
@@ -44,3 +44,31 @@ pub(crate) fn try_filetime_to_system_time(filetime: FILETIME) -> Option<SystemTi
         UNIX_EPOCH.checked_sub(delta)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filetime_unix_epoch() {
+        // FILETIME for 1970-01-01 00:00:00 UTC, i.e. the Unix epoch itself.
+        let filetime = FILETIME {
+            dwLowDateTime: 3_577_643_008,
+            dwHighDateTime: 27_111_902,
+        };
+
+        assert_eq!(try_filetime_to_system_time(filetime), Some(UNIX_EPOCH));
+    }
+
+    #[test]
+    fn test_filetime_after_unix_epoch() {
+        // FILETIME for May 12 2026 10:29:43.004771 UTC.
+        let filetime = FILETIME {
+            dwLowDateTime: 1_057_701_854,
+            dwHighDateTime: 31_252_986,
+        };
+
+        let expected = UNIX_EPOCH + Duration::new(1_778_581_783, 4_771_000);
+        assert_eq!(try_filetime_to_system_time(filetime), Some(expected));
+    }
+}

--- a/crates/libs/core/src/types/client/health.rs
+++ b/crates/libs/core/src/types/client/health.rs
@@ -12,9 +12,10 @@ use mssf_com::FabricTypes::{
     FABRIC_NODE_HEALTH_STATES_FILTER, FABRIC_SERVICE_TYPE_HEALTH_POLICY,
     FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP, FABRIC_SERVICE_TYPE_HEALTH_POLICY_MAP_ITEM,
 };
-use windows_core::Win32::Foundation::FILETIME;
+use std::time::SystemTime;
 
 use crate::mem::{BoxPool, GetRaw, GetRawWithBoxPool};
+use crate::time::filetime_to_system_time;
 use crate::{GUID, WString};
 
 use crate::types::{HealthInformation, HealthState, Uri};
@@ -219,8 +220,8 @@ impl NodeHealthResult {
 #[derive(Debug, Clone)]
 pub struct HealthEvent {
     pub health_information: HealthInformation,
-    pub source_utc_timestamp: FILETIME,
-    pub last_modified_utc_timestamp: FILETIME,
+    pub source_utc_timestamp: SystemTime,
+    pub last_modified_utc_timestamp: SystemTime,
     pub is_expired: bool,
 }
 
@@ -228,8 +229,10 @@ impl From<&FABRIC_HEALTH_EVENT> for HealthEvent {
     fn from(value: &FABRIC_HEALTH_EVENT) -> Self {
         Self {
             health_information: unsafe { value.HealthInformation.as_ref().unwrap().into() },
-            source_utc_timestamp: value.SourceUtcTimestamp,
-            last_modified_utc_timestamp: value.LastModifiedUtcTimestamp,
+            source_utc_timestamp: filetime_to_system_time(value.SourceUtcTimestamp)
+                .unwrap_or(SystemTime::UNIX_EPOCH),
+            last_modified_utc_timestamp: filetime_to_system_time(value.LastModifiedUtcTimestamp)
+                .unwrap_or(SystemTime::UNIX_EPOCH),
             is_expired: value.IsExpired,
         }
     }

--- a/crates/libs/core/src/types/client/health.rs
+++ b/crates/libs/core/src/types/client/health.rs
@@ -231,8 +231,10 @@ impl From<&FABRIC_HEALTH_EVENT> for HealthEvent {
             health_information: unsafe { value.HealthInformation.as_ref().unwrap().into() },
             source_utc_timestamp: try_filetime_to_system_time(value.SourceUtcTimestamp)
                 .unwrap_or(SystemTime::UNIX_EPOCH),
-            last_modified_utc_timestamp: try_filetime_to_system_time(value.LastModifiedUtcTimestamp)
-                .unwrap_or(SystemTime::UNIX_EPOCH),
+            last_modified_utc_timestamp: try_filetime_to_system_time(
+                value.LastModifiedUtcTimestamp,
+            )
+            .unwrap_or(SystemTime::UNIX_EPOCH),
             is_expired: value.IsExpired,
         }
     }

--- a/crates/libs/core/src/types/client/health.rs
+++ b/crates/libs/core/src/types/client/health.rs
@@ -15,7 +15,7 @@ use mssf_com::FabricTypes::{
 use std::time::SystemTime;
 
 use crate::mem::{BoxPool, GetRaw, GetRawWithBoxPool};
-use crate::time::filetime_to_system_time;
+use crate::time::try_filetime_to_system_time;
 use crate::{GUID, WString};
 
 use crate::types::{HealthInformation, HealthState, Uri};
@@ -229,9 +229,9 @@ impl From<&FABRIC_HEALTH_EVENT> for HealthEvent {
     fn from(value: &FABRIC_HEALTH_EVENT) -> Self {
         Self {
             health_information: unsafe { value.HealthInformation.as_ref().unwrap().into() },
-            source_utc_timestamp: filetime_to_system_time(value.SourceUtcTimestamp)
+            source_utc_timestamp: try_filetime_to_system_time(value.SourceUtcTimestamp)
                 .unwrap_or(SystemTime::UNIX_EPOCH),
-            last_modified_utc_timestamp: filetime_to_system_time(value.LastModifiedUtcTimestamp)
+            last_modified_utc_timestamp: try_filetime_to_system_time(value.LastModifiedUtcTimestamp)
                 .unwrap_or(SystemTime::UNIX_EPOCH),
             is_expired: value.IsExpired,
         }

--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -8,7 +8,7 @@
 use std::time::SystemTime;
 
 use crate::WString;
-use crate::time::filetime_to_system_time;
+use crate::time::try_filetime_to_system_time;
 use mssf_com::FabricTypes::FABRIC_LOAD_METRIC_REPORT;
 
 /// Wrapper for FABRIC_LOAD_METRIC_REPORT
@@ -24,7 +24,7 @@ impl From<&FABRIC_LOAD_METRIC_REPORT> for LoadMetricReport {
         Self {
             name: WString::from(value.Name),
             value: value.Value,
-            last_reported_utc: filetime_to_system_time(value.LastReportedUtc)
+            last_reported_utc: try_filetime_to_system_time(value.LastReportedUtc)
                 .unwrap_or(SystemTime::UNIX_EPOCH),
         }
     }

--- a/crates/libs/core/src/types/client/metrics.rs
+++ b/crates/libs/core/src/types/client/metrics.rs
@@ -8,6 +8,7 @@
 use std::time::SystemTime;
 
 use crate::WString;
+use crate::time::filetime_to_system_time;
 use mssf_com::FabricTypes::FABRIC_LOAD_METRIC_REPORT;
 
 /// Wrapper for FABRIC_LOAD_METRIC_REPORT
@@ -23,7 +24,8 @@ impl From<&FABRIC_LOAD_METRIC_REPORT> for LoadMetricReport {
         Self {
             name: WString::from(value.Name),
             value: value.Value,
-            last_reported_utc: SystemTime::UNIX_EPOCH, // TODO: convert Win32 FILETIME to SystemTime in Unix or Win32 depending on the platform
+            last_reported_utc: filetime_to_system_time(value.LastReportedUtc)
+                .unwrap_or(SystemTime::UNIX_EPOCH),
         }
     }
 }

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 use crate::mem::{BoxPool, GetRawWithBoxPool};
+use crate::time::filetime_to_system_time;
 use crate::types::HealthState;
 use crate::{WString, types::Uri};
 use bitflags::bitflags;
@@ -26,7 +27,7 @@ use mssf_com::{
     },
 };
 use std::ffi::c_void;
-use windows_core::Win32::Foundation::FILETIME;
+use std::time::SystemTime;
 
 #[derive(Debug, Default, Clone)]
 pub struct PagingStatus {
@@ -139,8 +140,8 @@ pub struct NodeQueryResultItem {
     // ex5
     pub node_down_time_in_seconds: i64,
     // ex6
-    pub node_up_at: FILETIME,
-    pub node_down_at: FILETIME,
+    pub node_up_at: SystemTime,
+    pub node_down_at: SystemTime,
     // ex7
     pub infrastructure_placement_id: WString,
     // ex8
@@ -193,8 +194,8 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for NodeQueryResultItem {
             node_instance_id: ex2.NodeInstanceId,
             is_stopped: ex4.IsStopped,
             node_down_time_in_seconds: ex5.NodeDownTimeInSeconds,
-            node_up_at: ex6.NodeUpAt,
-            node_down_at: ex6.NodeDownAt,
+            node_up_at: filetime_to_system_time(ex6.NodeUpAt).unwrap_or(SystemTime::UNIX_EPOCH),
+            node_down_at: filetime_to_system_time(ex6.NodeDownAt).unwrap_or(SystemTime::UNIX_EPOCH),
             infrastructure_placement_id: WString::from(ex7.InfrastructurePlacementID),
             is_node_by_node_upgrade_in_progress: ex9.IsNodeByNodeUpgradeInProgress,
         }
@@ -247,6 +248,8 @@ impl From<FABRIC_QUERY_NODE_STATUS> for NodeStatus {
 
 #[cfg(test)]
 mod tests {
+    use windows_core::Win32::Foundation::FILETIME;
+
     use super::*;
 
     #[test]
@@ -341,17 +344,19 @@ mod tests {
         assert_eq!(item.node_down_time_in_seconds, 123);
         assert_eq!(
             item.node_up_at,
-            FILETIME {
+            filetime_to_system_time(FILETIME {
                 dwLowDateTime: 100,
                 dwHighDateTime: 200,
-            }
+            })
+            .unwrap()
         );
         assert_eq!(
             item.node_down_at,
-            FILETIME {
+            filetime_to_system_time(FILETIME {
                 dwLowDateTime: 300,
                 dwHighDateTime: 400,
-            }
+            })
+            .unwrap()
         );
         assert_eq!(
             item.infrastructure_placement_id.to_string_lossy(),

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 
 use crate::mem::{BoxPool, GetRawWithBoxPool};
-use crate::time::filetime_to_system_time;
+use crate::time::try_filetime_to_system_time;
 use crate::types::HealthState;
 use crate::{WString, types::Uri};
 use bitflags::bitflags;
@@ -194,8 +194,8 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for NodeQueryResultItem {
             node_instance_id: ex2.NodeInstanceId,
             is_stopped: ex4.IsStopped,
             node_down_time_in_seconds: ex5.NodeDownTimeInSeconds,
-            node_up_at: filetime_to_system_time(ex6.NodeUpAt).unwrap_or(SystemTime::UNIX_EPOCH),
-            node_down_at: filetime_to_system_time(ex6.NodeDownAt).unwrap_or(SystemTime::UNIX_EPOCH),
+            node_up_at: try_filetime_to_system_time(ex6.NodeUpAt).unwrap_or(SystemTime::UNIX_EPOCH),
+            node_down_at: try_filetime_to_system_time(ex6.NodeDownAt).unwrap_or(SystemTime::UNIX_EPOCH),
             infrastructure_placement_id: WString::from(ex7.InfrastructurePlacementID),
             is_node_by_node_upgrade_in_progress: ex9.IsNodeByNodeUpgradeInProgress,
         }
@@ -344,7 +344,7 @@ mod tests {
         assert_eq!(item.node_down_time_in_seconds, 123);
         assert_eq!(
             item.node_up_at,
-            filetime_to_system_time(FILETIME {
+            try_filetime_to_system_time(FILETIME {
                 dwLowDateTime: 100,
                 dwHighDateTime: 200,
             })
@@ -352,7 +352,7 @@ mod tests {
         );
         assert_eq!(
             item.node_down_at,
-            filetime_to_system_time(FILETIME {
+            try_filetime_to_system_time(FILETIME {
                 dwLowDateTime: 300,
                 dwHighDateTime: 400,
             })

--- a/crates/libs/core/src/types/client/node.rs
+++ b/crates/libs/core/src/types/client/node.rs
@@ -195,7 +195,8 @@ impl From<&FABRIC_NODE_QUERY_RESULT_ITEM> for NodeQueryResultItem {
             is_stopped: ex4.IsStopped,
             node_down_time_in_seconds: ex5.NodeDownTimeInSeconds,
             node_up_at: try_filetime_to_system_time(ex6.NodeUpAt).unwrap_or(SystemTime::UNIX_EPOCH),
-            node_down_at: try_filetime_to_system_time(ex6.NodeDownAt).unwrap_or(SystemTime::UNIX_EPOCH),
+            node_down_at: try_filetime_to_system_time(ex6.NodeDownAt)
+                .unwrap_or(SystemTime::UNIX_EPOCH),
             infrastructure_placement_id: WString::from(ex7.InfrastructurePlacementID),
             is_node_by_node_upgrade_in_progress: ex9.IsNodeByNodeUpgradeInProgress,
         }

--- a/crates/libs/core/src/types/client/property.rs
+++ b/crates/libs/core/src/types/client/property.rs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+use std::time::SystemTime;
+
 use mssf_com::{
     FabricClient::IFabricNameEnumerationResult,
     FabricTypes::{
@@ -16,6 +18,7 @@ use mssf_com::{
 };
 use windows_core::WString;
 
+use crate::time::filetime_to_system_time;
 use crate::types::Uri;
 
 pub struct NameEnumerationResult {
@@ -80,7 +83,7 @@ pub struct NamedPropertyMetadata {
     pub property_type_id: PropertyTypeId,
     pub value_size: i32,
     pub sequence_number: i64,
-    pub last_modified_utc: windows_core::Win32::Foundation::FILETIME,
+    pub last_modified_utc: SystemTime,
     pub name: Uri,
 }
 
@@ -91,7 +94,8 @@ impl NamedPropertyMetadata {
             property_type_id: ptr.TypeId.into(),
             value_size: ptr.ValueSize,
             sequence_number: ptr.SequenceNumber,
-            last_modified_utc: ptr.LastModifiedUtc,
+            last_modified_utc: filetime_to_system_time(ptr.LastModifiedUtc)
+                .unwrap_or(SystemTime::UNIX_EPOCH),
             name: Uri::from(ptr.Name),
         }
     }

--- a/crates/libs/core/src/types/client/property.rs
+++ b/crates/libs/core/src/types/client/property.rs
@@ -18,7 +18,7 @@ use mssf_com::{
 };
 use windows_core::WString;
 
-use crate::time::filetime_to_system_time;
+use crate::time::try_filetime_to_system_time;
 use crate::types::Uri;
 
 pub struct NameEnumerationResult {
@@ -94,7 +94,7 @@ impl NamedPropertyMetadata {
             property_type_id: ptr.TypeId.into(),
             value_size: ptr.ValueSize,
             sequence_number: ptr.SequenceNumber,
-            last_modified_utc: filetime_to_system_time(ptr.LastModifiedUtc)
+            last_modified_utc: try_filetime_to_system_time(ptr.LastModifiedUtc)
                 .unwrap_or(SystemTime::UNIX_EPOCH),
             name: Uri::from(ptr.Name),
         }

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -29,6 +29,7 @@ use mssf_com::{
     },
 };
 
+use crate::time::filetime_to_system_time;
 use crate::types::{HealthState, HealthStateFilterFlags, ReplicaRole};
 
 use super::{QueryReplicatorOperationName, QueryServiceOperationName};
@@ -283,7 +284,10 @@ impl DeployedStatefulServiceReplicaDetailQueryResult {
             partition_id: value.PartitionId,
             replica_id: value.ReplicaId,
             current_service_operation: (value.CurrentServiceOperation).into(),
-            current_service_operation_start_time_utc: SystemTime::UNIX_EPOCH, // TODO: convert Win32 FILETIME to SystemTime in Unix or Win32 depending on the platform
+            current_service_operation_start_time_utc: filetime_to_system_time(
+                value.CurrentServiceOperationStartTimeUtc,
+            )
+            .unwrap_or(SystemTime::UNIX_EPOCH),
             current_replicator_operation: (value.CurrentReplicatorOperation).into(),
             read_status: (value.ReadStatus).into(),
             write_status: (value.WriteStatus).into(),

--- a/crates/libs/core/src/types/client/replica.rs
+++ b/crates/libs/core/src/types/client/replica.rs
@@ -29,7 +29,7 @@ use mssf_com::{
     },
 };
 
-use crate::time::filetime_to_system_time;
+use crate::time::try_filetime_to_system_time;
 use crate::types::{HealthState, HealthStateFilterFlags, ReplicaRole};
 
 use super::{QueryReplicatorOperationName, QueryServiceOperationName};
@@ -284,7 +284,7 @@ impl DeployedStatefulServiceReplicaDetailQueryResult {
             partition_id: value.PartitionId,
             replica_id: value.ReplicaId,
             current_service_operation: (value.CurrentServiceOperation).into(),
-            current_service_operation_start_time_utc: filetime_to_system_time(
+            current_service_operation_start_time_utc: try_filetime_to_system_time(
                 value.CurrentServiceOperationStartTimeUtc,
             )
             .unwrap_or(SystemTime::UNIX_EPOCH),


### PR DESCRIPTION
 Change usage of 'FILETIME' in mssf-core to 'SystemTime' and created a helper function to handle the conversion, based on the following Microsoft doc: [FILETIME Structure](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)

Also bump ms…sf-core from 0.8.5 -> 0.8.6